### PR TITLE
Breaking change: Update `createMarkedInput` signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,15 +89,19 @@ Using the `createMarkedInput`:
 ```tsx
 import {createMarkedInput} from "rc-marked-input";
 
-const ConfiguredMarkedInput = createMarkedInput(Button, [{
-    markup: Primary,
-    data: Data,
-    initMark: ({label, value}) => ({label, primary: true, onClick: () => alert(value)})
-}, {
-    trigger: '/',
-    markup: Default,
-    data: AnotherData
-}])
+const ConfiguredMarkedInput = createMarkedInput({
+    Mark: Button,
+    options: [{
+        markup: Primary,
+        data: ['First', 'Second', 'Third', 'Fourth', 'Fifth', 'Sixth'],
+        initMark: ({label, value}) => ({label, primary: true, onClick: () => alert(value)})
+    }, {
+        markup: Default,
+        trigger: '/',
+        data: ['Seventh', 'Eight', 'Ninth'],
+        initMark: ({label}) => ({label})
+    }],
+})
 
 const App = () => {
     const [value, setValue] = useState(
@@ -255,7 +259,7 @@ The `children` prop allows to forward any of div props to a container via react 
 Or
 
 ```tsx
-const MarkedInput = createMarkedInput(Mark, Overlay, [{
+const MarkedInput = createMarkedInput({Mark, Overlay, options: [{
     trigger: '@',
     markup: '@[__label__](__value__)',
     data: Data,
@@ -265,7 +269,7 @@ const MarkedInput = createMarkedInput(Mark, Overlay, [{
     markup: '@(__label__)[__value__]',
     data: AnotherData,
     initMark: getAnotherCustomMarkProps,
-}])
+}]})
 
 const App = () => <MarkedInput value={value} onChange={setValue}/>
 ```
@@ -286,14 +290,14 @@ const App = () => <MarkedInput value={value} onChange={setValue}/>
 
 ### Helpers
 
-| Name              | Type                                                                                                                                                                                              | Description                                  |
-|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------|
-| createMarkedInput | (Mark: ComponentType<T>, options: OptionProps<T>[]): ConfiguredMarkedInput<T> <br/> (Mark: ComponentType<T>, Overlay: ComponentType<T1>, options: OptionProps<T, T1>[]): ConfiguredMarkedInput<T> | Create the configured MarkedInput component. |
-| annotate          | (markup: Markup, label: string, value?: string) => string                                                                                                                                         | Make annotation from the markup              |
-| denote            | (value: string, callback: (mark: Mark) => string, ...markups: Markup[]) => string                                                                                                                 | Transform the annotated text                 |
-| useMark           | () => DynamicMark                                                                                                                                                                                 | Allow to use dynamic mark                    |
-| useOverlay        | () => OverlayProps                                                                                                                                                                                | Use overlay props                            |
-| useListener       | (type, listener, deps) => void                                                                                                                                                                    | Event listener                               |
+| Name              | Type                                                                              | Description                                  |
+|-------------------|-----------------------------------------------------------------------------------|----------------------------------------------|
+| createMarkedInput | <T = MarkStruct>(configs: MarkedInputProps<T>): ConfiguredMarkedInput<T>          | Create the configured MarkedInput component. |
+| annotate          | (markup: Markup, label: string, value?: string) => string                         | Make annotation from the markup              |
+| denote            | (value: string, callback: (mark: Mark) => string, ...markups: Markup[]) => string | Transform the annotated text                 |
+| useMark           | () => DynamicMark                                                                 | Allow to use dynamic mark                    |
+| useOverlay        | () => OverlayProps                                                                | Use overlay props                            |
+| useListener       | (type, listener, deps) => void                                                    | Event listener                               |
 
 ### Types
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -21,7 +21,6 @@ export type {
 
 	MarkStruct,
 	ConfiguredMarkedInput,
-	ConfiguredMarkedInputProps,
 
 	label,
 	value,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -63,8 +63,7 @@ export interface OptionProps<T = Record<string, any>> {
 	initMark?: (props: MarkStruct) => T
 }
 
-export type ConfiguredMarkedInputProps<T> = Omit<MarkedInputProps<T>, 'Mark' | 'Overlay' | 'options'>
-export type ConfiguredMarkedInput<T> = FunctionComponent<ConfiguredMarkedInputProps<T>>
+export type ConfiguredMarkedInput<T> = FunctionComponent<MarkedInputProps<T>>
 
 export type State = Omit<MarkedInputProps<any>, 'options'> & {
 	options: Options,

--- a/lib/utils/createMarkedInput.ts
+++ b/lib/utils/createMarkedInput.ts
@@ -1,29 +1,14 @@
-import {ComponentType, ForwardedRef, forwardRef} from 'react'
+import {ForwardedRef, forwardRef} from 'react'
 import {_MarkedInput, MarkedInputProps} from '../components/MarkedInput'
-import {ConfiguredMarkedInput, ConfiguredMarkedInputProps, MarkStruct, OptionProps} from '../types'
+import {ConfiguredMarkedInput, MarkStruct} from '../types'
 import {assign} from './index'
 
 /**
  * Create the configured MarkedInput component.
  */
-export function createMarkedInput<T = MarkStruct>(Mark: ComponentType<T>, options?: OptionProps<T>[]): ConfiguredMarkedInput<T>;
-export function createMarkedInput<T = MarkStruct>(Mark: ComponentType<T>, Overlay: ComponentType, options?: OptionProps<T>[]): ConfiguredMarkedInput<T>;
-export function createMarkedInput(
-	Mark: ComponentType<any>,
-	optionsOrOverlay: ComponentType<any> | OptionProps[] | undefined,
-	options?: OptionProps[]
-): ConfiguredMarkedInput<any> {
-	const predefinedProps = Array.isArray(optionsOrOverlay) ? {
-		Mark,
-		options: optionsOrOverlay,
-	} : {
-		Mark,
-		Overlay: optionsOrOverlay,
-		options
-	}
-
-	const ConfiguredMarkedInput = (props: ConfiguredMarkedInputProps<any>, ref: ForwardedRef<any>) => {
-		const assignedProps: MarkedInputProps<any> = assign({}, props, predefinedProps)
+export function createMarkedInput<T = MarkStruct>(configs: Omit<MarkedInputProps<T>, 'value' | 'onChange'>): ConfiguredMarkedInput<T> {
+	const ConfiguredMarkedInput = (props: MarkedInputProps<any>, ref: ForwardedRef<any>) => {
+		const assignedProps: MarkedInputProps = assign({}, configs, props)
 		return _MarkedInput(assignedProps, ref)
 	}
 

--- a/storybook/stories/Base.stories.tsx
+++ b/storybook/stories/Base.stories.tsx
@@ -20,16 +20,19 @@ export const Marked = () => {
 const Primary: Markup = '@[__label__](primary:__value__)'
 const Default: Markup = '@[__label__](default:__value__)'
 
-const ConfiguredMarkedInput = createMarkedInput(Button, [{
-	markup: Primary,
-	data: ['First', 'Second', 'Third', 'Fourth', 'Fifth', 'Sixth'],
-	initMark: ({label, value}) => ({label, primary: true, onClick: () => alert(value)})
-}, {
-	markup: Default,
-	trigger: '/',
-	data: ['Seventh', 'Eight', 'Ninth'],
-	initMark: ({label}) => ({label})
-}])
+const ConfiguredMarkedInput = createMarkedInput({
+	Mark: Button,
+	options: [{
+		markup: Primary,
+		data: ['First', 'Second', 'Third', 'Fourth', 'Fifth', 'Sixth'],
+		initMark: ({label, value}) => ({label, primary: true, onClick: () => alert(value)})
+	}, {
+		markup: Default,
+		trigger: '/',
+		data: ['Seventh', 'Eight', 'Ninth'],
+		initMark: ({label}) => ({label})
+	}],
+})
 
 const style = {minWidth: 100}
 const spanStyle = {width: 'auto', minWidth: 10}

--- a/storybook/stories/assets/MaterialMentions/MaterialMentions.tsx
+++ b/storybook/stories/assets/MaterialMentions/MaterialMentions.tsx
@@ -2,6 +2,6 @@ import {createMarkedInput} from 'rc-marked-input'
 import {Mention} from './Mention'
 import {UserList} from './UserList'
 
-export const MaterialMentions = createMarkedInput(Mention, UserList, [{
+export const MaterialMentions = createMarkedInput({Mark: Mention, Overlay: UserList, options: [{
 	markup: '@[__label__]',
-}])
+}]})

--- a/tests/integrations/createMarkedInput.spec.tsx
+++ b/tests/integrations/createMarkedInput.spec.tsx
@@ -31,7 +31,7 @@ describe(`Utility: createMarkedInput`, () => {
 	})
 
 	it('should to support the ref prop', async () => {
-		const Input = createMarkedInput(() => null)
+		const Input = createMarkedInput({})
 		let ref: MarkedInputHandler | null = null
 
 		render(<Input ref={(el) => ref = el} value={''} onChange={() => ({})}/>)
@@ -45,7 +45,7 @@ describe(`Utility: createMarkedInput`, () => {
 const Mark3 = () => {
 	const [value, setValue] = useState('Hello @')
 	const Overlay = forwardRef(() => <span>I'm here!</span>)
-	const Input = createMarkedInput(() => null, Overlay, [])
+	const Input = createMarkedInput({Mark: () => null, Overlay, options: []})
 
 	return <Input value={value} onChange={setValue}/>
 }


### PR DESCRIPTION
The `createMarkedInput` accepts one config object similar to `MarkedInputProps` now.

Migrating:
```tsx
const ConfiguredMarkedInput = createMarkedInput(Button, [{
    markup: Primary,
    data: Data,
    initMark: ({label, value}) => ({label, primary: true, onClick: () => alert(value)})
}, {
    trigger: '/',
    markup: Default,
    data: AnotherData
}])
```
To
```tsx
const ConfiguredMarkedInput = createMarkedInput({
    Mark: Button,
    options: [{
        markup: Primary,
        data: ['First', 'Second', 'Third', 'Fourth', 'Fifth', 'Sixth'],
        initMark: ({label, value}) => ({label, primary: true, onClick: () => alert(value)})
    }, {
        markup: Default,
        trigger: '/',
        data: ['Seventh', 'Eight', 'Ninth'],
        initMark: ({label}) => ({label})
    }],
})
```