### PR TITLE
 feat(clipboard): implement enhanced copy/cut/paste with cross-token selection support

### DIFF
--- a/packages/core/src/features/clipboard/CopyController.ts
+++ b/packages/core/src/features/clipboard/CopyController.ts
@@ -1,0 +1,59 @@
+import {toString} from '../parsing'
+import type {Store} from '../store'
+import {MARKPUT_MIME} from './pasteMarkup'
+import {selectionToTokens} from './selectionToTokens'
+
+export class CopyController {
+	#copyHandler?: (e: ClipboardEvent) => void
+
+	constructor(private store: Store) {}
+
+	enable() {
+		if (this.#copyHandler) return
+
+		this.#copyHandler = (e: ClipboardEvent) => {
+			const container = this.store.refs.container
+			if (!container) return
+
+			const sel = window.getSelection()
+			if (!sel || sel.isCollapsed || !sel.rangeCount) return
+
+			const range = sel.getRangeAt(0)
+			if (!container.contains(range.startContainer) || !container.contains(range.endContainer)) {
+				return
+			}
+
+			const result = selectionToTokens(this.store)
+			if (!result) return
+
+			// text/plain: visual selected text (partial marks = just selected text)
+			const plainText = range.toString()
+
+			// text/html: rendered DOM HTML from the actual selection
+			const fragment = range.cloneContents()
+			const div = document.createElement('div')
+			div.appendChild(fragment)
+			const html = div.innerHTML
+
+			// application/x-markput: only when selection covers complete tokens
+			// partial selections fall back to text/plain on paste
+			const isFullTokenRange = result.firstFullySelected && result.lastFullySelected
+
+			e.preventDefault()
+			e.clipboardData?.setData('text/plain', plainText)
+			e.clipboardData?.setData('text/html', html)
+			if (isFullTokenRange) {
+				e.clipboardData?.setData(MARKPUT_MIME, toString(result.tokens))
+			}
+		}
+
+		this.store.refs.container?.addEventListener('copy', this.#copyHandler)
+	}
+
+	disable() {
+		if (this.#copyHandler) {
+			this.store.refs.container?.removeEventListener('copy', this.#copyHandler)
+			this.#copyHandler = undefined
+		}
+	}
+}

--- a/packages/core/src/features/clipboard/CopyController.ts
+++ b/packages/core/src/features/clipboard/CopyController.ts
@@ -7,6 +7,11 @@ import {type SelectionTokenRange, selectionToTokens} from './selectionToTokens'
 /**
  * Trim boundary text tokens to the selected portion.
  * Mark tokens are always kept in full — partial mark selection expands to full mark.
+ *
+ * NOTE: Returned text tokens have stale `position` fields — the start/end positions
+ * still reflect the original token, not the trimmed content. Only `content` is
+ * authoritative on the returned tokens. `toString` is safe because it reads `content`
+ * directly; do not use `position` on the returned tokens for any other purpose.
  */
 function trimBoundaryTokens({tokens, startOffset, endOffset}: SelectionTokenRange): Token[] {
 	if (tokens.length === 0) return tokens

--- a/packages/core/src/features/clipboard/CopyController.ts
+++ b/packages/core/src/features/clipboard/CopyController.ts
@@ -31,6 +31,7 @@ function trimBoundaryTokens({tokens, startOffset, endOffset}: SelectionTokenRang
 
 export class CopyController {
 	#copyHandler?: (e: ClipboardEvent) => void
+	#cutHandler?: (e: ClipboardEvent) => void
 
 	constructor(private store: Store) {}
 
@@ -38,46 +39,91 @@ export class CopyController {
 		if (this.#copyHandler) return
 
 		this.#copyHandler = (e: ClipboardEvent) => {
-			const container = this.store.refs.container
-			if (!container) return
-
-			const sel = window.getSelection()
-			if (!sel || sel.isCollapsed || !sel.rangeCount) return
-
-			const range = sel.getRangeAt(0)
-			if (!container.contains(range.startContainer) || !container.contains(range.endContainer)) {
-				return
-			}
-
-			const result = selectionToTokens(this.store)
-			if (!result) return
-
-			// text/plain: visual selected text
-			const plainText = range.toString()
-
-			// text/html: rendered DOM HTML from the actual selection
-			const fragment = range.cloneContents()
-			const div = document.createElement('div')
-			div.appendChild(fragment)
-			const html = div.innerHTML
-
-			// application/x-markput: boundary text tokens trimmed to selected portion,
-			// mark tokens always expanded to full markup syntax
-			const markup = toString(trimBoundaryTokens(result))
-
-			e.preventDefault()
-			e.clipboardData?.setData('text/plain', plainText)
-			e.clipboardData?.setData('text/html', html)
-			e.clipboardData?.setData(MARKPUT_MIME, markup)
+			this.#handleCopy(e)
 		}
 
-		this.store.refs.container?.addEventListener('copy', this.#copyHandler)
+		this.#cutHandler = (e: ClipboardEvent) => {
+			if (!this.#handleCopy(e)) return
+
+			const result = selectionToTokens(this.store)
+			if (!result || result.tokens.length === 0) return
+
+			const first = result.tokens[0]
+			const last = result.tokens[result.tokens.length - 1]
+
+			const rawStart = first.type === 'text' ? first.position.start + result.startOffset : first.position.start
+			const rawEnd = last.type === 'text' ? last.position.start + result.endOffset : last.position.end
+
+			const value = this.store.state.previousValue.get() ?? this.store.state.value.get() ?? ''
+			if (rawStart === rawEnd) return
+
+			const newValue = value.slice(0, rawStart) + value.slice(rawEnd)
+			this.store.applyValue(newValue)
+
+			const newTokens = this.store.state.tokens.get()
+			let targetIdx = newTokens.findIndex(
+				t => t.type === 'text' && rawStart >= t.position.start && rawStart <= t.position.end
+			)
+			if (targetIdx === -1) targetIdx = newTokens.length - 1
+			const caretWithinToken = rawStart - newTokens[targetIdx].position.start
+
+			this.store.state.recovery.set({
+				anchor: this.store.nodes.focus,
+				caret: caretWithinToken,
+				isNext: true,
+				childIndex: targetIdx - 2,
+			})
+		}
+
+		const container = this.store.refs.container
+		container?.addEventListener('copy', this.#copyHandler)
+		container?.addEventListener('cut', this.#cutHandler)
 	}
 
 	disable() {
+		const container = this.store.refs.container
 		if (this.#copyHandler) {
-			this.store.refs.container?.removeEventListener('copy', this.#copyHandler)
+			container?.removeEventListener('copy', this.#copyHandler)
 			this.#copyHandler = undefined
 		}
+		if (this.#cutHandler) {
+			container?.removeEventListener('cut', this.#cutHandler)
+			this.#cutHandler = undefined
+		}
+	}
+
+	#handleCopy(e: ClipboardEvent): boolean {
+		const container = this.store.refs.container
+		if (!container) return false
+
+		const sel = window.getSelection()
+		if (!sel || sel.isCollapsed || !sel.rangeCount) return false
+
+		const range = sel.getRangeAt(0)
+		if (!container.contains(range.startContainer) || !container.contains(range.endContainer)) {
+			return false
+		}
+
+		const result = selectionToTokens(this.store)
+		if (!result) return false
+
+		// text/plain: visual selected text
+		const plainText = range.toString()
+
+		// text/html: rendered DOM HTML from the actual selection
+		const fragment = range.cloneContents()
+		const div = document.createElement('div')
+		div.appendChild(fragment)
+		const html = div.innerHTML
+
+		// application/x-markput: boundary text tokens trimmed to selected portion,
+		// mark tokens always expanded to full markup syntax
+		const markup = toString(trimBoundaryTokens(result))
+
+		e.preventDefault()
+		e.clipboardData?.setData('text/plain', plainText)
+		e.clipboardData?.setData('text/html', html)
+		e.clipboardData?.setData(MARKPUT_MIME, markup)
+		return true
 	}
 }

--- a/packages/core/src/features/clipboard/CopyController.ts
+++ b/packages/core/src/features/clipboard/CopyController.ts
@@ -1,7 +1,28 @@
 import {toString} from '../parsing'
+import type {Token} from '../parsing'
 import type {Store} from '../store'
 import {MARKPUT_MIME} from './pasteMarkup'
-import {selectionToTokens} from './selectionToTokens'
+import {type SelectionTokenRange, selectionToTokens} from './selectionToTokens'
+
+/**
+ * Trim boundary text tokens to the selected portion.
+ * Mark tokens are always kept in full — partial mark selection expands to full mark.
+ */
+function trimBoundaryTokens({tokens, startOffset, endOffset}: SelectionTokenRange): Token[] {
+	if (tokens.length === 0) return tokens
+
+	return tokens.map((token, i) => {
+		if (token.type !== 'text') return token
+
+		const isFirst = i === 0
+		const isLast = i === tokens.length - 1
+
+		if (isFirst && isLast) return {...token, content: token.content.slice(startOffset, endOffset)}
+		if (isFirst) return {...token, content: token.content.slice(startOffset)}
+		if (isLast) return {...token, content: token.content.slice(0, endOffset)}
+		return token
+	})
+}
 
 export class CopyController {
 	#copyHandler?: (e: ClipboardEvent) => void
@@ -26,7 +47,7 @@ export class CopyController {
 			const result = selectionToTokens(this.store)
 			if (!result) return
 
-			// text/plain: visual selected text (partial marks = just selected text)
+			// text/plain: visual selected text
 			const plainText = range.toString()
 
 			// text/html: rendered DOM HTML from the actual selection
@@ -35,16 +56,14 @@ export class CopyController {
 			div.appendChild(fragment)
 			const html = div.innerHTML
 
-			// application/x-markput: only when selection covers complete tokens
-			// partial selections fall back to text/plain on paste
-			const isFullTokenRange = result.firstFullySelected && result.lastFullySelected
+			// application/x-markput: boundary text tokens trimmed to selected portion,
+			// mark tokens always expanded to full markup syntax
+			const markup = toString(trimBoundaryTokens(result))
 
 			e.preventDefault()
 			e.clipboardData?.setData('text/plain', plainText)
 			e.clipboardData?.setData('text/html', html)
-			if (isFullTokenRange) {
-				e.clipboardData?.setData(MARKPUT_MIME, toString(result.tokens))
-			}
+			e.clipboardData?.setData(MARKPUT_MIME, markup)
 		}
 
 		this.store.refs.container?.addEventListener('copy', this.#copyHandler)

--- a/packages/core/src/features/clipboard/index.ts
+++ b/packages/core/src/features/clipboard/index.ts
@@ -1,0 +1,4 @@
+export {CopyController} from './CopyController'
+export {selectionToTokens} from './selectionToTokens'
+export type {SelectionTokenRange} from './selectionToTokens'
+export {MARKPUT_MIME, captureMarkupPaste, consumeMarkupPaste, clearMarkupPaste} from './pasteMarkup'

--- a/packages/core/src/features/clipboard/index.ts
+++ b/packages/core/src/features/clipboard/index.ts
@@ -1,4 +1,4 @@
 export {CopyController} from './CopyController'
-export {selectionToTokens} from './selectionToTokens'
-export type {SelectionTokenRange} from './selectionToTokens'
+export {getBoundaryOffset, selectionToTokens} from './selectionToTokens'
+export type {RangeBoundary, SelectionTokenRange} from './selectionToTokens'
 export {MARKPUT_MIME, captureMarkupPaste, consumeMarkupPaste, clearMarkupPaste} from './pasteMarkup'

--- a/packages/core/src/features/clipboard/pasteMarkup.spec.ts
+++ b/packages/core/src/features/clipboard/pasteMarkup.spec.ts
@@ -1,0 +1,55 @@
+import {describe, expect, it} from 'vitest'
+
+import {captureMarkupPaste, clearMarkupPaste, consumeMarkupPaste, MARKPUT_MIME} from './pasteMarkup'
+
+function makeContainer(): HTMLElement {
+	// oxlint-disable-next-line no-unsafe-type-assertion -- plain object used as WeakMap key; no DOM methods needed
+	return {} as HTMLElement
+}
+
+function makePasteEvent(markup: string): ClipboardEvent {
+	// oxlint-disable-next-line no-unsafe-type-assertion -- minimal stub; only clipboardData.getData is accessed
+	return {
+		clipboardData: {
+			getData: (mime: string) => (mime === MARKPUT_MIME ? markup : ''),
+		},
+	} as unknown as ClipboardEvent
+}
+
+describe('captureMarkupPaste / consumeMarkupPaste', () => {
+	it('returns markup captured for its own container', () => {
+		const containerA = makeContainer()
+		const event = makePasteEvent('hello @[world](1)')
+		captureMarkupPaste(event, containerA)
+		expect(consumeMarkupPaste(containerA)).toBe('hello @[world](1)')
+	})
+
+	it('does not leak captured markup to another container', () => {
+		const containerA = makeContainer()
+		const containerB = makeContainer()
+		captureMarkupPaste(makePasteEvent('@[a](1)'), containerA)
+		expect(consumeMarkupPaste(containerB)).toBeUndefined()
+		// A's markup is still there and consumable
+		expect(consumeMarkupPaste(containerA)).toBe('@[a](1)')
+	})
+
+	it('consumeMarkupPaste clears after first call', () => {
+		const container = makeContainer()
+		captureMarkupPaste(makePasteEvent('@[a](1)'), container)
+		expect(consumeMarkupPaste(container)).toBe('@[a](1)')
+		expect(consumeMarkupPaste(container)).toBeUndefined()
+	})
+
+	it('returns undefined when no markup was captured', () => {
+		const container = makeContainer()
+		captureMarkupPaste(makePasteEvent(''), container)
+		expect(consumeMarkupPaste(container)).toBeUndefined()
+	})
+
+	it('clearMarkupPaste removes pending markup for that container', () => {
+		const container = makeContainer()
+		captureMarkupPaste(makePasteEvent('@[a](1)'), container)
+		clearMarkupPaste(container)
+		expect(consumeMarkupPaste(container)).toBeUndefined()
+	})
+})

--- a/packages/core/src/features/clipboard/pasteMarkup.ts
+++ b/packages/core/src/features/clipboard/pasteMarkup.ts
@@ -1,31 +1,38 @@
 /** Custom MIME type for markput markup syntax. */
 export const MARKPUT_MIME = 'application/x-markput'
 
-let pendingMarkup: string | undefined
+const pendingMarkupByContainer = new WeakMap<HTMLElement, string>()
 
 /**
- * Capture markup data from a paste event.
+ * Capture markup data from a paste event, scoped to a specific container.
  * Call this from the `paste` event handler — custom MIME types are readable
  * on ClipboardEvent.clipboardData but not reliably on InputEvent.dataTransfer.
+ *
+ * Scoping to the container prevents multiple editor instances from consuming
+ * each other's clipboard data.
  */
-export function captureMarkupPaste(event: ClipboardEvent): void {
+export function captureMarkupPaste(event: ClipboardEvent, container: HTMLElement): void {
 	const raw = event.clipboardData?.getData(MARKPUT_MIME)
-	pendingMarkup = raw !== '' ? raw : undefined
+	if (raw) {
+		pendingMarkupByContainer.set(container, raw)
+	} else {
+		pendingMarkupByContainer.delete(container)
+	}
 }
 
 /**
- * Consume the pending markup data (if any) from a prior captureMarkupPaste call.
+ * Consume the pending markup data (if any) for the given container.
  * Returns undefined if no markup was captured or the data was already consumed.
  */
-export function consumeMarkupPaste(): string | undefined {
-	const markup = pendingMarkup
-	pendingMarkup = undefined
+export function consumeMarkupPaste(container: HTMLElement): string | undefined {
+	const markup = pendingMarkupByContainer.get(container)
+	pendingMarkupByContainer.delete(container)
 	return markup
 }
 
 /**
- * Clear the pending markup buffer. Useful for test cleanup.
+ * Clear the pending markup buffer for the given container. Useful for test cleanup.
  */
-export function clearMarkupPaste(): void {
-	pendingMarkup = undefined
+export function clearMarkupPaste(container: HTMLElement): void {
+	pendingMarkupByContainer.delete(container)
 }

--- a/packages/core/src/features/clipboard/pasteMarkup.ts
+++ b/packages/core/src/features/clipboard/pasteMarkup.ts
@@ -1,0 +1,31 @@
+/** Custom MIME type for markput markup syntax. */
+export const MARKPUT_MIME = 'application/x-markput'
+
+let pendingMarkup: string | undefined
+
+/**
+ * Capture markup data from a paste event.
+ * Call this from the `paste` event handler — custom MIME types are readable
+ * on ClipboardEvent.clipboardData but not reliably on InputEvent.dataTransfer.
+ */
+export function captureMarkupPaste(event: ClipboardEvent): void {
+	const raw = event.clipboardData?.getData(MARKPUT_MIME)
+	pendingMarkup = raw !== '' ? raw : undefined
+}
+
+/**
+ * Consume the pending markup data (if any) from a prior captureMarkupPaste call.
+ * Returns undefined if no markup was captured or the data was already consumed.
+ */
+export function consumeMarkupPaste(): string | undefined {
+	const markup = pendingMarkup
+	pendingMarkup = undefined
+	return markup
+}
+
+/**
+ * Clear the pending markup buffer. Useful for test cleanup.
+ */
+export function clearMarkupPaste(): void {
+	pendingMarkup = undefined
+}

--- a/packages/core/src/features/clipboard/selectionToTokens.spec.ts
+++ b/packages/core/src/features/clipboard/selectionToTokens.spec.ts
@@ -1,0 +1,128 @@
+import {describe, expect, it} from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Minimal DOM mock — supports the subset of DOM APIs used by computeOffset:
+//   Node / Text / HTMLElement creation, appendChild, contains, createTreeWalker
+// ---------------------------------------------------------------------------
+
+class MockNode {
+	readonly childNodes: MockNode[] = []
+	parentNode: MockNode | null = null
+
+	appendChild(child: MockNode): MockNode {
+		child.parentNode = this
+		this.childNodes.push(child)
+		return child
+	}
+
+	contains(node: MockNode | null): boolean {
+		if (!node) return false
+		// eslint-disable-next-line @typescript-eslint/no-this-alias
+		let current: MockNode | null = node
+		while (current) {
+			if (current === this) return true
+			current = current.parentNode
+		}
+		return false
+	}
+}
+
+class MockText extends MockNode {
+	readonly nodeType = 3
+	constructor(public data: string) {
+		super()
+	}
+	get length(): number {
+		return this.data.length
+	}
+}
+
+class MockElement extends MockNode {
+	readonly nodeType = 1
+	constructor(public tagName: string) {
+		super()
+	}
+}
+
+/** Collect all text nodes in document order via a simple recursive walk. */
+function textNodesInOrder(node: MockNode): MockText[] {
+	const result: MockText[] = []
+	function walk(n: MockNode) {
+		if (n instanceof MockText) {
+			result.push(n)
+		}
+		for (const child of n.childNodes) {
+			walk(child)
+		}
+	}
+	walk(node)
+	return result
+}
+
+// ---------------------------------------------------------------------------
+// computeOffset — mirrors the fixed getBoundaryOffset logic
+// ---------------------------------------------------------------------------
+
+function computeOffset(child: MockElement, targetNode: MockNode, targetOffset: number): number {
+	if (!child.contains(targetNode)) {
+		return 0
+	}
+	let charOffset = 0
+	for (const text of textNodesInOrder(child)) {
+		if (text === targetNode) {
+			return charOffset + targetOffset
+		}
+		charOffset += text.length
+	}
+	return 0
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a mock element containing multiple text nodes (simulating a nested mark).
+ * Returns [element, t1 ("hello"), t2 (" world")].
+ * DOM structure: <span>"hello"<em>" world"</em></span>
+ */
+function makeNestedElement(): [MockElement, MockText, MockText] {
+	const el = new MockElement('span')
+	const t1 = new MockText('hello')
+	const inner = new MockElement('em')
+	const t2 = new MockText(' world')
+	inner.appendChild(t2)
+	el.appendChild(t1)
+	el.appendChild(inner)
+	return [el, t1, t2]
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('getBoundaryOffset (cumulative text walk)', () => {
+	it('returns correct offset when boundary is in first text node', () => {
+		const [el, t1] = makeNestedElement()
+		// Boundary in t1 ("hello") at offset 2 → "he"
+		expect(computeOffset(el, t1, 2)).toBe(2)
+	})
+
+	it('returns correct cumulative offset when boundary is in second text node', () => {
+		const [el, , t2] = makeNestedElement()
+		// t1 = "hello" (5 chars), boundary in t2 (" world") at offset 3 → 5 + 3 = 8
+		expect(computeOffset(el, t2, 3)).toBe(8)
+	})
+
+	it('returns 0 when target node is not inside child', () => {
+		const [el] = makeNestedElement()
+		const outsideNode = new MockText('outside')
+		expect(computeOffset(el, outsideNode, 0)).toBe(0)
+	})
+
+	it('returns full offset at end of second text node', () => {
+		const [el, , t2] = makeNestedElement()
+		// t2 = " world" (6 chars), end boundary at offset 6 → 5 + 6 = 11
+		expect(computeOffset(el, t2, t2.length)).toBe(11)
+	})
+})

--- a/packages/core/src/features/clipboard/selectionToTokens.spec.ts
+++ b/packages/core/src/features/clipboard/selectionToTokens.spec.ts
@@ -1,10 +1,12 @@
 import {describe, expect, it} from 'vitest'
 
 // NOTE: The core package runs under vitest's node environment without jsdom.
-// We cannot call window.getSelection() or document.createRange() here.
-// These tests validate the tree-walk algorithm used inside getBoundaryOffset
-// using a minimal mock DOM. Integration coverage for the actual DOM path
-// is provided by the storybook browser tests.
+// window.getSelection(), document.createRange(), and document.createTreeWalker()
+// are all unavailable here (document.createTreeWalker is the specific API
+// getBoundaryOffset uses internally). These tests validate the tree-walk algorithm
+// used inside getBoundaryOffset using a minimal pure-JS mock DOM. Integration
+// coverage for the actual DOM path (real TreeWalker + Selection API) is provided
+// by the storybook browser tests (Clipboard.react.spec.tsx: copy and paste tests).
 
 // ---------------------------------------------------------------------------
 // Minimal DOM mock — supports the subset of DOM APIs used by getBoundaryOffset:

--- a/packages/core/src/features/clipboard/selectionToTokens.spec.ts
+++ b/packages/core/src/features/clipboard/selectionToTokens.spec.ts
@@ -1,7 +1,13 @@
 import {describe, expect, it} from 'vitest'
 
+// NOTE: The core package runs under vitest's node environment without jsdom.
+// We cannot call window.getSelection() or document.createRange() here.
+// These tests validate the tree-walk algorithm used inside getBoundaryOffset
+// using a minimal mock DOM. Integration coverage for the actual DOM path
+// is provided by the storybook browser tests.
+
 // ---------------------------------------------------------------------------
-// Minimal DOM mock — supports the subset of DOM APIs used by computeOffset:
+// Minimal DOM mock — supports the subset of DOM APIs used by getBoundaryOffset:
 //   Node / Text / HTMLElement creation, appendChild, contains, createTreeWalker
 // ---------------------------------------------------------------------------
 
@@ -17,7 +23,7 @@ class MockNode {
 
 	contains(node: MockNode | null): boolean {
 		if (!node) return false
-		// eslint-disable-next-line @typescript-eslint/no-this-alias
+		// oxlint-disable-next-line no-this-alias
 		let current: MockNode | null = node
 		while (current) {
 			if (current === this) return true
@@ -60,7 +66,7 @@ function textNodesInOrder(node: MockNode): MockText[] {
 }
 
 // ---------------------------------------------------------------------------
-// computeOffset — mirrors the fixed getBoundaryOffset logic
+// computeOffset — mirrors the getBoundaryOffset algorithm from selectionToTokens.ts
 // ---------------------------------------------------------------------------
 
 function computeOffset(child: MockElement, targetNode: MockNode, targetOffset: number): number {

--- a/packages/core/src/features/clipboard/selectionToTokens.ts
+++ b/packages/core/src/features/clipboard/selectionToTokens.ts
@@ -21,19 +21,31 @@ function findContainerChildIndex(node: Node, container: HTMLElement): number {
 
 /**
  * Returns the character offset of a range boundary within a container child.
- * For text nodes directly inside the child, uses the range offset directly.
- * Falls back to 0 (start) or full text length (end) for element-level boundaries.
+ * Walks all text nodes in document order to compute a cumulative character
+ * offset, which correctly handles nested marks with multiple text nodes.
+ * Falls back to 0 (start) or full text length (end) for out-of-child boundaries.
  */
 function getBoundaryOffset(range: Range, child: Element, isStart: boolean): number {
+	const targetNode = isStart ? range.startContainer : range.endContainer
+	const targetOffset = isStart ? range.startOffset : range.endOffset
+
+	if (!child.contains(targetNode)) {
+		return isStart ? 0 : child.textContent.length
+	}
+
+	let charOffset = 0
 	const walker = document.createTreeWalker(child, NodeFilter.SHOW_TEXT)
 	// oxlint-disable-next-line no-unsafe-type-assertion -- SHOW_TEXT guarantees Text
-	const firstText = walker.nextNode() as Text | null
-	if (!firstText) return 0
+	let current = walker.nextNode() as Text | null
+	while (current) {
+		if (current === targetNode) {
+			return charOffset + targetOffset
+		}
+		charOffset += current.length
+		// oxlint-disable-next-line no-unsafe-type-assertion -- SHOW_TEXT guarantees Text
+		current = walker.nextNode() as Text | null
+	}
 
-	const node = isStart ? range.startContainer : range.endContainer
-	const offset = isStart ? range.startOffset : range.endOffset
-
-	if (node === firstText) return offset
 	return isStart ? 0 : child.textContent.length
 }
 

--- a/packages/core/src/features/clipboard/selectionToTokens.ts
+++ b/packages/core/src/features/clipboard/selectionToTokens.ts
@@ -1,0 +1,96 @@
+import type {Token} from '../parsing'
+import type {Store} from '../store'
+
+/**
+ * Walk up the DOM from `node` until reaching a direct child of `container`.
+ * Returns the index of that child in container.children, or -1 if not found.
+ *
+ * Works for both drag and non-drag modes:
+ * - Non-drag: container children are Token-rendered elements (1:1 with tokens)
+ * - Drag: container children are Block wrappers (1:1 with tokens)
+ * - Nested marks: walks past inner mark elements to the top-level container child
+ */
+function findContainerChildIndex(node: Node, container: HTMLElement): number {
+	let current: HTMLElement | null = node instanceof HTMLElement ? node : node.parentElement
+	while (current && current.parentElement !== container) {
+		current = current.parentElement
+	}
+	if (!current) return -1
+	return Array.from(container.children).indexOf(current)
+}
+
+/**
+ * Check whether the selection range fully covers a container child element
+ * at the given boundary (start or end).
+ *
+ * Uses text-node-level ranges for comparison because browser selections
+ * resolve to text nodes, while selectNodeContents resolves to the element —
+ * making compareBoundaryPoints mismatch.
+ */
+function isBoundaryFullyCovered(range: Range, container: HTMLElement, childIndex: number, isStart: boolean): boolean {
+	const child = container.children.item(childIndex)
+	if (!child) return false
+
+	// Find the first and last text nodes inside the child
+	const walker = document.createTreeWalker(child, NodeFilter.SHOW_TEXT)
+	const firstText = walker.nextNode()
+	if (!firstText) return false
+
+	let lastText = firstText
+	while (walker.nextNode()) {
+		lastText = walker.currentNode
+	}
+
+	const fullRange = document.createRange()
+	fullRange.setStart(firstText, 0)
+	fullRange.setEnd(lastText, lastText.textContent?.length ?? 0)
+
+	if (isStart) {
+		return range.compareBoundaryPoints(Range.START_TO_START, fullRange) <= 0
+	}
+	return range.compareBoundaryPoints(Range.END_TO_END, fullRange) >= 0
+}
+
+export interface SelectionTokenRange {
+	tokens: Token[]
+	firstFullySelected: boolean
+	lastFullySelected: boolean
+}
+
+/**
+ * Map a browser Selection to the subset of tokens it covers.
+ * Reports whether boundary tokens are fully covered by the selection.
+ * Returns null if selection is collapsed, empty, or outside the container.
+ */
+export function selectionToTokens(store: Store): SelectionTokenRange | null {
+	const container = store.refs.container
+	if (!container) return null
+
+	const sel = window.getSelection()
+	if (!sel || sel.isCollapsed || !sel.rangeCount) return null
+
+	const range = sel.getRangeAt(0)
+
+	if (!container.contains(range.startContainer) || !container.contains(range.endContainer)) {
+		return null
+	}
+
+	const tokens = store.state.tokens.get()
+
+	let startIndex = findContainerChildIndex(range.startContainer, container)
+	let endIndex = findContainerChildIndex(range.endContainer, container)
+
+	if (startIndex === -1 || endIndex === -1) return null
+
+	if (startIndex > endIndex) {
+		;[startIndex, endIndex] = [endIndex, startIndex]
+	}
+
+	const selectedTokens = tokens.slice(startIndex, endIndex + 1)
+
+	return {
+		tokens: selectedTokens,
+		firstFullySelected: isBoundaryFullyCovered(range, container, startIndex, true),
+		lastFullySelected: isBoundaryFullyCovered(range, container, endIndex, false),
+	}
+}

--- a/packages/core/src/features/clipboard/selectionToTokens.ts
+++ b/packages/core/src/features/clipboard/selectionToTokens.ts
@@ -20,46 +20,33 @@ function findContainerChildIndex(node: Node, container: HTMLElement): number {
 }
 
 /**
- * Check whether the selection range fully covers a container child element
- * at the given boundary (start or end).
- *
- * Uses text-node-level ranges for comparison because browser selections
- * resolve to text nodes, while selectNodeContents resolves to the element —
- * making compareBoundaryPoints mismatch.
+ * Returns the character offset of a range boundary within a container child.
+ * For text nodes directly inside the child, uses the range offset directly.
+ * Falls back to 0 (start) or full text length (end) for element-level boundaries.
  */
-function isBoundaryFullyCovered(range: Range, container: HTMLElement, childIndex: number, isStart: boolean): boolean {
-	const child = container.children.item(childIndex)
-	if (!child) return false
-
-	// Find the first and last text nodes inside the child
+function getBoundaryOffset(range: Range, child: Element, isStart: boolean): number {
 	const walker = document.createTreeWalker(child, NodeFilter.SHOW_TEXT)
-	const firstText = walker.nextNode()
-	if (!firstText) return false
+	// oxlint-disable-next-line no-unsafe-type-assertion -- SHOW_TEXT guarantees Text
+	const firstText = walker.nextNode() as Text | null
+	if (!firstText) return 0
 
-	let lastText = firstText
-	while (walker.nextNode()) {
-		lastText = walker.currentNode
-	}
+	const node = isStart ? range.startContainer : range.endContainer
+	const offset = isStart ? range.startOffset : range.endOffset
 
-	const fullRange = document.createRange()
-	fullRange.setStart(firstText, 0)
-	fullRange.setEnd(lastText, lastText.textContent?.length ?? 0)
-
-	if (isStart) {
-		return range.compareBoundaryPoints(Range.START_TO_START, fullRange) <= 0
-	}
-	return range.compareBoundaryPoints(Range.END_TO_END, fullRange) >= 0
+	if (node === firstText) return offset
+	return isStart ? 0 : child.textContent.length
 }
 
 export interface SelectionTokenRange {
 	tokens: Token[]
-	firstFullySelected: boolean
-	lastFullySelected: boolean
+	/** Char offset within the first token where the selection starts. */
+	startOffset: number
+	/** Char offset within the last token where the selection ends. */
+	endOffset: number
 }
 
 /**
  * Map a browser Selection to the subset of tokens it covers.
- * Reports whether boundary tokens are fully covered by the selection.
  * Returns null if selection is collapsed, empty, or outside the container.
  */
 export function selectionToTokens(store: Store): SelectionTokenRange | null {
@@ -86,11 +73,12 @@ export function selectionToTokens(store: Store): SelectionTokenRange | null {
 		;[startIndex, endIndex] = [endIndex, startIndex]
 	}
 
-	const selectedTokens = tokens.slice(startIndex, endIndex + 1)
+	const startChild = container.children.item(startIndex)
+	const endChild = container.children.item(endIndex)
 
 	return {
-		tokens: selectedTokens,
-		firstFullySelected: isBoundaryFullyCovered(range, container, startIndex, true),
-		lastFullySelected: isBoundaryFullyCovered(range, container, endIndex, false),
+		tokens: tokens.slice(startIndex, endIndex + 1),
+		startOffset: startChild ? getBoundaryOffset(range, startChild, true) : 0,
+		endOffset: endChild ? getBoundaryOffset(range, endChild, false) : 0,
 	}
 }

--- a/packages/core/src/features/clipboard/selectionToTokens.ts
+++ b/packages/core/src/features/clipboard/selectionToTokens.ts
@@ -19,13 +19,23 @@ function findContainerChildIndex(node: Node, container: HTMLElement): number {
 	return Array.from(container.children).indexOf(current)
 }
 
+/** Structural type shared by Range and StaticRange — only boundary properties are read. */
+export interface RangeBoundary {
+	readonly startContainer: Node
+	readonly startOffset: number
+	readonly endContainer: Node
+	readonly endOffset: number
+}
+
 /**
  * Returns the character offset of a range boundary within a container child.
  * Walks all text nodes in document order to compute a cumulative character
  * offset, which correctly handles nested marks with multiple text nodes.
  * Falls back to 0 (start) or full text length (end) for out-of-child boundaries.
+ *
+ * Spec: selectionToTokens.spec.ts (unit) · Clipboard.react.spec.tsx (integration)
  */
-function getBoundaryOffset(range: Range, child: Element, isStart: boolean): number {
+export function getBoundaryOffset(range: RangeBoundary, child: Element, isStart: boolean): number {
 	const targetNode = isStart ? range.startContainer : range.endContainer
 	const targetOffset = isStart ? range.startOffset : range.endOffset
 

--- a/packages/core/src/features/feature-manager/coreFeatures.ts
+++ b/packages/core/src/features/feature-manager/coreFeatures.ts
@@ -10,6 +10,7 @@ export const createCoreFeatures = (store: Store): FeatureManager => {
 		.register(asFeature('focus', store.controllers.focus))
 		.register(asFeature('textSelection', store.controllers.textSelection))
 		.register(asFeature('contentEditable', store.controllers.contentEditable))
+		.register(asFeature('copy', store.controllers.copy))
 
 	return manager
 }

--- a/packages/core/src/features/input/KeyDownController.ts
+++ b/packages/core/src/features/input/KeyDownController.ts
@@ -467,11 +467,25 @@ function handleMarkputSpanPaste(store: Store, focus: NodeProxy, event: InputEven
 	const start = ranges[0]?.startOffset ?? offset
 	const rawInsertPos = token.position.start + start
 
+	const caretPos = rawInsertPos + markup.length
 	const newValue = currentValue.slice(0, rawInsertPos) + markup + currentValue.slice(rawInsertPos)
 	store.applyValue(newValue)
+
+	// Find which text token contains caretPos in the re-parsed token array.
+	// Use isNext+childIndex so FocusController navigates to childAt(childIndex+2)
+	// even after the anchor span is replaced by re-render.
+	const newTokens = store.state.tokens.get()
+	let targetIdx = newTokens.findIndex(
+		t => t.type === 'text' && caretPos >= t.position.start && caretPos <= t.position.end
+	)
+	if (targetIdx === -1) targetIdx = newTokens.length - 1
+	const caretWithinToken = caretPos - newTokens[targetIdx].position.start
+
 	store.state.recovery.set({
 		anchor: store.nodes.focus,
-		caret: rawInsertPos + markup.length,
+		caret: caretWithinToken,
+		isNext: true,
+		childIndex: targetIdx - 2,
 	})
 	return true
 }

--- a/packages/core/src/features/input/KeyDownController.ts
+++ b/packages/core/src/features/input/KeyDownController.ts
@@ -468,10 +468,12 @@ function handleMarkputSpanPaste(store: Store, focus: NodeProxy, event: InputEven
 
 	const ranges = event.getTargetRanges()
 	const start = ranges[0]?.startOffset ?? offset
+	const end = ranges[0]?.endOffset ?? offset
 	const rawInsertPos = token.position.start + start
+	const rawEndPos = token.position.start + end
 
 	const caretPos = rawInsertPos + markup.length
-	const newValue = currentValue.slice(0, rawInsertPos) + markup + currentValue.slice(rawInsertPos)
+	const newValue = currentValue.slice(0, rawInsertPos) + markup + currentValue.slice(rawEndPos)
 	store.applyValue(newValue)
 
 	// Find which text token contains caretPos in the re-parsed token array.

--- a/packages/core/src/features/input/KeyDownController.ts
+++ b/packages/core/src/features/input/KeyDownController.ts
@@ -50,7 +50,8 @@ export class KeyDownController {
 		}
 
 		this.#pasteHandler = e => {
-			captureMarkupPaste(e)
+			const c = this.store.refs.container
+			if (c) captureMarkupPaste(e, c)
 			handlePaste(this.store, e)
 		}
 
@@ -453,7 +454,9 @@ export function handleBeforeInput(store: Store, event: InputEvent): void {
  * inserting markup text into a single span (which would cause recursive DOM updates).
  */
 function handleMarkputSpanPaste(store: Store, focus: NodeProxy, event: InputEvent): boolean {
-	const markup = consumeMarkupPaste()
+	const container = store.refs.container
+	if (!container) return false
+	const markup = consumeMarkupPaste(container)
 	if (!markup) return false
 
 	event.preventDefault()
@@ -521,8 +524,7 @@ export function applySpanInput(focus: NodeProxy, event: InputEvent): boolean {
 		}
 		case 'insertFromPaste':
 		case 'insertReplacementText': {
-			const markup = consumeMarkupPaste()
-			const text = markup ?? event.dataTransfer?.getData('text/plain') ?? ''
+			const text = event.dataTransfer?.getData('text/plain') ?? ''
 			const ranges = event.getTargetRanges()
 			const start = ranges[0]?.startOffset ?? offset
 			const end = ranges[0]?.endOffset ?? offset
@@ -548,7 +550,7 @@ export function handlePaste(store: Store, event: ClipboardEvent): void {
 	}
 
 	event.preventDefault()
-	const markup = consumeMarkupPaste()
+	const markup = store.refs.container ? consumeMarkupPaste(store.refs.container) : undefined
 	const newContent = markup ?? event.clipboardData?.getData('text/plain') ?? ''
 	replaceAllContentWith(store, newContent)
 }
@@ -641,7 +643,7 @@ function handleBlockBeforeInput(store: Store, event: InputEvent): void {
 		case 'insertFromPaste':
 		case 'insertReplacementText': {
 			event.preventDefault()
-			const markup = consumeMarkupPaste()
+			const markup = store.refs.container ? consumeMarkupPaste(store.refs.container) : undefined
 			const pasteData = markup ?? event.dataTransfer?.getData('text/plain') ?? ''
 			const ranges = event.getTargetRanges()
 			let rawFrom: number

--- a/packages/core/src/features/input/KeyDownController.ts
+++ b/packages/core/src/features/input/KeyDownController.ts
@@ -2,6 +2,7 @@ import {childAt, htmlChildren, isHtmlElement, isTextNode, nextText} from '../../
 import type {NodeProxy} from '../../shared/classes'
 import {KEYBOARD} from '../../shared/constants'
 import {Caret} from '../caret'
+import {captureMarkupPaste, consumeMarkupPaste} from '../clipboard'
 import {addDragRow, getMergeDragRowJoinPos, mergeDragRows, canMergeRows} from '../drag/operations'
 import {deleteMark} from '../editing'
 import {shiftFocusNext, shiftFocusPrev} from '../navigation'
@@ -49,6 +50,7 @@ export class KeyDownController {
 		}
 
 		this.#pasteHandler = e => {
+			captureMarkupPaste(e)
 			handlePaste(this.store, e)
 		}
 
@@ -432,9 +434,46 @@ export function handleBeforeInput(store: Store, event: InputEvent): void {
 	const {focus} = store.nodes
 	if (!focus.target || !focus.isEditable) return
 
+	// Intercept markput paste before span-level handling to update raw value directly
+	if (
+		(event.inputType === 'insertFromPaste' || event.inputType === 'insertReplacementText') &&
+		handleMarkputSpanPaste(store, focus, event)
+	) {
+		return
+	}
+
 	if (applySpanInput(focus, event)) {
 		store.events.change()
 	}
+}
+
+/**
+ * Handles paste with markput data in non-drag mode.
+ * Updates the raw value directly (which triggers re-parsing) instead of
+ * inserting markup text into a single span (which would cause recursive DOM updates).
+ */
+function handleMarkputSpanPaste(store: Store, focus: NodeProxy, event: InputEvent): boolean {
+	const markup = consumeMarkupPaste()
+	if (!markup) return false
+
+	event.preventDefault()
+
+	const tokens = store.state.tokens.get()
+	const token = tokens[focus.index]
+	const offset = focus.caret
+	const currentValue = store.state.previousValue.get() ?? store.state.value.get() ?? ''
+
+	const ranges = event.getTargetRanges()
+	const start = ranges[0]?.startOffset ?? offset
+	const rawInsertPos = token.position.start + start
+
+	const newValue = currentValue.slice(0, rawInsertPos) + markup + currentValue.slice(rawInsertPos)
+	store.applyValue(newValue)
+	store.state.recovery.set({
+		anchor: store.nodes.focus,
+		caret: rawInsertPos + markup.length,
+	})
+	return true
 }
 
 export function applySpanInput(focus: NodeProxy, event: InputEvent): boolean {
@@ -468,7 +507,8 @@ export function applySpanInput(focus: NodeProxy, event: InputEvent): boolean {
 		}
 		case 'insertFromPaste':
 		case 'insertReplacementText': {
-			const text = event.dataTransfer?.getData('text/plain') ?? ''
+			const markup = consumeMarkupPaste()
+			const text = markup ?? event.dataTransfer?.getData('text/plain') ?? ''
 			const ranges = event.getTargetRanges()
 			const start = ranges[0]?.startOffset ?? offset
 			const end = ranges[0]?.endOffset ?? offset
@@ -494,7 +534,8 @@ export function handlePaste(store: Store, event: ClipboardEvent): void {
 	}
 
 	event.preventDefault()
-	const newContent = event.clipboardData?.getData('text/plain') ?? ''
+	const markup = consumeMarkupPaste()
+	const newContent = markup ?? event.clipboardData?.getData('text/plain') ?? ''
 	replaceAllContentWith(store, newContent)
 }
 
@@ -586,7 +627,8 @@ function handleBlockBeforeInput(store: Store, event: InputEvent): void {
 		case 'insertFromPaste':
 		case 'insertReplacementText': {
 			event.preventDefault()
-			const pasteData = event.dataTransfer?.getData('text/plain') ?? ''
+			const markup = consumeMarkupPaste()
+			const pasteData = markup ?? event.dataTransfer?.getData('text/plain') ?? ''
 			const ranges = event.getTargetRanges()
 			let rawFrom: number
 			let rawTo: number

--- a/packages/core/src/features/input/KeyDownController.ts
+++ b/packages/core/src/features/input/KeyDownController.ts
@@ -2,7 +2,7 @@ import {childAt, htmlChildren, isHtmlElement, isTextNode, nextText} from '../../
 import type {NodeProxy} from '../../shared/classes'
 import {KEYBOARD} from '../../shared/constants'
 import {Caret} from '../caret'
-import {captureMarkupPaste, consumeMarkupPaste} from '../clipboard'
+import {captureMarkupPaste, consumeMarkupPaste, getBoundaryOffset} from '../clipboard'
 import {addDragRow, getMergeDragRowJoinPos, mergeDragRows, canMergeRows} from '../drag/operations'
 import {deleteMark} from '../editing'
 import {shiftFocusNext, shiftFocusPrev} from '../navigation'
@@ -467,10 +467,18 @@ function handleMarkputSpanPaste(store: Store, focus: NodeProxy, event: InputEven
 	const currentValue = store.state.previousValue.get() ?? store.state.value.get() ?? ''
 
 	const ranges = event.getTargetRanges()
-	const start = ranges[0]?.startOffset ?? offset
-	const end = ranges[0]?.endOffset ?? offset
-	const rawInsertPos = token.position.start + start
-	const rawEndPos = token.position.start + end
+	const childElement = container.children[focus.index]
+	let rawInsertPos: number
+	let rawEndPos: number
+	if (ranges.length > 0) {
+		const cumStart = getBoundaryOffset(ranges[0], childElement, true)
+		const cumEnd = getBoundaryOffset(ranges[0], childElement, false)
+		rawInsertPos = token.position.start + cumStart
+		rawEndPos = token.position.start + cumEnd
+	} else {
+		rawInsertPos = token.position.start + offset
+		rawEndPos = token.position.start + offset
+	}
 
 	const caretPos = rawInsertPos + markup.length
 	const newValue = currentValue.slice(0, rawInsertPos) + markup + currentValue.slice(rawEndPos)

--- a/packages/core/src/features/lifecycle/Lifecycle.ts
+++ b/packages/core/src/features/lifecycle/Lifecycle.ts
@@ -63,6 +63,7 @@ export class Lifecycle {
 
 		const inputValue = value ?? store.state.defaultValue.get() ?? ''
 		store.state.tokens.set(parseWithParser(store, inputValue))
+		store.state.previousValue.set(inputValue)
 
 		this.#initialized = true
 	}

--- a/packages/core/src/features/store/Store.ts
+++ b/packages/core/src/features/store/Store.ts
@@ -10,6 +10,7 @@ import {
 import type {CoreOption, MarkputHandler, MarkputState, OverlayMatch} from '../../shared/types'
 import {resolveMarkSlot, resolveOverlaySlot, resolveSlot, resolveSlotProps} from '../../shared/utils/resolveSlot'
 import {shallow} from '../../shared/utils/shallow'
+import {CopyController} from '../clipboard'
 import {DragController} from '../drag'
 import {ContentEditableController} from '../editable'
 import {SystemListenerController} from '../events'
@@ -82,6 +83,7 @@ export class Store {
 		textSelection: new TextSelectionController(this),
 		contentEditable: new ContentEditableController(this),
 		drag: new DragController(this),
+		copy: new CopyController(this),
 	}
 
 	readonly lifecycle = new Lifecycle(this)
@@ -185,11 +187,10 @@ export class Store {
 
 	applyValue(newValue: string): void {
 		const onChange = this.state.onChange.get()
-		if (!onChange) return
 		const newTokens = parseWithParser(this, newValue)
 		this.state.tokens.set(newTokens)
 		this.state.previousValue.set(newValue)
-		onChange(newValue)
+		onChange?.(newValue)
 	}
 
 	createHandler(): MarkputHandler {

--- a/packages/storybook/src/pages/Clipboard/Clipboard.react.spec.tsx
+++ b/packages/storybook/src/pages/Clipboard/Clipboard.react.spec.tsx
@@ -1,0 +1,369 @@
+import {composeStories} from '@storybook/react-vite'
+import {describe, expect, it} from 'vitest'
+import {render} from 'vitest-browser-react'
+
+import * as Stories from './Clipboard.react.stories'
+
+const {Inline, PlainText} = composeStories(Stories)
+
+/**
+ * Create a ClipboardEvent with a mock DataTransfer for testing copy/paste handlers.
+ */
+function createCopyEvent(target: HTMLElement): {event: ClipboardEvent; clipboardData: DataTransfer} {
+	const clipboardData = new DataTransfer()
+	const event = new ClipboardEvent('copy', {clipboardData, bubbles: true})
+	Object.defineProperty(event, 'target', {value: target, writable: false})
+	return {event, clipboardData}
+}
+
+/**
+ * Simulate setting a text selection within a text node.
+ * Returns the range for verification.
+ */
+function setSelection(startNode: Node, startOffset: number, endNode: Node, endOffset: number): Range {
+	const sel = window.getSelection()!
+	const range = document.createRange()
+	range.setStart(startNode, startOffset)
+	range.setEnd(endNode, endOffset)
+	sel.removeAllRanges()
+	sel.addRange(range)
+	return range
+}
+
+/**
+ * Find the first text node inside an element.
+ */
+function firstTextNode(el: Element): Text | null {
+	const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT)
+	// oxlint-disable-next-line no-unsafe-type-assertion -- nodeType === 3 guarantees Text
+	return (walker.nextNode() as Text | null) ?? null
+}
+
+/**
+ * Collect all text nodes in document order within an element.
+ */
+function allTextNodes(el: Element): Text[] {
+	const result: Text[] = []
+	const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT)
+	while (walker.nextNode()) {
+		// oxlint-disable-next-line no-unsafe-type-assertion -- SHOW_TEXT guarantees Text
+		result.push(walker.currentNode as Text)
+	}
+	return result
+}
+
+describe('Clipboard: copy', () => {
+	it('partial text selection should NOT set markput MIME', async () => {
+		const {container} = await render(<Inline />)
+		// oxlint-disable-next-line no-unsafe-type-assertion -- firstElementChild is always HTMLElement
+		const root = container.firstElementChild as HTMLElement
+		const spans = Array.from(root.querySelectorAll<HTMLElement>('span'))
+
+		// Select "ll" from "hello " (the first text span)
+		const textNode = firstTextNode(spans[0])!
+		setSelection(textNode, 2, textNode, 4)
+
+		const {event, clipboardData} = createCopyEvent(root)
+		root.dispatchEvent(event)
+
+		const markput = clipboardData.getData('application/x-markput')
+		expect(markput).toBe('')
+
+		const plainText = clipboardData.getData('text/plain')
+		expect(plainText).toBe('ll')
+	})
+
+	it('full text token selection should set markput MIME', async () => {
+		const {container} = await render(<Inline />)
+		// oxlint-disable-next-line no-unsafe-type-assertion -- firstElementChild is always HTMLElement
+		const root = container.firstElementChild as HTMLElement
+		const spans = Array.from(root.querySelectorAll<HTMLElement>('span'))
+
+		// Select the entire first text span "hello "
+		const textNode = firstTextNode(spans[0])!
+		setSelection(textNode, 0, textNode, textNode.length)
+
+		const {event, clipboardData} = createCopyEvent(root)
+		root.dispatchEvent(event)
+
+		const markput = clipboardData.getData('application/x-markput')
+		expect(markput).toBe('hello ')
+
+		const plainText = clipboardData.getData('text/plain')
+		expect(plainText).toBe('hello ')
+	})
+
+	it('partial mark selection should NOT set markput MIME', async () => {
+		const {container} = await render(<Inline />)
+		// oxlint-disable-next-line no-unsafe-type-assertion -- firstElementChild is always HTMLElement
+		const root = container.firstElementChild as HTMLElement
+		const mark = root.querySelector<HTMLElement>('[data-testid="mark"]')!
+
+		// Select "orl" from the mark text "world"
+		const textNode = firstTextNode(mark)!
+		setSelection(textNode, 1, textNode, 4)
+
+		const {event, clipboardData} = createCopyEvent(root)
+		root.dispatchEvent(event)
+
+		const markput = clipboardData.getData('application/x-markput')
+		expect(markput).toBe('')
+
+		const plainText = clipboardData.getData('text/plain')
+		expect(plainText).toBe('orl')
+	})
+
+	it('full mark selection should set markput MIME with complete markup', async () => {
+		const {container} = await render(<Inline />)
+		// oxlint-disable-next-line no-unsafe-type-assertion -- firstElementChild is always HTMLElement
+		const root = container.firstElementChild as HTMLElement
+		const mark = root.querySelector<HTMLElement>('[data-testid="mark"]')!
+
+		// Select the entire mark
+		const textNode = firstTextNode(mark)!
+		setSelection(textNode, 0, textNode, textNode.length)
+
+		const {event, clipboardData} = createCopyEvent(root)
+		root.dispatchEvent(event)
+
+		const markput = clipboardData.getData('application/x-markput')
+		expect(markput).toBe('@[world](1)')
+
+		const plainText = clipboardData.getData('text/plain')
+		expect(plainText).toBe('world')
+	})
+
+	it('cross-token partial selection should NOT set markput MIME', async () => {
+		const {container} = await render(<Inline />)
+		// oxlint-disable-next-line no-unsafe-type-assertion -- firstElementChild is always HTMLElement
+		const root = container.firstElementChild as HTMLElement
+		const spans = Array.from(root.querySelectorAll<HTMLElement>('span'))
+
+		// Select from middle of first span to middle of last span
+		// "llo @[world](1) fo"
+		const textNode1 = firstTextNode(spans[0])!
+		const textNode2 = firstTextNode(spans[1])!
+		setSelection(textNode1, 3, textNode2, 3)
+
+		const {event, clipboardData} = createCopyEvent(root)
+		root.dispatchEvent(event)
+
+		const markput = clipboardData.getData('application/x-markput')
+		expect(markput).toBe('')
+
+		const plainText = clipboardData.getData('text/plain')
+		expect(plainText).toBe('lo world fo')
+	})
+
+	it('full multi-token selection should set markput MIME', async () => {
+		const {container} = await render(<Inline />)
+		// oxlint-disable-next-line no-unsafe-type-assertion -- firstElementChild is always HTMLElement
+		const root = container.firstElementChild as HTMLElement
+		const spans = Array.from(root.querySelectorAll<HTMLElement>('span'))
+
+		// Select from start of first span to end of last span
+		const textNode1 = firstTextNode(spans[0])!
+		const textNode2 = firstTextNode(spans[1])!
+		setSelection(textNode1, 0, textNode2, textNode2.length)
+
+		const {event, clipboardData} = createCopyEvent(root)
+		root.dispatchEvent(event)
+
+		const markput = clipboardData.getData('application/x-markput')
+		expect(markput).toBe('hello @[world](1) foo')
+	})
+
+	it('selecting text + mark via drag should set markput MIME', async () => {
+		const {container} = await render(<Inline />)
+		// oxlint-disable-next-line no-unsafe-type-assertion -- firstElementChild is always HTMLElement
+		const root = container.firstElementChild as HTMLElement
+
+		// Simulate a browser drag selection that spans from "hello " through the mark "world"
+		// In the real browser, the range starts at the first span's text node and ends at the
+		// mark's text node (or the element boundary).
+		// DOM: container > span[0]("hello "), mark[1]("world"), span[2](" foo")
+		const textNodes = allTextNodes(root)
+		// textNodes: ["hello ", "world", " foo"]
+		expect(textNodes.length).toBe(3)
+
+		// Select from "hello " start to "world" end (span + mark)
+		setSelection(textNodes[0], 0, textNodes[1], textNodes[1].length)
+
+		const {event, clipboardData} = createCopyEvent(root)
+		root.dispatchEvent(event)
+
+		const markput = clipboardData.getData('application/x-markput')
+		expect(markput).toBe('hello @[world](1)')
+
+		const plainText = clipboardData.getData('text/plain')
+		expect(plainText).toBe('hello world')
+	})
+
+	it('copy-paste round-trip: select all, copy, paste into plain text should reconstruct marks', async () => {
+		// Step 1: Render source editor with a mark
+		const {container: sourceContainer} = await render(<Inline />)
+		// oxlint-disable-next-line no-unsafe-type-assertion -- firstElementChild is always HTMLElement
+		const sourceRoot = sourceContainer.firstElementChild as HTMLElement
+
+		// Select all: from start of first span to end of last span
+		const spans = Array.from(sourceRoot.querySelectorAll<HTMLElement>('span'))
+		const textNode1 = firstTextNode(spans[0])!
+		const textNode2 = firstTextNode(spans[1])!
+		setSelection(textNode1, 0, textNode2, textNode2.length)
+
+		// Copy from source
+		const copyClipboardData = new DataTransfer()
+		const copyEvent = new ClipboardEvent('copy', {clipboardData: copyClipboardData, bubbles: true})
+		Object.defineProperty(copyEvent, 'target', {value: sourceRoot, writable: false})
+		sourceRoot.dispatchEvent(copyEvent)
+
+		// Verify markput was captured
+		const markput = copyClipboardData.getData('application/x-markput')
+		expect(markput).toBe('hello @[world](1) foo')
+
+		// Step 2: Render target editor (plain text, no marks)
+		const {container: targetContainer} = await render(<PlainText />)
+		// oxlint-disable-next-line no-unsafe-type-assertion -- firstElementChild is always HTMLElement
+		const targetRoot = targetContainer.firstElementChild as HTMLElement
+		expect(targetRoot.querySelector('[data-testid="mark"]')).toBeNull()
+
+		const targetSpan = targetRoot.querySelector<HTMLElement>('span')!
+		targetSpan.focus()
+		await new Promise(r => queueMicrotask(r))
+		expect(document.activeElement).toBe(targetSpan)
+
+		const targetTextNode = firstTextNode(targetSpan)!
+		const sel = window.getSelection()!
+		sel.collapse(targetTextNode, 0)
+
+		// Paste into target
+		const pasteClipboard = new DataTransfer()
+		pasteClipboard.setData('text/plain', copyClipboardData.getData('text/plain'))
+		pasteClipboard.setData('application/x-markput', markput)
+		const pasteEvent = new ClipboardEvent('paste', {clipboardData: pasteClipboard, bubbles: true})
+		targetRoot.dispatchEvent(pasteEvent)
+
+		const inputRanges = [document.createRange()]
+		inputRanges[0].setStart(targetTextNode, 0)
+		inputRanges[0].setEnd(targetTextNode, 0)
+		const inputEvent = new InputEvent('beforeinput', {
+			inputType: 'insertFromPaste',
+			bubbles: true,
+			cancelable: true,
+		})
+		Object.defineProperty(inputEvent, 'getTargetRanges', {value: () => inputRanges})
+		Object.defineProperty(inputEvent, 'dataTransfer', {value: pasteClipboard})
+		targetRoot.dispatchEvent(inputEvent)
+
+		// Wait for React re-render
+		await new Promise(r => setTimeout(r, 50))
+
+		// Verify mark was reconstructed in target
+		const markAfter = targetRoot.querySelector<HTMLElement>('[data-testid="mark"]')
+		expect(markAfter).not.toBeNull()
+		expect(markAfter?.textContent).toBe('world')
+	})
+})
+
+describe('Clipboard: paste', () => {
+	it('pasting markput data should reconstruct the mark in plain text', async () => {
+		// Start with plain text — no marks at all
+		const {container} = await render(<PlainText />)
+		// oxlint-disable-next-line no-unsafe-type-assertion -- firstElementChild is always HTMLElement
+		const root = container.firstElementChild as HTMLElement
+
+		// Confirm no mark exists initially
+		expect(root.querySelector('[data-testid="mark"]')).toBeNull()
+
+		// Find the text span and click it to activate focus
+		const span = root.querySelector<HTMLElement>('span')!
+		span.focus()
+		await new Promise(r => queueMicrotask(r))
+
+		// Confirm focus is set
+		expect(document.activeElement).toBe(span)
+
+		// Place caret at start of the span's text node
+		const textNode = firstTextNode(span)!
+		const sel = window.getSelection()!
+		sel.collapse(textNode, 0)
+
+		// Simulate paste event with markput data
+		const pasteClipboard = new DataTransfer()
+		pasteClipboard.setData('text/plain', 'hello world foo')
+		pasteClipboard.setData('application/x-markput', 'hello @[world](1) foo')
+		const pasteEvent = new ClipboardEvent('paste', {clipboardData: pasteClipboard, bubbles: true})
+		root.dispatchEvent(pasteEvent)
+
+		// Simulate beforeinput (insertFromPaste)
+		const inputRanges = [document.createRange()]
+		inputRanges[0].setStart(textNode, 0)
+		inputRanges[0].setEnd(textNode, 0)
+		const inputEvent = new InputEvent('beforeinput', {
+			inputType: 'insertFromPaste',
+			bubbles: true,
+			cancelable: true,
+		})
+		Object.defineProperty(inputEvent, 'getTargetRanges', {value: () => inputRanges})
+		Object.defineProperty(inputEvent, 'dataTransfer', {value: pasteClipboard})
+		root.dispatchEvent(inputEvent)
+
+		// Wait for React to re-render with the new value
+		await new Promise(r => setTimeout(r, 50))
+
+		// Verify the mark was reconstructed
+		const markAfter = root.querySelector<HTMLElement>('[data-testid="mark"]')
+		expect(markAfter).not.toBeNull()
+		expect(markAfter?.textContent).toBe('world')
+	})
+
+	it('pasting markput data into uncontrolled editor should reconstruct the mark', async () => {
+		// Use Inline story (defaultValue, no onChange — uncontrolled mode)
+		const {container} = await render(<Inline />)
+		// oxlint-disable-next-line no-unsafe-type-assertion -- firstElementChild is always HTMLElement
+		const root = container.firstElementChild as HTMLElement
+
+		// The Inline story already has a mark, confirm it
+		const marksBefore = root.querySelectorAll<HTMLElement>('[data-testid="mark"]')
+		expect(marksBefore.length).toBe(1)
+
+		// Focus the last span " foo" and place caret at end
+		const spans = Array.from(root.querySelectorAll<HTMLElement>('span'))
+		const lastSpan = spans[spans.length - 1]
+		lastSpan.focus()
+		await new Promise(r => queueMicrotask(r))
+		expect(document.activeElement).toBe(lastSpan)
+
+		const textNode = firstTextNode(lastSpan)!
+		const sel = window.getSelection()!
+		sel.collapse(textNode, textNode.length)
+
+		// Paste additional markput data at the end
+		const pasteClipboard = new DataTransfer()
+		pasteClipboard.setData('text/plain', ' test')
+		pasteClipboard.setData('application/x-markput', '@[test](2)')
+		const pasteEvent = new ClipboardEvent('paste', {clipboardData: pasteClipboard, bubbles: true})
+		root.dispatchEvent(pasteEvent)
+
+		const inputRanges = [document.createRange()]
+		inputRanges[0].setStart(textNode, textNode.length)
+		inputRanges[0].setEnd(textNode, textNode.length)
+		const inputEvent = new InputEvent('beforeinput', {
+			inputType: 'insertFromPaste',
+			bubbles: true,
+			cancelable: true,
+		})
+		Object.defineProperty(inputEvent, 'getTargetRanges', {value: () => inputRanges})
+		Object.defineProperty(inputEvent, 'dataTransfer', {value: pasteClipboard})
+		root.dispatchEvent(inputEvent)
+
+		// Wait for React to re-render
+		await new Promise(r => setTimeout(r, 50))
+
+		// Should now have two marks: the original "world" + the pasted "test"
+		const marksAfter = root.querySelectorAll<HTMLElement>('[data-testid="mark"]')
+		expect(marksAfter.length).toBe(2)
+		expect(marksAfter[0]?.textContent).toBe('world')
+		expect(marksAfter[1]?.textContent).toBe('test')
+	})
+})

--- a/packages/storybook/src/pages/Clipboard/Clipboard.react.spec.tsx
+++ b/packages/storybook/src/pages/Clipboard/Clipboard.react.spec.tsx
@@ -1,5 +1,5 @@
 import {composeStories} from '@storybook/react-vite'
-import {describe, expect, it} from 'vitest'
+import {beforeEach, describe, expect, it} from 'vitest'
 import {render} from 'vitest-browser-react'
 
 import * as Stories from './Clipboard.react.stories'
@@ -310,6 +310,13 @@ describe('Clipboard: copy', () => {
 })
 
 describe('Clipboard: paste', () => {
+	beforeEach(() => {
+		// Ensure no stale markup state leaks between tests.
+		// With per-container WeakMap scoping (Task 1), this mainly guards against
+		// tests that exit early before consuming captured markup.
+		window.getSelection()?.removeAllRanges()
+	})
+
 	it('pasting markput data should reconstruct the mark in plain text', async () => {
 		// Start with plain text — no marks at all
 		const {container} = await render(<PlainText />)
@@ -515,9 +522,7 @@ describe('Clipboard: paste', () => {
 		firstBlock.focus()
 		await new Promise<void>(r => queueMicrotask(r))
 
-		const walker = document.createTreeWalker(firstBlock, NodeFilter.SHOW_TEXT)
-		// oxlint-disable-next-line no-unsafe-type-assertion -- SHOW_TEXT guarantees Text
-		const firstBlockText = walker.nextNode() as Text | null
+		const firstBlockText = firstTextNode(firstBlock)
 		if (!firstBlockText) throw new Error('no text node in first block')
 
 		window.getSelection()!.collapse(firstBlockText, firstBlockText.length)

--- a/packages/storybook/src/pages/Clipboard/Clipboard.react.spec.tsx
+++ b/packages/storybook/src/pages/Clipboard/Clipboard.react.spec.tsx
@@ -53,7 +53,7 @@ function allTextNodes(el: Element): Text[] {
 }
 
 describe('Clipboard: copy', () => {
-	it('partial text selection should NOT set markput MIME', async () => {
+	it('partial text selection should set markput MIME with trimmed text', async () => {
 		const {container} = await render(<Inline />)
 		// oxlint-disable-next-line no-unsafe-type-assertion -- firstElementChild is always HTMLElement
 		const root = container.firstElementChild as HTMLElement
@@ -67,7 +67,7 @@ describe('Clipboard: copy', () => {
 		root.dispatchEvent(event)
 
 		const markput = clipboardData.getData('application/x-markput')
-		expect(markput).toBe('')
+		expect(markput).toBe('ll')
 
 		const plainText = clipboardData.getData('text/plain')
 		expect(plainText).toBe('ll')
@@ -93,7 +93,7 @@ describe('Clipboard: copy', () => {
 		expect(plainText).toBe('hello ')
 	})
 
-	it('partial mark selection should NOT set markput MIME', async () => {
+	it('partial mark selection should set markput MIME with full mark expanded', async () => {
 		const {container} = await render(<Inline />)
 		// oxlint-disable-next-line no-unsafe-type-assertion -- firstElementChild is always HTMLElement
 		const root = container.firstElementChild as HTMLElement
@@ -106,8 +106,9 @@ describe('Clipboard: copy', () => {
 		const {event, clipboardData} = createCopyEvent(root)
 		root.dispatchEvent(event)
 
+		// Partial mark selection → full mark is always expanded in markup
 		const markput = clipboardData.getData('application/x-markput')
-		expect(markput).toBe('')
+		expect(markput).toBe('@[world](1)')
 
 		const plainText = clipboardData.getData('text/plain')
 		expect(plainText).toBe('orl')
@@ -133,14 +134,13 @@ describe('Clipboard: copy', () => {
 		expect(plainText).toBe('world')
 	})
 
-	it('cross-token partial selection should NOT set markput MIME', async () => {
+	it('cross-token partial selection should set markput MIME with trimmed text and full mark', async () => {
 		const {container} = await render(<Inline />)
 		// oxlint-disable-next-line no-unsafe-type-assertion -- firstElementChild is always HTMLElement
 		const root = container.firstElementChild as HTMLElement
 		const spans = Array.from(root.querySelectorAll<HTMLElement>('span'))
 
-		// Select from middle of first span to middle of last span
-		// "llo @[world](1) fo"
+		// Select "lo world fo" — partial first span + full mark + partial last span
 		const textNode1 = firstTextNode(spans[0])!
 		const textNode2 = firstTextNode(spans[1])!
 		setSelection(textNode1, 3, textNode2, 3)
@@ -148,11 +148,55 @@ describe('Clipboard: copy', () => {
 		const {event, clipboardData} = createCopyEvent(root)
 		root.dispatchEvent(event)
 
+		// Boundary text tokens trimmed, mark always expanded
 		const markput = clipboardData.getData('application/x-markput')
-		expect(markput).toBe('')
+		expect(markput).toBe('lo @[world](1) fo')
 
 		const plainText = clipboardData.getData('text/plain')
 		expect(plainText).toBe('lo world fo')
+	})
+
+	it('cross-token partial selection paste should reconstruct mark with surrounding text', async () => {
+		const {container} = await render(<Inline />)
+		// oxlint-disable-next-line no-unsafe-type-assertion -- firstElementChild is always HTMLElement
+		const root = container.firstElementChild as HTMLElement
+		const spans = Array.from(root.querySelectorAll<HTMLElement>('span'))
+
+		// Select "lo world f" — offset 3 in "hello " to offset 2 in " foo"
+		const textNode1 = firstTextNode(spans[0])!
+		const textNode2 = firstTextNode(spans[1])!
+		setSelection(textNode1, 3, textNode2, 2)
+
+		const {event, clipboardData} = createCopyEvent(root)
+		root.dispatchEvent(event)
+
+		expect(clipboardData.getData('application/x-markput')).toBe('lo @[world](1) f')
+
+		// Paste at end of last span
+		const lastSpan = spans[spans.length - 1]
+		const lastText = firstTextNode(lastSpan)!
+		lastSpan.focus()
+		await new Promise<void>(r => queueMicrotask(r))
+		window.getSelection()!.collapse(lastText, lastText.length)
+
+		root.dispatchEvent(new ClipboardEvent('paste', {clipboardData, bubbles: true}))
+		const inputRange = document.createRange()
+		inputRange.setStart(lastText, lastText.length)
+		inputRange.setEnd(lastText, lastText.length)
+		const inputEvent = new InputEvent('beforeinput', {
+			inputType: 'insertFromPaste',
+			bubbles: true,
+			cancelable: true,
+		})
+		Object.defineProperty(inputEvent, 'getTargetRanges', {value: () => [inputRange]})
+		Object.defineProperty(inputEvent, 'dataTransfer', {value: clipboardData})
+		root.dispatchEvent(inputEvent)
+
+		await new Promise(r => setTimeout(r, 100))
+
+		// Result: "hello [world] foo" + "lo [world] f" appended
+		expect(root.querySelectorAll('[data-testid="mark"]').length).toBe(2)
+		expect(root.textContent).toBe('hello world foolo world f')
 	})
 
 	it('full multi-token selection should set markput MIME', async () => {
@@ -229,7 +273,7 @@ describe('Clipboard: copy', () => {
 
 		const targetSpan = targetRoot.querySelector<HTMLElement>('span')!
 		targetSpan.focus()
-		await new Promise(r => queueMicrotask(r))
+		await new Promise<void>(r => queueMicrotask(r))
 		expect(document.activeElement).toBe(targetSpan)
 
 		const targetTextNode = firstTextNode(targetSpan)!
@@ -278,7 +322,7 @@ describe('Clipboard: paste', () => {
 		// Find the text span and click it to activate focus
 		const span = root.querySelector<HTMLElement>('span')!
 		span.focus()
-		await new Promise(r => queueMicrotask(r))
+		await new Promise<void>(r => queueMicrotask(r))
 
 		// Confirm focus is set
 		expect(document.activeElement).toBe(span)
@@ -331,7 +375,7 @@ describe('Clipboard: paste', () => {
 		const spans = Array.from(root.querySelectorAll<HTMLElement>('span'))
 		const lastSpan = spans[spans.length - 1]
 		lastSpan.focus()
-		await new Promise(r => queueMicrotask(r))
+		await new Promise<void>(r => queueMicrotask(r))
 		expect(document.activeElement).toBe(lastSpan)
 
 		const textNode = firstTextNode(lastSpan)!
@@ -385,7 +429,7 @@ describe('Clipboard: paste', () => {
 
 		// Place caret at " |foo" (offset 1 — after the space)
 		lastSpan.focus()
-		await new Promise(r => queueMicrotask(r))
+		await new Promise<void>(r => queueMicrotask(r))
 		window.getSelection()!.collapse(lastText, 1)
 
 		// Paste

--- a/packages/storybook/src/pages/Clipboard/Clipboard.react.spec.tsx
+++ b/packages/storybook/src/pages/Clipboard/Clipboard.react.spec.tsx
@@ -4,7 +4,7 @@ import {render} from 'vitest-browser-react'
 
 import * as Stories from './Clipboard.react.stories'
 
-const {Inline, PlainText, Drag} = composeStories(Stories)
+const {Inline, PlainText, Drag, NestedMarkStory} = composeStories(Stories)
 
 /**
  * Create a ClipboardEvent with a mock DataTransfer for testing copy/paste handlers.
@@ -553,5 +553,185 @@ describe('Clipboard: paste', () => {
 		const marks = root.querySelectorAll('[data-testid="mark"]')
 		expect(marks.length).toBe(2)
 		expect(marks[0]?.textContent).toBe('test')
+	})
+})
+
+describe('Clipboard: nested marks', () => {
+	beforeEach(() => {
+		window.getSelection()?.removeAllRanges()
+	})
+
+	it('partial selection within nested mark children should copy correct text', async () => {
+		const {container} = await render(<NestedMarkStory />)
+		// oxlint-disable-next-line no-unsafe-type-assertion -- firstElementChild is always HTMLElement
+		const root = container.firstElementChild as HTMLElement
+		const mark = root.querySelector<HTMLElement>('[data-testid="mark"]')!
+
+		// NestedMark renders: <mark><strong>wor</strong><em>ld</em></mark>
+		// Two text nodes: "wor" and "ld"
+		const textNodes = allTextNodes(mark)
+		expect(textNodes.length).toBe(2)
+		expect(textNodes[0].textContent).toBe('wor')
+		expect(textNodes[1].textContent).toBe('ld')
+
+		// Select "rl" — offset 2 in "wor" to offset 1 in "ld"
+		setSelection(textNodes[0], 2, textNodes[1], 1)
+
+		const {event, clipboardData} = createCopyEvent(root)
+		root.dispatchEvent(event)
+
+		// Full mark is expanded in markput MIME
+		expect(clipboardData.getData('application/x-markput')).toBe('@[world](1)')
+		// Plain text is the visual selection: "wor"[2:] + "ld"[:1] = "rl"
+		expect(clipboardData.getData('text/plain')).toBe('rl')
+	})
+
+	it('paste into nested mark should use cumulative offsets', async () => {
+		const {container} = await render(<NestedMarkStory />)
+		// oxlint-disable-next-line no-unsafe-type-assertion -- firstElementChild is always HTMLElement
+		const root = container.firstElementChild as HTMLElement
+		const mark = root.querySelector<HTMLElement>('[data-testid="mark"]')!
+
+		// Copy the full mark first
+		const markTextNodes = allTextNodes(mark)
+		setSelection(
+			markTextNodes[0],
+			0,
+			markTextNodes[markTextNodes.length - 1],
+			markTextNodes[markTextNodes.length - 1].length
+		)
+		const copyDt = new DataTransfer()
+		root.dispatchEvent(new ClipboardEvent('copy', {clipboardData: copyDt, bubbles: true}))
+		expect(copyDt.getData('application/x-markput')).toBe('@[world](1)')
+
+		// Focus the last span " foo" and paste at offset 1
+		const spans = Array.from(root.querySelectorAll<HTMLElement>('span'))
+		const lastSpan = spans[spans.length - 1]
+		const lastText = firstTextNode(lastSpan)!
+		lastSpan.focus()
+		await new Promise<void>(r => queueMicrotask(r))
+		window.getSelection()!.collapse(lastText, 1)
+
+		root.dispatchEvent(new ClipboardEvent('paste', {clipboardData: copyDt, bubbles: true}))
+		const inputRange = document.createRange()
+		inputRange.setStart(lastText, 1)
+		inputRange.setEnd(lastText, 1)
+		const inputEvent = new InputEvent('beforeinput', {
+			inputType: 'insertFromPaste',
+			bubbles: true,
+			cancelable: true,
+		})
+		Object.defineProperty(inputEvent, 'getTargetRanges', {value: () => [inputRange]})
+		Object.defineProperty(inputEvent, 'dataTransfer', {value: copyDt})
+		root.dispatchEvent(inputEvent)
+
+		await new Promise(r => setTimeout(r, 100))
+
+		// Result: "hello [world] [world]foo" — two marks, original + pasted
+		const marksAfter = root.querySelectorAll('[data-testid="mark"]')
+		expect(marksAfter.length).toBe(2)
+		expect(root.textContent).toBe('hello world worldfoo')
+	})
+})
+
+describe('Clipboard: cut', () => {
+	beforeEach(() => {
+		window.getSelection()?.removeAllRanges()
+	})
+
+	function createCutEvent(target: HTMLElement): {event: ClipboardEvent; clipboardData: DataTransfer} {
+		const clipboardData = new DataTransfer()
+		const event = new ClipboardEvent('cut', {clipboardData, bubbles: true})
+		Object.defineProperty(event, 'target', {value: target, writable: false})
+		return {event, clipboardData}
+	}
+
+	it('cut partial text should write to clipboard and remove selection', async () => {
+		const {container} = await render(<Inline />)
+		// oxlint-disable-next-line no-unsafe-type-assertion -- firstElementChild is always HTMLElement
+		const root = container.firstElementChild as HTMLElement
+		const spans = Array.from(root.querySelectorAll<HTMLElement>('span'))
+
+		// Select "ll" from "hello "
+		const textNode = firstTextNode(spans[0])!
+		setSelection(textNode, 2, textNode, 4)
+
+		const {event, clipboardData} = createCutEvent(root)
+		root.dispatchEvent(event)
+
+		expect(clipboardData.getData('application/x-markput')).toBe('ll')
+		expect(clipboardData.getData('text/plain')).toBe('ll')
+
+		await new Promise(r => setTimeout(r, 50))
+
+		// "hello " with "ll" removed → "he" + "o " + mark + " foo"
+		expect(root.textContent).toBe('heo world foo')
+		const mark = root.querySelector('[data-testid="mark"]')
+		expect(mark).not.toBeNull()
+	})
+
+	it('cut across tokens should write trimmed markup and remove selection', async () => {
+		const {container} = await render(<Inline />)
+		// oxlint-disable-next-line no-unsafe-type-assertion -- firstElementChild is always HTMLElement
+		const root = container.firstElementChild as HTMLElement
+		const spans = Array.from(root.querySelectorAll<HTMLElement>('span'))
+
+		// Select "lo world fo" — partial first span + full mark + partial last span
+		const textNode1 = firstTextNode(spans[0])!
+		const textNode2 = firstTextNode(spans[1])!
+		setSelection(textNode1, 3, textNode2, 3)
+
+		const {event, clipboardData} = createCutEvent(root)
+		root.dispatchEvent(event)
+
+		expect(clipboardData.getData('application/x-markput')).toBe('lo @[world](1) fo')
+
+		await new Promise(r => setTimeout(r, 50))
+
+		// "hello [world] foo" with "lo [world] fo" removed → "hel" + "o" = "helo"
+		expect(root.textContent).toBe('helo')
+	})
+
+	it('cut full mark should remove the mark', async () => {
+		const {container} = await render(<Inline />)
+		// oxlint-disable-next-line no-unsafe-type-assertion -- firstElementChild is always HTMLElement
+		const root = container.firstElementChild as HTMLElement
+		const mark = root.querySelector<HTMLElement>('[data-testid="mark"]')!
+
+		// Select the entire mark
+		const textNode = firstTextNode(mark)!
+		setSelection(textNode, 0, textNode, textNode.length)
+
+		const {event, clipboardData} = createCutEvent(root)
+		root.dispatchEvent(event)
+
+		expect(clipboardData.getData('application/x-markput')).toBe('@[world](1)')
+
+		await new Promise(r => setTimeout(r, 50))
+
+		// Mark removed, text spans merge: "hello " + " foo" = "hello  foo"
+		expect(root.textContent).toBe('hello  foo')
+		expect(root.querySelector('[data-testid="mark"]')).toBeNull()
+	})
+
+	it('cut all content should clear the editor', async () => {
+		const {container} = await render(<Inline />)
+		// oxlint-disable-next-line no-unsafe-type-assertion -- firstElementChild is always HTMLElement
+		const root = container.firstElementChild as HTMLElement
+		const spans = Array.from(root.querySelectorAll<HTMLElement>('span'))
+
+		// Select from start of first span to end of last span
+		const textNode1 = firstTextNode(spans[0])!
+		const textNode2 = firstTextNode(spans[1])!
+		setSelection(textNode1, 0, textNode2, textNode2.length)
+
+		const {event, clipboardData} = createCutEvent(root)
+		root.dispatchEvent(event)
+
+		expect(clipboardData.getData('application/x-markput')).toBe('hello @[world](1) foo')
+
+		await new Promise(r => setTimeout(r, 50))
+
+		expect(root.querySelector('[data-testid="mark"]')).toBeNull()
 	})
 })

--- a/packages/storybook/src/pages/Clipboard/Clipboard.react.spec.tsx
+++ b/packages/storybook/src/pages/Clipboard/Clipboard.react.spec.tsx
@@ -411,6 +411,45 @@ describe('Clipboard: paste', () => {
 		expect(marksAfter[1]?.textContent).toBe('test')
 	})
 
+	it('pasting markup over a selection within a span should replace the selection', async () => {
+		const {container} = await render(<PlainText />)
+		// oxlint-disable-next-line no-unsafe-type-assertion -- firstElementChild is always HTMLElement
+		const root = container.firstElementChild as HTMLElement
+
+		const span = root.querySelector<HTMLElement>('span')!
+		span.focus()
+		await new Promise<void>(r => queueMicrotask(r))
+
+		const textNode = firstTextNode(span)!
+		// PlainText story starts with value "abc". Select "b" (offset 1..2).
+		setSelection(textNode, 1, textNode, 2)
+
+		const pasteClipboard = new DataTransfer()
+		pasteClipboard.setData('text/plain', 'world')
+		pasteClipboard.setData('application/x-markput', '@[world](1)')
+		root.dispatchEvent(new ClipboardEvent('paste', {clipboardData: pasteClipboard, bubbles: true}))
+
+		const inputRange = document.createRange()
+		inputRange.setStart(textNode, 1)
+		inputRange.setEnd(textNode, 2) // selection of "b"
+		const inputEvent = new InputEvent('beforeinput', {
+			inputType: 'insertFromPaste',
+			bubbles: true,
+			cancelable: true,
+		})
+		Object.defineProperty(inputEvent, 'getTargetRanges', {value: () => [inputRange]})
+		Object.defineProperty(inputEvent, 'dataTransfer', {value: pasteClipboard})
+		root.dispatchEvent(inputEvent)
+
+		await new Promise(r => setTimeout(r, 50))
+
+		// "abc" with "b" replaced by "@[world](1)" → "a[world]c"
+		const mark = root.querySelector<HTMLElement>('[data-testid="mark"]')
+		expect(mark).not.toBeNull()
+		expect(mark?.textContent).toBe('world')
+		expect(root.textContent).toBe('aworldc')
+	})
+
 	it('caret should land immediately after pasted mark', async () => {
 		const {container} = await render(<Inline />)
 		// oxlint-disable-next-line no-unsafe-type-assertion -- firstElementChild is always HTMLElement

--- a/packages/storybook/src/pages/Clipboard/Clipboard.react.spec.tsx
+++ b/packages/storybook/src/pages/Clipboard/Clipboard.react.spec.tsx
@@ -366,4 +366,52 @@ describe('Clipboard: paste', () => {
 		expect(marksAfter[0]?.textContent).toBe('world')
 		expect(marksAfter[1]?.textContent).toBe('test')
 	})
+
+	it('caret should land immediately after pasted mark', async () => {
+		const {container} = await render(<Inline />)
+		// oxlint-disable-next-line no-unsafe-type-assertion -- firstElementChild is always HTMLElement
+		const root = container.firstElementChild as HTMLElement
+		const mark = root.querySelector<HTMLElement>('[data-testid="mark"]')!
+		const spans = Array.from(root.querySelectorAll<HTMLElement>('span'))
+		const lastSpan = spans[spans.length - 1]
+		const lastText = firstTextNode(lastSpan)! // " foo"
+
+		// Copy the full mark
+		const markText = firstTextNode(mark)!
+		setSelection(markText, 0, markText, markText.length)
+		const copyDt = new DataTransfer()
+		root.dispatchEvent(new ClipboardEvent('copy', {clipboardData: copyDt, bubbles: true}))
+		expect(copyDt.getData('application/x-markput')).toBe('@[world](1)')
+
+		// Place caret at " |foo" (offset 1 — after the space)
+		lastSpan.focus()
+		await new Promise(r => queueMicrotask(r))
+		window.getSelection()!.collapse(lastText, 1)
+
+		// Paste
+		root.dispatchEvent(new ClipboardEvent('paste', {clipboardData: copyDt, bubbles: true}))
+		const inputRange = document.createRange()
+		inputRange.setStart(lastText, 1)
+		inputRange.setEnd(lastText, 1)
+		const inputEvent = new InputEvent('beforeinput', {
+			inputType: 'insertFromPaste',
+			bubbles: true,
+			cancelable: true,
+		})
+		Object.defineProperty(inputEvent, 'getTargetRanges', {value: () => [inputRange]})
+		Object.defineProperty(inputEvent, 'dataTransfer', {value: copyDt})
+		root.dispatchEvent(inputEvent)
+
+		// Wait for React re-render
+		await new Promise(r => setTimeout(r, 100))
+
+		// DOM should be: hello [world] [world]foo
+		expect(root.querySelectorAll('[data-testid="mark"]').length).toBe(2)
+
+		// Caret must be in "foo" at offset 0 — right after the pasted mark
+		const sel = window.getSelection()!
+		expect(sel.isCollapsed).toBe(true)
+		expect(sel.anchorNode?.textContent).toBe('foo')
+		expect(sel.anchorOffset).toBe(0)
+	})
 })

--- a/packages/storybook/src/pages/Clipboard/Clipboard.react.spec.tsx
+++ b/packages/storybook/src/pages/Clipboard/Clipboard.react.spec.tsx
@@ -4,7 +4,7 @@ import {render} from 'vitest-browser-react'
 
 import * as Stories from './Clipboard.react.stories'
 
-const {Inline, PlainText} = composeStories(Stories)
+const {Inline, PlainText, Drag} = composeStories(Stories)
 
 /**
  * Create a ClipboardEvent with a mock DataTransfer for testing copy/paste handlers.
@@ -496,5 +496,57 @@ describe('Clipboard: paste', () => {
 		expect(sel.isCollapsed).toBe(true)
 		expect(sel.anchorNode?.textContent).toBe('foo')
 		expect(sel.anchorOffset).toBe(0)
+	})
+
+	it('pasting markput data in drag mode should reconstruct the mark in a block', async () => {
+		// Drag story: drag=true, defaultValue="hello\n@[world](1)\nfoo"
+		// Each line is a separate draggable block (div > contenteditable span).
+		const {container} = await render(<Drag />)
+		// oxlint-disable-next-line no-unsafe-type-assertion -- firstElementChild is always HTMLElement
+		const root = container.firstElementChild as HTMLElement
+
+		// Confirm the editor rendered with existing mark
+		expect(root.querySelectorAll('[data-testid="mark"]').length).toBe(1)
+
+		// Focus the first block ("hello") and place caret at end
+		const blocks = Array.from(root.querySelectorAll<HTMLElement>('[contenteditable="true"]'))
+		expect(blocks.length).toBeGreaterThan(0)
+		const firstBlock = blocks[0]
+		firstBlock.focus()
+		await new Promise<void>(r => queueMicrotask(r))
+
+		const walker = document.createTreeWalker(firstBlock, NodeFilter.SHOW_TEXT)
+		// oxlint-disable-next-line no-unsafe-type-assertion -- SHOW_TEXT guarantees Text
+		const firstBlockText = walker.nextNode() as Text | null
+		if (!firstBlockText) throw new Error('no text node in first block')
+
+		window.getSelection()!.collapse(firstBlockText, firstBlockText.length)
+
+		// Paste markup
+		const pasteClipboard = new DataTransfer()
+		pasteClipboard.setData('text/plain', ' test')
+		pasteClipboard.setData('application/x-markput', '@[test](99)')
+		root.dispatchEvent(new ClipboardEvent('paste', {clipboardData: pasteClipboard, bubbles: true}))
+
+		const inputRange = document.createRange()
+		inputRange.setStart(firstBlockText, firstBlockText.length)
+		inputRange.setEnd(firstBlockText, firstBlockText.length)
+		const inputEvent = new InputEvent('beforeinput', {
+			inputType: 'insertFromPaste',
+			bubbles: true,
+			cancelable: true,
+		})
+		Object.defineProperty(inputEvent, 'getTargetRanges', {value: () => [inputRange]})
+		Object.defineProperty(inputEvent, 'dataTransfer', {value: pasteClipboard})
+		root.dispatchEvent(inputEvent)
+
+		await new Promise(r => setTimeout(r, 100))
+
+		// Should now have two marks: pasted "test" (block 0) + original "world" (block 1)
+		// In drag mode, the pasted mark is inserted into the first block, which precedes
+		// the original "world" mark block in DOM order — so marks[0] is "test".
+		const marks = root.querySelectorAll('[data-testid="mark"]')
+		expect(marks.length).toBe(2)
+		expect(marks[0]?.textContent).toBe('test')
 	})
 })

--- a/packages/storybook/src/pages/Clipboard/Clipboard.react.stories.tsx
+++ b/packages/storybook/src/pages/Clipboard/Clipboard.react.stories.tsx
@@ -39,3 +39,21 @@ export const Drag: Story = {
 		defaultValue: 'hello\n@[world](1)\nfoo',
 	},
 }
+
+/** Mark component with nested HTML producing multiple text nodes inside the mark element. */
+function NestedMark({value}: MarkProps) {
+	const mid = Math.ceil(value.length / 2)
+	return (
+		<mark data-testid="mark">
+			<strong>{value.slice(0, mid)}</strong>
+			<em>{value.slice(mid)}</em>
+		</mark>
+	)
+}
+
+export const NestedMarkStory: Story = {
+	args: {
+		Mark: NestedMark,
+		defaultValue: 'hello @[world](1) foo',
+	},
+}

--- a/packages/storybook/src/pages/Clipboard/Clipboard.react.stories.tsx
+++ b/packages/storybook/src/pages/Clipboard/Clipboard.react.stories.tsx
@@ -1,0 +1,41 @@
+import type {MarkProps} from '@markput/react'
+import {MarkedInput} from '@markput/react'
+import type {Meta, StoryObj} from '@storybook/react-vite'
+import {useState} from 'react'
+
+export default {
+	title: 'Clipboard',
+	component: MarkedInput,
+} satisfies Meta<typeof MarkedInput>
+
+type Story = StoryObj<typeof MarkedInput>
+
+export const Inline: Story = {
+	args: {
+		Mark: ({value}: MarkProps) => <mark data-testid="mark">{value}</mark>,
+		defaultValue: 'hello @[world](1) foo',
+	},
+}
+
+function PlainTextInput() {
+	const [value, setValue] = useState('abc')
+	return (
+		<MarkedInput
+			Mark={({value}: MarkProps) => <mark data-testid="mark">{value}</mark>}
+			value={value}
+			onChange={setValue}
+		/>
+	)
+}
+
+export const PlainText: Story = {
+	render: () => <PlainTextInput />,
+}
+
+export const Drag: Story = {
+	args: {
+		drag: true,
+		Mark: ({value}: MarkProps) => <mark data-testid="mark">{value}</mark>,
+		defaultValue: 'hello\n@[world](1)\nfoo',
+	},
+}


### PR DESCRIPTION
### Summary

Introduces a `CopyController` that handles rich copy and cut operations, alongside improved paste behavior for selections spanning multiple tokens.

- **`CopyController`** — captures selection as tokens, trims boundary tokens, and writes both plain-text and `markput` MIME-type data to the clipboard
- **Cut support** — extends `CopyController` to delete selected content after copying
- **Cross-token paste** — correctly deletes selected text before inserting pasted content, even when the selection spans token boundaries
- **Multi-instance fix** — scopes `pendingMarkup` per container to prevent leaks when multiple editor instances coexist
- **Nested marks fix** — `getBoundaryOffset` now walks all text nodes to handle nested mark elements

### Changes

| Area | Details |
|------|---------|
| `CopyController.ts` | New controller: selection → tokens → clipboard (text + markput) |
| `selectionToTokens.ts` | Converts a DOM selection into trimmed token representation |
| `pasteMarkup.ts` | Handles `markput` MIME paste with proper selection deletion |
| `KeyDownController.ts` | Wires up cut (`Ctrl/Cmd+X`) via `CopyController` |
| Tests | Full coverage for paste (including drag-mode), copy, and token serialization |