### PR TITLE
feat(core): add effect cleanup, listen() helper, and refactor features to use them

### DIFF
--- a/packages/core/src/features/arrownav/ArrowNavFeature.ts
+++ b/packages/core/src/features/arrownav/ArrowNavFeature.ts
@@ -1,40 +1,38 @@
 import {KEYBOARD} from '../../shared/constants'
+import {effectScope, listen} from '../../shared/signals/index.js'
 import type {Store} from '../../store/Store'
 import {shiftFocusPrev, shiftFocusNext} from '../navigation'
 import {selectAllText} from '../selection'
 
 export class ArrowNavFeature {
-	#keydownHandler?: (e: KeyboardEvent) => void
+	#scope?: () => void
 
 	constructor(private store: Store) {}
 
 	enable() {
-		if (this.#keydownHandler) return
+		if (this.#scope) return
 
 		const container = this.store.refs.container
 		if (!container) return
 
-		this.#keydownHandler = e => {
-			if (this.store.props.drag()) return
-			if (!this.store.nodes.focus.target) return
+		this.#scope = effectScope(() => {
+			listen(container, 'keydown', e => {
+				if (this.store.props.drag()) return
+				if (!this.store.nodes.focus.target) return
 
-			if (e.key === KEYBOARD.LEFT) {
-				shiftFocusPrev(this.store, e)
-			} else if (e.key === KEYBOARD.RIGHT) {
-				shiftFocusNext(this.store, e)
-			}
+				if (e.key === KEYBOARD.LEFT) {
+					shiftFocusPrev(this.store, e)
+				} else if (e.key === KEYBOARD.RIGHT) {
+					shiftFocusNext(this.store, e)
+				}
 
-			selectAllText(this.store, e)
-		}
-
-		container.addEventListener('keydown', this.#keydownHandler)
+				selectAllText(this.store, e)
+			})
+		})
 	}
 
 	disable() {
-		const container = this.store.refs.container
-		if (!container || !this.#keydownHandler) return
-
-		container.removeEventListener('keydown', this.#keydownHandler)
-		this.#keydownHandler = undefined
+		this.#scope?.()
+		this.#scope = undefined
 	}
 }

--- a/packages/core/src/features/block-editing/BlockEditFeature.ts
+++ b/packages/core/src/features/block-editing/BlockEditFeature.ts
@@ -1,5 +1,6 @@
 import {childAt, htmlChildren, isHtmlElement} from '../../shared/checkers'
 import {KEYBOARD} from '../../shared/constants'
+import {effectScope, listen} from '../../shared/signals/index.js'
 import type {Store} from '../../store/Store'
 import {Caret} from '../caret'
 import {consumeMarkupPaste} from '../clipboard'
@@ -14,49 +15,46 @@ function isTextLikeRow(token: Token): boolean {
 }
 
 export class BlockEditFeature {
-	#keydownHandler?: (e: KeyboardEvent) => void
-	#beforeInputHandler?: (e: InputEvent) => void
+	#scope?: () => void
 
 	constructor(private store: Store) {}
 
 	enable() {
-		if (this.#keydownHandler) return
+		if (this.#scope) return
 
 		const container = this.store.refs.container
 		if (!container) return
 
-		this.#keydownHandler = e => {
-			if (!this.store.props.drag()) return
+		this.#scope = effectScope(() => {
+			listen(container, 'keydown', e => {
+				if (!this.store.props.drag()) return
 
-			if (e.key === KEYBOARD.LEFT || e.key === KEYBOARD.RIGHT) {
-				this.#handleBlockArrowLeftRight(e, e.key === KEYBOARD.LEFT ? 'left' : 'right')
-			} else if (e.key === KEYBOARD.UP || e.key === KEYBOARD.DOWN) {
-				this.#handleArrowUpDown(e)
-			}
+				if (e.key === KEYBOARD.LEFT || e.key === KEYBOARD.RIGHT) {
+					this.#handleBlockArrowLeftRight(e, e.key === KEYBOARD.LEFT ? 'left' : 'right')
+				} else if (e.key === KEYBOARD.UP || e.key === KEYBOARD.DOWN) {
+					this.#handleArrowUpDown(e)
+				}
 
-			this.#handleDelete(e)
-			this.#handleEnter(e)
-		}
+				this.#handleDelete(e)
+				this.#handleEnter(e)
+			})
 
-		this.#beforeInputHandler = e => {
-			if (!this.store.props.drag()) return
-			if (e.defaultPrevented) return
-			this.#handleBlockBeforeInput(e)
-		}
-
-		container.addEventListener('keydown', this.#keydownHandler)
-		container.addEventListener('beforeinput', this.#beforeInputHandler, true)
+			listen(
+				container,
+				'beforeinput',
+				e => {
+					if (!this.store.props.drag()) return
+					if (e.defaultPrevented) return
+					this.#handleBlockBeforeInput(e)
+				},
+				true
+			)
+		})
 	}
 
 	disable() {
-		const container = this.store.refs.container
-		if (!container || !this.#keydownHandler) return
-
-		container.removeEventListener('keydown', this.#keydownHandler)
-		if (this.#beforeInputHandler) container.removeEventListener('beforeinput', this.#beforeInputHandler, true)
-
-		this.#keydownHandler = undefined
-		this.#beforeInputHandler = undefined
+		this.#scope?.()
+		this.#scope = undefined
 	}
 
 	#handleDelete(event: KeyboardEvent) {

--- a/packages/core/src/features/clipboard/CopyFeature.ts
+++ b/packages/core/src/features/clipboard/CopyFeature.ts
@@ -1,3 +1,4 @@
+import {effectScope, listen} from '../../shared/signals/index.js'
 import type {Store} from '../../store'
 import {toString} from '../parsing'
 import type {Token} from '../parsing'
@@ -30,66 +31,60 @@ function trimBoundaryTokens({tokens, startOffset, endOffset}: SelectionTokenRang
 }
 
 export class CopyFeature {
-	#copyHandler?: (e: ClipboardEvent) => void
-	#cutHandler?: (e: ClipboardEvent) => void
+	#scope?: () => void
 
 	constructor(private store: Store) {}
 
 	enable() {
-		if (this.#copyHandler) return
-
-		this.#copyHandler = (e: ClipboardEvent) => {
-			this.#handleCopy(e)
-		}
-
-		this.#cutHandler = (e: ClipboardEvent) => {
-			if (!this.#handleCopy(e)) return
-
-			const result = selectionToTokens(this.store)
-			if (!result || result.tokens.length === 0) return
-
-			const first = result.tokens[0]
-			const last = result.tokens[result.tokens.length - 1]
-
-			const rawStart = first.type === 'text' ? first.position.start + result.startOffset : first.position.start
-			const rawEnd = last.type === 'text' ? last.position.start + result.endOffset : last.position.end
-
-			const value = this.store.state.previousValue() ?? this.store.props.value() ?? ''
-			if (rawStart === rawEnd) return
-
-			const newValue = value.slice(0, rawStart) + value.slice(rawEnd)
-			this.store.state.innerValue(newValue)
-
-			const newTokens = this.store.state.tokens()
-			let targetIdx = newTokens.findIndex(
-				t => t.type === 'text' && rawStart >= t.position.start && rawStart <= t.position.end
-			)
-			if (targetIdx === -1) targetIdx = newTokens.length - 1
-			const caretWithinToken = rawStart - newTokens[targetIdx].position.start
-
-			this.store.state.recovery({
-				anchor: this.store.nodes.focus,
-				caret: caretWithinToken,
-				isNext: true,
-				childIndex: targetIdx - 2,
-			})
-		}
+		if (this.#scope) return
 
 		const container = this.store.refs.container
-		container?.addEventListener('copy', this.#copyHandler)
-		container?.addEventListener('cut', this.#cutHandler)
+		if (!container) return
+
+		this.#scope = effectScope(() => {
+			listen(container, 'copy', e => {
+				this.#handleCopy(e)
+			})
+
+			listen(container, 'cut', e => {
+				if (!this.#handleCopy(e)) return
+
+				const result = selectionToTokens(this.store)
+				if (!result || result.tokens.length === 0) return
+
+				const first = result.tokens[0]
+				const last = result.tokens[result.tokens.length - 1]
+
+				const rawStart =
+					first.type === 'text' ? first.position.start + result.startOffset : first.position.start
+				const rawEnd = last.type === 'text' ? last.position.start + result.endOffset : last.position.end
+
+				const value = this.store.state.previousValue() ?? this.store.props.value() ?? ''
+				if (rawStart === rawEnd) return
+
+				const newValue = value.slice(0, rawStart) + value.slice(rawEnd)
+				this.store.state.innerValue(newValue)
+
+				const newTokens = this.store.state.tokens()
+				let targetIdx = newTokens.findIndex(
+					t => t.type === 'text' && rawStart >= t.position.start && rawStart <= t.position.end
+				)
+				if (targetIdx === -1) targetIdx = newTokens.length - 1
+				const caretWithinToken = rawStart - newTokens[targetIdx].position.start
+
+				this.store.state.recovery({
+					anchor: this.store.nodes.focus,
+					caret: caretWithinToken,
+					isNext: true,
+					childIndex: targetIdx - 2,
+				})
+			})
+		})
 	}
 
 	disable() {
-		const container = this.store.refs.container
-		if (this.#copyHandler) {
-			container?.removeEventListener('copy', this.#copyHandler)
-			this.#copyHandler = undefined
-		}
-		if (this.#cutHandler) {
-			container?.removeEventListener('cut', this.#cutHandler)
-			this.#cutHandler = undefined
-		}
+		this.#scope?.()
+		this.#scope = undefined
 	}
 
 	#handleCopy(e: ClipboardEvent): boolean {

--- a/packages/core/src/features/focus/FocusFeature.ts
+++ b/packages/core/src/features/focus/FocusFeature.ts
@@ -1,44 +1,37 @@
 import {childAt, firstHtmlChild, isHtmlElement} from '../../shared/checkers'
-import {effectScope, watch} from '../../shared/signals/index.js'
+import {effectScope, watch, listen} from '../../shared/signals/index.js'
 import type {Store} from '../../store/Store'
 
 export class FocusFeature {
-	#focusinHandler?: (e: FocusEvent) => void
-	#focusoutHandler?: () => void
-	#clickHandler?: () => void
 	#scope?: () => void
 
 	constructor(private store: Store) {}
 
 	enable() {
-		if (this.#focusinHandler) return
+		if (this.#scope) return
 
 		const container = this.store.refs.container
 		if (!container) return
 
-		this.#focusinHandler = e => {
-			const target = isHtmlElement(e.target) ? e.target : undefined
-			this.store.nodes.focus.target = target
-		}
-
-		this.#focusoutHandler = () => {
-			this.store.nodes.focus.target = undefined
-		}
-
-		this.#clickHandler = () => {
-			const tokens = this.store.state.tokens()
-			if (tokens.length === 1 && tokens[0].type === 'text' && tokens[0].content === '') {
-				const container = this.store.refs.container
-				const element = container ? firstHtmlChild(container) : null
-				element?.focus()
-			}
-		}
-
-		container.addEventListener('focusin', this.#focusinHandler)
-		container.addEventListener('focusout', this.#focusoutHandler)
-		container.addEventListener('click', this.#clickHandler)
-
 		this.#scope = effectScope(() => {
+			listen(container, 'focusin', e => {
+				const target = isHtmlElement(e.target) ? e.target : undefined
+				this.store.nodes.focus.target = target
+			})
+
+			listen(container, 'focusout', () => {
+				this.store.nodes.focus.target = undefined
+			})
+
+			listen(container, 'click', () => {
+				const tokens = this.store.state.tokens()
+				if (tokens.length === 1 && tokens[0].type === 'text' && tokens[0].content === '') {
+					const container = this.store.refs.container
+					const element = container ? firstHtmlChild(container) : null
+					element?.focus()
+				}
+			})
+
 			watch(this.store.event.recoverFocus, () => {
 				this.#recover()
 			})
@@ -52,20 +45,8 @@ export class FocusFeature {
 	}
 
 	disable() {
-		const container = this.store.refs.container
-		if (!container || !this.#focusinHandler) return
-
-		container.removeEventListener('focusin', this.#focusinHandler)
-		if (this.#focusoutHandler) container.removeEventListener('focusout', this.#focusoutHandler)
-		if (this.#clickHandler) container.removeEventListener('click', this.#clickHandler)
-
 		this.#scope?.()
 		this.#scope = undefined
-
-		this.#focusinHandler = undefined
-		this.#focusoutHandler = undefined
-		this.#clickHandler = undefined
-
 		this.store.nodes.focus.clear()
 	}
 

--- a/packages/core/src/features/input/InputFeature.ts
+++ b/packages/core/src/features/input/InputFeature.ts
@@ -1,56 +1,50 @@
 import {isHtmlElement} from '../../shared/checkers'
 import type {NodeProxy} from '../../shared/classes'
 import {KEYBOARD} from '../../shared/constants'
+import {effectScope, listen} from '../../shared/signals/index.js'
 import type {Store} from '../../store/Store'
 import {captureMarkupPaste, consumeMarkupPaste, getBoundaryOffset} from '../clipboard'
 import {deleteMark} from '../editing/utils/deleteMark'
 import {isFullSelection} from '../selection'
 
 export class InputFeature {
-	#keydownHandler?: (e: KeyboardEvent) => void
-	#pasteHandler?: (e: ClipboardEvent) => void
-	#beforeInputHandler?: (e: InputEvent) => void
+	#scope?: () => void
 
 	constructor(private store: Store) {}
 
 	enable() {
-		if (this.#keydownHandler) return
+		if (this.#scope) return
 
 		const container = this.store.refs.container
 		if (!container) return
 
-		this.#keydownHandler = e => {
-			if (!this.store.props.drag()) {
-				this.#handleDelete(e)
-			}
-		}
+		this.#scope = effectScope(() => {
+			listen(container, 'keydown', e => {
+				if (!this.store.props.drag()) {
+					this.#handleDelete(e)
+				}
+			})
 
-		this.#pasteHandler = e => {
-			const c = this.store.refs.container
-			if (c) captureMarkupPaste(e, c)
-			handlePaste(this.store, e)
-		}
+			listen(container, 'paste', e => {
+				const c = this.store.refs.container
+				if (c) captureMarkupPaste(e, c)
+				handlePaste(this.store, e)
+			})
 
-		this.#beforeInputHandler = e => {
-			handleBeforeInput(this.store, e)
-		}
-
-		container.addEventListener('keydown', this.#keydownHandler)
-		container.addEventListener('paste', this.#pasteHandler)
-		container.addEventListener('beforeinput', this.#beforeInputHandler, true)
+			listen(
+				container,
+				'beforeinput',
+				e => {
+					handleBeforeInput(this.store, e)
+				},
+				true
+			)
+		})
 	}
 
 	disable() {
-		const container = this.store.refs.container
-		if (!container || !this.#keydownHandler) return
-
-		container.removeEventListener('keydown', this.#keydownHandler)
-		if (this.#pasteHandler) container.removeEventListener('paste', this.#pasteHandler)
-		if (this.#beforeInputHandler) container.removeEventListener('beforeinput', this.#beforeInputHandler, true)
-
-		this.#keydownHandler = undefined
-		this.#pasteHandler = undefined
-		this.#beforeInputHandler = undefined
+		this.#scope?.()
+		this.#scope = undefined
 	}
 
 	#handleDelete(event: KeyboardEvent) {

--- a/packages/core/src/features/overlay/OverlayFeature.ts
+++ b/packages/core/src/features/overlay/OverlayFeature.ts
@@ -76,23 +76,25 @@ export class OverlayFeature {
 	}
 
 	disable() {
-		const container = this.store.refs.container
+		// 1. Reset state
+		this.store.state.overlayTrigger(undefined)
 
+		// 2. Remove DOM listeners
+		const container = this.store.refs.container
 		if (container && this.#focusinHandler) {
 			container.removeEventListener('focusin', this.#focusinHandler)
 			if (this.#focusoutHandler) container.removeEventListener('focusout', this.#focusoutHandler)
 		}
-
 		if (this.#selectionChangeHandler) {
 			document.removeEventListener('selectionchange', this.#selectionChangeHandler)
 		}
-
 		this.#disableClose()
 
-		this.store.state.overlayTrigger(undefined)
-
+		// 3. Dispose scope
 		this.#scope?.()
 		this.#scope = undefined
+
+		// 4. Null refs
 		this.#selectionChangeHandler = undefined
 		this.#focusinHandler = undefined
 		this.#focusoutHandler = undefined

--- a/packages/core/src/features/overlay/OverlayFeature.ts
+++ b/packages/core/src/features/overlay/OverlayFeature.ts
@@ -1,16 +1,11 @@
 import {KEYBOARD} from '../../shared/constants'
-import {effectScope, watch} from '../../shared/signals/index.js'
+import {effectScope, effect, watch, listen} from '../../shared/signals/index.js'
 import type {OverlayTrigger} from '../../shared/types'
 import type {Store} from '../../store/Store'
 import {TriggerFinder} from '../caret'
 
 export class OverlayFeature {
 	#scope?: () => void
-	#selectionChangeHandler?: () => void
-	#focusinHandler?: (e: FocusEvent) => void
-	#focusoutHandler?: (e: FocusEvent) => void
-	#escHandler?: (e: KeyboardEvent) => void
-	#clickHandler?: (e: MouseEvent) => void
 
 	constructor(private store: Store) {}
 
@@ -40,92 +35,52 @@ export class OverlayFeature {
 				}
 			})
 
-			watch(this.store.state.overlayMatch, match => {
+			// Overlay match tracking + conditional close handlers
+			effect(() => {
+				const match = this.store.state.overlayMatch()
 				if (match) {
 					this.store.nodes.input.target = this.store.nodes.focus.target
-					this.#enableClose()
-				} else {
-					this.#disableClose()
+
+					listen(window, 'keydown', e => {
+						if (e.key === KEYBOARD.ESC) {
+							this.store.event.clearOverlay()
+						}
+					})
+
+					listen(
+						document,
+						'click',
+						e => {
+							const target = e.target instanceof HTMLElement ? e.target : null
+							if (this.store.refs.overlay?.contains(target)) return
+							if (this.store.refs.container?.contains(target)) return
+							this.store.event.clearOverlay()
+						},
+						true
+					)
 				}
 			})
-		})
 
-		const selectionChangeHandler = () => {
-			const showOverlayOn = this.store.props.showOverlayOn()
-			const type: OverlayTrigger = 'selectionChange'
+			// Focus-based selection change tracking
+			const selectionChangeHandler = () => {
+				const container = this.store.refs.container
+				if (!container?.contains(document.activeElement)) return
 
-			if (showOverlayOn === type || (Array.isArray(showOverlayOn) && showOverlayOn.includes(type))) {
-				this.store.event.checkOverlay()
+				const showOverlayOn = this.store.props.showOverlayOn()
+				const type: OverlayTrigger = 'selectionChange'
+
+				if (showOverlayOn === type || (Array.isArray(showOverlayOn) && showOverlayOn.includes(type))) {
+					this.store.event.checkOverlay()
+				}
 			}
-		}
-		this.#selectionChangeHandler = selectionChangeHandler
 
-		this.#focusinHandler = () => {
-			document.addEventListener('selectionchange', selectionChangeHandler)
-		}
-
-		this.#focusoutHandler = () => {
-			document.removeEventListener('selectionchange', selectionChangeHandler)
-		}
-
-		const container = this.store.refs.container
-		if (container) {
-			container.addEventListener('focusin', this.#focusinHandler)
-			container.addEventListener('focusout', this.#focusoutHandler)
-		}
+			listen(document, 'selectionchange', selectionChangeHandler)
+		})
 	}
 
 	disable() {
-		// 1. Reset state
 		this.store.state.overlayTrigger(undefined)
-
-		// 2. Remove DOM listeners
-		const container = this.store.refs.container
-		if (container && this.#focusinHandler) {
-			container.removeEventListener('focusin', this.#focusinHandler)
-			if (this.#focusoutHandler) container.removeEventListener('focusout', this.#focusoutHandler)
-		}
-		if (this.#selectionChangeHandler) {
-			document.removeEventListener('selectionchange', this.#selectionChangeHandler)
-		}
-		this.#disableClose()
-
-		// 3. Dispose scope
 		this.#scope?.()
 		this.#scope = undefined
-
-		// 4. Null refs
-		this.#selectionChangeHandler = undefined
-		this.#focusinHandler = undefined
-		this.#focusoutHandler = undefined
-	}
-
-	#enableClose() {
-		if (this.#escHandler) return
-
-		this.#escHandler = e => {
-			if (e.key === KEYBOARD.ESC) {
-				this.store.event.clearOverlay()
-			}
-		}
-
-		this.#clickHandler = e => {
-			const target = e.target instanceof HTMLElement ? e.target : null
-			if (this.store.refs.overlay?.contains(target)) return
-			if (this.store.refs.container?.contains(target)) return
-			this.store.event.clearOverlay()
-		}
-
-		window.addEventListener('keydown', this.#escHandler)
-		document.addEventListener('click', this.#clickHandler, true)
-	}
-
-	#disableClose() {
-		if (this.#escHandler) {
-			window.removeEventListener('keydown', this.#escHandler)
-			if (this.#clickHandler) document.removeEventListener('click', this.#clickHandler, true)
-			this.#escHandler = undefined
-			this.#clickHandler = undefined
-		}
 	}
 }

--- a/packages/core/src/features/parsing/ParseFeature.ts
+++ b/packages/core/src/features/parsing/ParseFeature.ts
@@ -22,9 +22,9 @@ export class ParseFeature {
 	}
 
 	disable() {
+		this.#initialized = false
 		this.#scope?.()
 		this.#scope = undefined
-		this.#initialized = false
 	}
 
 	sync() {

--- a/packages/core/src/features/selection/TextSelectionFeature.ts
+++ b/packages/core/src/features/selection/TextSelectionFeature.ts
@@ -1,12 +1,8 @@
 import {nodeTarget} from '../../shared/checkers'
-import {effectScope, effect} from '../../shared/signals/index.js'
+import {effectScope, effect, listen} from '../../shared/signals/index.js'
 import type {Store} from '../../store/Store'
 
 export class TextSelectionFeature {
-	#mousedownHandler?: (e: MouseEvent) => void
-	#mousemoveHandler?: (e: MouseEvent) => void
-	#mouseupHandler?: () => void
-	#selectionchangeHandler?: () => void
 	#scope?: () => void
 	#pressedNode: Node | null = null
 	#isPressed = false
@@ -14,47 +10,47 @@ export class TextSelectionFeature {
 	constructor(private store: Store) {}
 
 	enable() {
-		if (this.#mousedownHandler) return
+		if (this.#scope) return
 
-		this.#mousedownHandler = e => {
-			this.#pressedNode = nodeTarget(e)
-			this.#isPressed = true
-		}
+		this.#scope = effectScope(() => {
+			listen(document, 'mousedown', e => {
+				this.#pressedNode = nodeTarget(e)
+				this.#isPressed = true
+			})
 
-		this.#mousemoveHandler = e => {
-			const container = this.store.refs.container
-			if (!container) return
-			const isPressed = this.#isPressed
-			const isNotInnerSome = !container.contains(this.#pressedNode) || this.#pressedNode !== e.target
-			const isInside = window.getSelection()?.containsNode(container, true)
+			listen(document, 'mousemove', e => {
+				const container = this.store.refs.container
+				if (!container) return
+				const isPressed = this.#isPressed
+				const isNotInnerSome = !container.contains(this.#pressedNode) || this.#pressedNode !== e.target
+				const isInside = window.getSelection()?.containsNode(container, true)
 
-			if (isPressed && isNotInnerSome && isInside) {
-				if (this.store.state.selecting() !== 'drag') {
-					this.store.state.selecting('drag')
+				if (isPressed && isNotInnerSome && isInside) {
+					if (this.store.state.selecting() !== 'drag') {
+						this.store.state.selecting('drag')
+					}
 				}
-			}
-		}
+			})
 
-		this.#mouseupHandler = () => {
-			this.#isPressed = false
-			this.#pressedNode = null
-			if (this.store.state.selecting() === 'drag') {
+			listen(document, 'mouseup', () => {
+				this.#isPressed = false
+				this.#pressedNode = null
+				if (this.store.state.selecting() === 'drag') {
+					const sel = window.getSelection()
+					if (!sel || sel.isCollapsed) {
+						this.store.state.selecting(undefined)
+					}
+				}
+			})
+
+			listen(document, 'selectionchange', () => {
+				if (this.store.state.selecting() !== 'drag') return
 				const sel = window.getSelection()
 				if (!sel || sel.isCollapsed) {
 					this.store.state.selecting(undefined)
 				}
-			}
-		}
+			})
 
-		this.#selectionchangeHandler = () => {
-			if (this.store.state.selecting() !== 'drag') return
-			const sel = window.getSelection()
-			if (!sel || sel.isCollapsed) {
-				this.store.state.selecting(undefined)
-			}
-		}
-
-		this.#scope = effectScope(() => {
 			effect(() => {
 				const value = this.store.state.selecting()
 				if (value !== 'drag') return
@@ -65,35 +61,15 @@ export class TextSelectionFeature {
 					.forEach(el => (el.contentEditable = 'false'))
 			})
 		})
-
-		document.addEventListener('mousedown', this.#mousedownHandler)
-		document.addEventListener('mousemove', this.#mousemoveHandler)
-		document.addEventListener('mouseup', this.#mouseupHandler)
-		document.addEventListener('selectionchange', this.#selectionchangeHandler)
 	}
 
 	disable() {
 		if (this.store.state.selecting() === 'drag') {
-			// Set state before unsubscribing so ContentEditableFeature.sync() still fires
 			this.store.state.selecting(undefined)
 		}
 
 		this.#scope?.()
 		this.#scope = undefined
-
-		if (this.#mousedownHandler) {
-			document.removeEventListener('mousedown', this.#mousedownHandler)
-			if (this.#mousemoveHandler) document.removeEventListener('mousemove', this.#mousemoveHandler)
-			if (this.#mouseupHandler) document.removeEventListener('mouseup', this.#mouseupHandler)
-			if (this.#selectionchangeHandler)
-				document.removeEventListener('selectionchange', this.#selectionchangeHandler)
-
-			this.#mousedownHandler = undefined
-			this.#mousemoveHandler = undefined
-			this.#mouseupHandler = undefined
-			this.#selectionchangeHandler = undefined
-		}
-
 		this.#pressedNode = null
 		this.#isPressed = false
 	}

--- a/packages/core/src/shared/signals/index.ts
+++ b/packages/core/src/shared/signals/index.ts
@@ -1,2 +1,2 @@
-export {signal, computed, effect, effectScope, event, watch, batch, trigger, untracked} from './signal'
+export {signal, computed, effect, effectScope, event, watch, batch, trigger, untracked, listen} from './signal'
 export type {Signal, Computed, Event, SignalValues} from './signal'

--- a/packages/core/src/shared/signals/signal.ts
+++ b/packages/core/src/shared/signals/signal.ts
@@ -565,3 +565,43 @@ export function untracked<T>(fn: () => T): T {
 		setActiveSub(prev)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// listen() — scope-aware DOM event listener
+// ---------------------------------------------------------------------------
+
+export function listen<K extends keyof WindowEventMap>(
+	target: Window,
+	event: K,
+	handler: (e: WindowEventMap[K]) => void,
+	options?: boolean | AddEventListenerOptions
+): () => void
+export function listen<K extends keyof DocumentEventMap>(
+	target: Document,
+	event: K,
+	handler: (e: DocumentEventMap[K]) => void,
+	options?: boolean | AddEventListenerOptions
+): () => void
+export function listen<K extends keyof HTMLElementEventMap>(
+	target: HTMLElement,
+	event: K,
+	handler: (e: HTMLElementEventMap[K]) => void,
+	options?: boolean | AddEventListenerOptions
+): () => void
+export function listen(
+	target: EventTarget,
+	event: string,
+	handler: EventListenerOrEventListenerObject,
+	options?: boolean | AddEventListenerOptions
+): () => void
+export function listen(
+	target: EventTarget,
+	event: string,
+	handler: EventListenerOrEventListenerObject,
+	options?: boolean | AddEventListenerOptions
+): () => void {
+	return alienEffect(() => {
+		target.addEventListener(event, handler, options)
+		return () => target.removeEventListener(event, handler, options)
+	})
+}

--- a/packages/core/src/shared/signals/signal.ts
+++ b/packages/core/src/shared/signals/signal.ts
@@ -21,7 +21,8 @@ interface ComputedNode<T = any> extends ReactiveNode {
 }
 
 interface EffectNode extends ReactiveNode {
-	fn(): void
+	fn(): void | (() => void)
+	cleanup?: () => void
 }
 
 interface EventNode<T = any> extends ReactiveNode {
@@ -85,6 +86,14 @@ const {link, unlink, propagate, checkDirty, shallowPropagate} = createReactiveSy
 	},
 	unwatched(node) {
 		if (!(node.flags & ReactiveFlags.Mutable)) {
+			if ('fn' in node) {
+				// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- discriminated by runtime 'fn' in node check
+				const e = node as EffectNode
+				if (e.cleanup !== undefined) {
+					e.cleanup()
+					e.cleanup = undefined
+				}
+			}
 			effectScopeOper.call(node)
 		} else if (node.depsTail !== undefined) {
 			node.depsTail = undefined
@@ -137,12 +146,19 @@ function run(e: EffectNode): void {
 	const flags = e.flags
 	// oxlint-disable-next-line typescript/no-non-null-assertion -- deps is guaranteed present when Pending
 	if (flags & ReactiveFlags.Dirty || (flags & ReactiveFlags.Pending && checkDirty(e.deps!, e))) {
+		if (e.cleanup !== undefined) {
+			e.cleanup()
+			e.cleanup = undefined
+		}
 		++cycle
 		e.depsTail = undefined
 		e.flags = ReactiveFlags.Watching | ReactiveFlags.RecursedCheck
 		const prevSub = setActiveSub(e)
 		try {
-			e.fn()
+			const result = e.fn()
+			if (typeof result === 'function') {
+				e.cleanup = result as () => void
+			}
 		} finally {
 			activeSub = prevSub
 			e.flags &= ~ReactiveFlags.RecursedCheck
@@ -288,6 +304,10 @@ function eventReadOper<T>(this: EventNode<T>): T | undefined {
 }
 
 function effectOper(this: EffectNode): void {
+	if (this.cleanup !== undefined) {
+		this.cleanup()
+		this.cleanup = undefined
+	}
 	effectScopeOper.call(this)
 }
 
@@ -407,9 +427,10 @@ export function event<T = void>(): Event<T> {
 
 export {alienEffect as effect}
 
-function alienEffect(fn: () => void): () => void {
+function alienEffect(fn: () => void | (() => void)): () => void {
 	const e: EffectNode = {
 		fn,
+		cleanup: undefined,
 		subs: undefined,
 		subsTail: undefined,
 		deps: undefined,
@@ -421,7 +442,10 @@ function alienEffect(fn: () => void): () => void {
 		link(e, prevSub, 0)
 	}
 	try {
-		e.fn()
+		const result = e.fn()
+		if (typeof result === 'function') {
+			e.cleanup = result as () => void
+		}
 	} finally {
 		activeSub = prevSub
 		e.flags &= ~ReactiveFlags.RecursedCheck

--- a/packages/core/src/shared/signals/signals.spec.ts
+++ b/packages/core/src/shared/signals/signals.spec.ts
@@ -14,7 +14,7 @@ afterEach(() => {
 	disposers = []
 })
 
-function trackedEffect(fn: () => void): () => void {
+function trackedEffect(fn: () => void | (() => void)): () => void {
 	const dispose = effect(fn)
 	disposers.push(dispose)
 	return dispose

--- a/packages/core/src/shared/signals/signals.spec.ts
+++ b/packages/core/src/shared/signals/signals.spec.ts
@@ -1,6 +1,6 @@
 import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest'
 
-import {signal, watch, event, batch, effect, effectScope} from './signal'
+import {signal, watch, event, batch, effect, effectScope, listen} from './signal'
 
 // Helper to track and dispose effects created during tests
 let disposers: (() => void)[]
@@ -623,5 +623,69 @@ describe('effect cleanup', () => {
 		expect(runs).toHaveBeenCalledTimes(1)
 		s(1)
 		expect(runs).toHaveBeenCalledTimes(2)
+	})
+})
+
+describe('listen()', () => {
+	beforeEach(() => vi.clearAllMocks())
+
+	it('should add listener and auto-remove on scope disposal', () => {
+		const target = new EventTarget()
+		const handler = vi.fn()
+		const addSpy = vi.spyOn(target, 'addEventListener')
+		const removeSpy = vi.spyOn(target, 'removeEventListener')
+
+		const scope = effectScope(() => {
+			listen(target, 'click', handler)
+		})
+
+		expect(addSpy).toHaveBeenCalledWith('click', handler, undefined)
+		expect(removeSpy).not.toHaveBeenCalled()
+
+		scope()
+
+		expect(removeSpy).toHaveBeenCalledWith('click', handler, undefined)
+	})
+
+	it('should remove listener when nested effect re-runs', () => {
+		const target = new EventTarget()
+		const handler = vi.fn()
+		const show = signal(true)
+		const removeSpy = vi.spyOn(target, 'removeEventListener')
+
+		trackedEffect(() => {
+			if (show()) {
+				listen(target, 'input', handler)
+			}
+		})
+
+		expect(removeSpy).not.toHaveBeenCalled()
+		show(false)
+		expect(removeSpy).toHaveBeenCalledWith('input', handler, undefined)
+	})
+
+	it('should return a dispose function for manual cleanup', () => {
+		const target = new EventTarget()
+		const handler = vi.fn()
+		const removeSpy = vi.spyOn(target, 'removeEventListener')
+
+		const dispose = listen(target, 'keydown', handler)
+		disposers.push(dispose)
+
+		expect(removeSpy).not.toHaveBeenCalled()
+		dispose()
+		expect(removeSpy).toHaveBeenCalledWith('keydown', handler, undefined)
+	})
+
+	it('should pass options through to addEventListener', () => {
+		const target = new EventTarget()
+		const handler = vi.fn()
+		const addSpy = vi.spyOn(target, 'addEventListener')
+
+		effectScope(() => {
+			listen(target, 'click', handler, {capture: true})
+		})()
+
+		expect(addSpy).toHaveBeenCalledWith('click', handler, {capture: true})
 	})
 })

--- a/packages/core/src/shared/signals/signals.spec.ts
+++ b/packages/core/src/shared/signals/signals.spec.ts
@@ -1,6 +1,6 @@
 import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest'
 
-import {signal, watch, event, batch, effect} from './signal'
+import {signal, watch, event, batch, effect, effectScope} from './signal'
 
 // Helper to track and dispose effects created during tests
 let disposers: (() => void)[]
@@ -532,5 +532,96 @@ describe('watch()', () => {
 		s('c')
 
 		expect(seen).toEqual(['b', 'c'])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// effect cleanup
+// ---------------------------------------------------------------------------
+
+describe('effect cleanup', () => {
+	beforeEach(() => vi.clearAllMocks())
+
+	it('should call returned cleanup on re-run', () => {
+		const s = signal(0)
+		const cleanup = vi.fn()
+
+		trackedEffect(() => {
+			s()
+			return cleanup
+		})
+
+		expect(cleanup).not.toHaveBeenCalled()
+		s(1)
+		expect(cleanup).toHaveBeenCalledTimes(1)
+		s(2)
+		expect(cleanup).toHaveBeenCalledTimes(2)
+	})
+
+	it('should call returned cleanup on explicit disposal', () => {
+		const cleanup = vi.fn()
+
+		const dispose = effect(() => cleanup)
+		disposers.push(dispose)
+
+		expect(cleanup).not.toHaveBeenCalled()
+		dispose()
+		expect(cleanup).toHaveBeenCalledTimes(1)
+	})
+
+	it('should call inner effect cleanup when outer re-runs', () => {
+		const show = signal(true)
+		const innerCleanup = vi.fn()
+
+		trackedEffect(() => {
+			if (show()) {
+				effect(() => innerCleanup)
+			}
+		})
+
+		expect(innerCleanup).not.toHaveBeenCalled()
+		show(false)
+		expect(innerCleanup).toHaveBeenCalledTimes(1)
+	})
+
+	it('should call cleanup when scope is disposed', () => {
+		const cleanup = vi.fn()
+
+		const scope = effectScope(() => {
+			effect(() => cleanup)
+		})
+
+		expect(cleanup).not.toHaveBeenCalled()
+		scope()
+		expect(cleanup).toHaveBeenCalledTimes(1)
+	})
+
+	it('should replace cleanup on each re-run', () => {
+		const s = signal(0)
+		const cleanups: number[] = []
+
+		trackedEffect(() => {
+			const v = s()
+			return () => cleanups.push(v)
+		})
+
+		s(1)
+		expect(cleanups).toEqual([0])
+		s(2)
+		expect(cleanups).toEqual([0, 1])
+	})
+
+	it('should work with effects returning void (no cleanup)', () => {
+		const s = signal(0)
+		const runs = vi.fn()
+
+		trackedEffect(() => {
+			s()
+			runs()
+		})
+
+		expect(runs).toHaveBeenCalledTimes(1)
+		s(1)
+		expect(runs).toHaveBeenCalledTimes(2)
 	})
 })


### PR DESCRIPTION
## Summary

- Add cleanup return support to `effect()` — effects can return a function that is called before re-run and on disposal
- Add `listen()` helper with typed overloads (Window, Document, HTMLElement, EventTarget) for scope-aware DOM event listeners
- Refactor 7 features (Overlay, TextSelection, Input, ArrowNav, BlockEdit, Copy, Focus) to replace manual `addEventListener`/`removeEventListener` + handler ref boilerplate with `listen()` inside `effectScope()`

## Key changes

**Reactive system** (`signal.ts`):
- `EffectNode` now supports `fn(): void | (() => void)` and `cleanup?: () => void`
- Cleanup is called before re-run, on explicit disposal, and on implicit disposal (via `unwatched`)
- `listen()` wraps `alienEffect` to auto-remove listeners when the enclosing scope is disposed

**Feature refactors** — consistent pattern across all 7 features:
- Remove private handler ref fields and manual `addEventListener`/`removeEventListener`
- Wrap listeners in `effectScope(() => { listen(...) })` — scope disposal cleans up everything
- `disable()` reduced to 2–5 lines in most cases