### PR TITLE
Breaking change: Improve naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,10 +208,10 @@ The `OverlayProps` provide some methods like `onSelect` for creating a new annot
 
 ```tsx
 const List = () => {
-    const {onSelect} = useOverlay()
+    const {select} = useOverlay()
     return <ul>
-        <li onClick={() => onSelect({label: 'First'})}>Clickable First</li>
-        <li onClick={() => onSelect({label: 'Second'})}>Clickable Second</li>
+        <li onClick={() => select({label: 'First'})}>Clickable First</li>
+        <li onClick={() => select({label: 'Second'})}>Clickable Second</li>
     </ul>;
 }
 

--- a/lib/components/Featurer/hooks/useSystemListeners.tsx
+++ b/lib/components/Featurer/hooks/useSystemListeners.tsx
@@ -39,7 +39,7 @@ export function useSystemListeners() {
 		const {pieces} = store.state
 		const {value, trigger: {option, span, index, source, node}} = event
 
-		const annotation = annotate(option.markup, value.label, value.value)
+		const annotation = annotate(option.markup!, value.label, value.value)
 		const newSpan = createNewSpan(span, annotation, index, source)
 		//const key = findSpanKey(span, pieces)
 		const piece = pieces.findNode(node => node.mark.label === span)

--- a/lib/components/MarkedInput.tsx
+++ b/lib/components/MarkedInput.tsx
@@ -1,6 +1,6 @@
 import {ComponentType, CSSProperties, ForwardedRef, forwardRef, ReactElement} from 'react'
 import '../styles.css'
-import {MarkedInputHandler, MarkStruct, OptionProps} from '../types'
+import {MarkedInputHandler, MarkStruct, Option} from '../types'
 import {Container} from './Container'
 import {Featurer} from './Featurer'
 import {StoreProvider} from './StoreProvider'
@@ -35,7 +35,7 @@ export interface MarkedInputProps<T = MarkStruct> {
 	 * Passed options for configure
 	 * @default One option with default values is used
 	 */
-	options?: OptionProps<T>[]
+	options?: Option<T>[]
 	/**
 	 * Additional classes
 	 */

--- a/lib/components/Suggestions/Suggestions.tsx
+++ b/lib/components/Suggestions/Suggestions.tsx
@@ -4,7 +4,7 @@ import {useDownOf} from '../../utils/useDownOf'
 import {useOverlay} from '../../utils/useOverlay'
 
 export const Suggestions = () => {
-	const {trigger, onSelect, style, ref} = useOverlay()
+	const {trigger, select, style, ref} = useOverlay()
 	const [active, setActive] = useState(NaN)
 	const filtered = useMemo(
 		() => trigger.option.data!.filter(s => s.toLowerCase().indexOf(trigger.value.toLowerCase()) > -1),
@@ -25,7 +25,7 @@ export const Suggestions = () => {
 	useDownOf(KEY.ENTER, event => {
 		event.preventDefault()
 		const suggestion = filtered[active]
-		onSelect({label: suggestion, value: active.toString()})
+		select({label: suggestion, value: active.toString()})
 	}, [filtered, active])
 
 	if (!filtered.length) return null
@@ -39,7 +39,7 @@ export const Suggestions = () => {
 					<li key={suggestion}
 						ref={el => className && el?.scrollIntoView(false)}
 						className={className}
-						onClick={_ => onSelect({label: suggestion, value: index.toString()})}
+						onClick={_ => select({label: suggestion, value: index.toString()})}
 						children={suggestion}
 					/>
 				)

--- a/lib/components/Suggestions/Suggestions.tsx
+++ b/lib/components/Suggestions/Suggestions.tsx
@@ -7,7 +7,7 @@ export const Suggestions = () => {
 	const {trigger, onSelect, style, ref} = useOverlay()
 	const [active, setActive] = useState(NaN)
 	const filtered = useMemo(
-		() => trigger.option.data.filter(s => s.toLowerCase().indexOf(trigger.value.toLowerCase()) > -1),
+		() => trigger.option.data!.filter(s => s.toLowerCase().indexOf(trigger.value.toLowerCase()) > -1),
 		[trigger.value]
 	)
 	const length = filtered.length

--- a/lib/components/Whisper.tsx
+++ b/lib/components/Whisper.tsx
@@ -3,10 +3,10 @@ import {useSelector} from '../utils/useSelector'
 import {Suggestions} from './Suggestions'
 
 export const Whisper = memo(() => {
-	const key = useSelector(state => state.trigger?.option.index)
+	const key = useSelector(state => state.options.indexOf(state.trigger?.option ?? {}))
 	const Overlay = useSelector(state => state.Overlay ?? Suggestions)
 
-	return key !== undefined ? <Overlay key={key}/> : null
+	return key !== -1 ? <Overlay key={key}/> : null
 })
 
 Whisper.displayName = 'Whisper'

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,4 +1,4 @@
-import {OptionType} from './types'
+import {Option} from './types'
 import LinkedList from './utils/LinkedList'
 
 export enum KEY {
@@ -36,11 +36,10 @@ export const EmptyFunc = () => {
 
 export const DefaultClass = 'mk-input'
 
-export const DefaultOptionProps: OptionType = {
+export const DefaultOptionProps: Option = {
 	trigger: '@',
 	markup: '@[__label__](__value__)',
 	data: [],
-	index: 0
 }
 
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,8 +6,8 @@ export {useOverlay} from './utils/useOverlay'
 export {useListener} from './utils/useListener'
 
 export type {MarkedInputProps, MarkedInputComponent} from './components/MarkedInput'
-export type {DynamicMark} from './utils/useMark' //TODO rename to MarkProps or similar?
-export type {OverlayProps} from './utils/useOverlay' //TODO rename?
+export type {MarkHandler} from './utils/useMark'
+export type {OverlayHandler} from './utils/useOverlay'
 export type {
 	MarkedInputHandler,
 	Markup,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -15,9 +15,7 @@ export type {
 	Trigger, //TODO named
 	AnnotatedMark, //TODO named
 
-	OptionProps, //TODO named
-	PartialPick, //TODO Remove?
-	OptionType, //TODO named
+	Option,
 
 	MarkStruct,
 	ConfiguredMarkedInput,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -34,14 +34,7 @@ export type Piece = string | AnnotatedMark
 
 export type KeyedPieces = Map<number, Piece>
 
-export type PartialPick<T, F extends keyof T> = Omit<Required<T>, F> & Partial<Pick<T, F>>
-
-export type OptionType = PartialPick<OptionProps, 'initMark'> & { index: number }
-
-export type Options = OptionType[]
-
-//TODO rename to options
-export interface OptionProps<T = Record<string, any>> {
+export interface Option<T = Record<string, any>> {
 	/**
 	 * Template string instead of which the mark is rendered.
 	 * Must contain placeholders: `__label__` and optional `__value__`
@@ -66,7 +59,7 @@ export interface OptionProps<T = Record<string, any>> {
 export type ConfiguredMarkedInput<T> = FunctionComponent<MarkedInputProps<T>>
 
 export type State = Omit<MarkedInputProps<any>, 'options'> & {
-	options: Options,
+	options: Option[],
 	pieces: LinkedList<NodeData>,
 	trigger?: Trigger,
 }
@@ -100,7 +93,7 @@ export type Trigger = {
 	/**
 	 * Trigger's option
 	 */
-	option: OptionType
+	option: Option
 }
 
 export type Listener<T = any> = (e: T) => void

--- a/lib/utils/Parser.ts
+++ b/lib/utils/Parser.ts
@@ -1,4 +1,4 @@
-import {Markup, Options, Piece} from '../types'
+import {Markup, Option, Piece} from '../types'
 import {markupToRegex, normalizeMark} from './index'
 import {ParserMatches} from './ParserMatches'
 
@@ -11,8 +11,8 @@ export class Parser {
 		return this.markups.map(markupToRegex)
 	}
 
-	static split(value: string, options?: Options) {
-		const markups = options?.map((c) => c.markup)
+	static split(value: string, options?: Option[]) {
+		const markups = options?.map((c) => c.markup!)
 		return () => markups ? new Parser(markups).split(value) : [value]
 	}
 

--- a/lib/utils/TriggerFinder.tsx
+++ b/lib/utils/TriggerFinder.tsx
@@ -1,5 +1,5 @@
 import {wordRegex} from '../constants'
-import {Options, Trigger} from '../types'
+import {Option, Trigger} from '../types'
 import {Caret} from './Caret'
 import {escape} from './index'
 
@@ -15,7 +15,7 @@ export class TriggerFinder {
 		this.dividedText = this.getDividedTextBy(caretPosition)
 	}
 
-	static find(options: Options) {
+	static find(options: Option[]) {
 		if (Caret.isSelectedPosition)
 			return new TriggerFinder().find(options)
 	}
@@ -24,9 +24,9 @@ export class TriggerFinder {
 		return {left: this.span.slice(0, position), right: this.span.slice(position)}
 	}
 
-	find(options: Options): Trigger | undefined {
+	find(options: Option[]): Trigger | undefined {
 		for (let option of options) {
-			let match = this.matchInTextVia(option.trigger)
+			let match = this.matchInTextVia(option.trigger!)
 			if (match) return {
 				value: match.word,
 				source: match.annotation,

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,15 +1,6 @@
 import React, {Context, useContext} from 'react'
 import {DefaultOptionProps, PLACEHOLDER} from '../constants'
-import {
-	AnnotatedMark,
-	KeyedPieces,
-	MarkStruct,
-	Markup,
-	NodeData,
-	OptionProps,
-	Options,
-	Piece,
-} from '../types'
+import {AnnotatedMark, KeyedPieces, MarkStruct, Markup, NodeData, Option, Piece,} from '../types'
 import {Parser} from './Parser'
 import {Store} from './Store'
 
@@ -60,11 +51,11 @@ export function denote(value: string, callback: (mark: AnnotatedMark) => string,
 	return pieces.reduce((previous: string, current) => previous += isObject(current) ? callback(current) : current, '')
 }
 
-export function toString(values: MarkStruct[], options: Options) {
+export function toString(values: MarkStruct[], options: Option[]) {
 	let result = ''
 	for (let value of values) {
 		result += isAnnotated(value)
-			? annotate(options[value.childIndex].markup, value.label, value.value)
+			? annotate(options[value.childIndex].markup!, value.label, value.value)
 			: value.label
 	}
 	return result
@@ -98,12 +89,12 @@ export function assertAnnotated(value: unknown): asserts value is AnnotatedMark 
 
 export const isFunction = (value: unknown): value is Function => typeof value === 'function'
 
-export function extractOptions(options?: OptionProps[]): Options {
+export function extractOptions(options?: Option[]): Option[] {
 	if (options?.length) return options.map(initOption)
 
 	return [DefaultOptionProps]
 
-	function initOption(props: OptionProps, index: number) {
+	function initOption(props: Option, index: number) {
 		return assign({}, DefaultOptionProps, props, {index})
 	}
 }

--- a/lib/utils/useMark.ts
+++ b/lib/utils/useMark.ts
@@ -4,7 +4,7 @@ import {MarkStruct} from '../types'
 import {useNode, useStore} from './index'
 import {useSelector} from './useSelector'
 
-export interface DynamicMark<T> extends MarkStruct {
+export interface MarkHandler<T> extends MarkStruct {
 	/**
 	 * MarkStruct ref. Used for focusing and key handling operations.
 	 */
@@ -24,7 +24,7 @@ export interface DynamicMark<T> extends MarkStruct {
 	readOnly?: boolean
 }
 
-export const useMark = <T extends HTMLElement = HTMLElement, >(): DynamicMark<T> => {
+export const useMark = <T extends HTMLElement = HTMLElement, >(): MarkHandler<T> => {
 	const node = useNode()
 	const {bus} = useStore()
 	const readOnly = useSelector(state => state.readOnly)

--- a/lib/utils/useOverlay.tsx
+++ b/lib/utils/useOverlay.tsx
@@ -5,7 +5,7 @@ import {Caret} from './Caret'
 import {useStore} from './index'
 import {useSelector} from './useSelector'
 
-export interface OverlayProps {
+export interface OverlayHandler {
 	/**
 	 * Style with caret absolute position. Used for placing an overlay.
 	 */
@@ -28,7 +28,7 @@ export interface OverlayProps {
 	ref: RefObject<HTMLElement>
 }
 
-export function useOverlay(): OverlayProps {
+export function useOverlay(): OverlayHandler {
 	const store = useStore()
 	const trigger = useSelector(state => state.trigger!)
 	const style = Caret.getAbsolutePosition()

--- a/lib/utils/useOverlay.tsx
+++ b/lib/utils/useOverlay.tsx
@@ -16,11 +16,11 @@ export interface OverlayProps {
 	/**
 	 * Used for close overlay.
 	 */
-	onClose: () => void
+	close: () => void
 	/**
 	 * Used for insert an annotation instead a triggered value.
 	 */
-	onSelect: (value: MarkStruct) => void
+	select: (value: MarkStruct) => void
 	/**
 	 * Trigger details
 	 */
@@ -33,11 +33,11 @@ export function useOverlay(): OverlayProps {
 	const trigger = useSelector(state => state.trigger!)
 	const style = Caret.getAbsolutePosition()
 
-	const onClose = useCallback(() => store.bus.send(SystemEvent.ClearTrigger), [])
-	const onSelect = useCallback((value: MarkStruct) => {
+	const close = useCallback(() => store.bus.send(SystemEvent.ClearTrigger), [])
+	const select = useCallback((value: MarkStruct) => {
 		store.bus.send(SystemEvent.Select, {value, trigger})
 		store.bus.send(SystemEvent.ClearTrigger)
 	}, [trigger])
 
-	return {trigger, style, onSelect, onClose, ref: store.overlayRef}
+	return {trigger, style, select, close, ref: store.overlayRef}
 }

--- a/storybook/stories/Overlay.stories.tsx
+++ b/storybook/stories/Overlay.stories.tsx
@@ -36,10 +36,10 @@ export const PositionedOverlay = () => {
 }
 
 const List = () => {
-	const {onSelect} = useOverlay()
+	const {select} = useOverlay()
 	return <ul>
-		<li onClick={() => onSelect({label: 'First'})}>Clickable First</li>
-		<li onClick={() => onSelect({label: 'Second'})}>Clickable Second</li>
+		<li onClick={() => select({label: 'First'})}>Clickable First</li>
+		<li onClick={() => select({label: 'Second'})}>Clickable Second</li>
 	</ul>
 }
 

--- a/storybook/stories/Rsuite.stories.tsx
+++ b/storybook/stories/Rsuite.stories.tsx
@@ -15,14 +15,14 @@ export default {
 } as ComponentMeta<typeof MarkedInput>
 
 const Overlay = () => {
-	const {style, trigger, onSelect, onClose} = useOverlay()
+	const {style, trigger, select, close} = useOverlay()
 
 	useEffect(() => {
 		const handleEnter = (ev: KeyboardEvent) => {
 			if (ev.key === KEY.ENTER) {
 				ev.preventDefault()
-				onSelect({label: trigger.value})
-				onClose()
+				select({label: trigger.value})
+				close()
 			}
 		}
 

--- a/storybook/stories/assets/MaterialMentions/UserList/UserList.tsx
+++ b/storybook/stories/assets/MaterialMentions/UserList/UserList.tsx
@@ -5,7 +5,7 @@ import {useFetch} from '../utils/useFetch'
 import {UserItem} from './UserItem'
 
 export const UserList = () => {
-	const {onSelect, trigger: {value}, style} = useOverlay()
+	const {select, trigger: {value}, style} = useOverlay()
 	const [data] = useFetch<{ items: SearchUser[] }>(`https://api.github.com/search/users?q=${value}`, [value])
 	const users = data?.items ?? []
 
@@ -22,7 +22,7 @@ export const UserList = () => {
 				   top: style.top
 			   }}>
 			<List dense>
-				{users.map(user => (<UserItem key={user.login} onSelect={onSelect} user={user}/>))}
+				{users.map(user => (<UserItem key={user.login} onSelect={select} user={user}/>))}
 			</List>
 		</Paper>
 	)


### PR DESCRIPTION
Rename:
* `OptionProps` to `Option` type
* `onSelect` to select of `useOverlay`
* `onClose` to close of `useOverlay`
* `DynamicMark` to `MarkHandler`
* `OverlayProps` to `OverlayHandler`

Remove extra api types