### PR TITLE
fix(core): improve signal handling and reactive type guards

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -20,7 +20,7 @@ export type {Markup, Token, TextToken, MarkToken} from './src/features/parsing'
 
 // Reactive system
 export type {Signal, Computed, Event, SignalValues} from './src/shared/signals'
-export {effect, event, signal, computed, watch, batch} from './src/shared/signals'
+export {effect, event, signal, computed, watch, batch, isReactive} from './src/shared/signals'
 
 // Store
 export {Store} from './src/store'

--- a/packages/core/src/shared/signals/index.ts
+++ b/packages/core/src/shared/signals/index.ts
@@ -1,2 +1,14 @@
-export {signal, computed, effect, effectScope, event, watch, batch, trigger, untracked, listen} from './signal'
+export {
+	signal,
+	computed,
+	effect,
+	effectScope,
+	event,
+	watch,
+	batch,
+	trigger,
+	untracked,
+	listen,
+	isReactive,
+} from './signal'
 export type {Signal, Computed, Event, SignalValues} from './signal'

--- a/packages/core/src/shared/signals/signal.ts
+++ b/packages/core/src/shared/signals/signal.ts
@@ -243,10 +243,11 @@ function signalOper<T>(this: SignalNode<T>, ...value: [T | undefined] | []): T |
 				}
 			}
 		}
-		// Walk past intermediate computed nodes to find the actual effect/watcher subscriber.
-		// Unlike computedOper/eventReadOper, signals can be read inside a computed getter where
-		// activeSub is a ComputedNode (no Mutable|Watching flags). The walk skips these
-		// intermediaries to link directly to the EffectNode/WatcherNode that needs notification.
+		// Walk to the nearest subscriber with Mutable or Watching flags.
+		// Needed when activeSub is a non-tracking scope node (e.g. effectScope with flags: None)
+		// rather than a computed/effect. computedOper/eventReadOper can link directly because they
+		// are only called inside reactive contexts that guarantee a valid subscriber, but signals
+		// may be read in broader scopes.
 		let sub = activeSub
 		while (sub !== undefined) {
 			if (sub.flags & (ReactiveFlags.Mutable | ReactiveFlags.Watching)) {

--- a/packages/core/src/shared/signals/signal.ts
+++ b/packages/core/src/shared/signals/signal.ts
@@ -243,6 +243,10 @@ function signalOper<T>(this: SignalNode<T>, ...value: [T | undefined] | []): T |
 				}
 			}
 		}
+		// Walk past intermediate computed nodes to find the actual effect/watcher subscriber.
+		// Unlike computedOper/eventReadOper, signals can be read inside a computed getter where
+		// activeSub is a ComputedNode (no Mutable|Watching flags). The walk skips these
+		// intermediaries to link directly to the EffectNode/WatcherNode that needs notification.
 		let sub = activeSub
 		while (sub !== undefined) {
 			if (sub.flags & (ReactiveFlags.Mutable | ReactiveFlags.Watching)) {

--- a/packages/core/src/shared/signals/signal.ts
+++ b/packages/core/src/shared/signals/signal.ts
@@ -354,7 +354,7 @@ export function signal<T>(initial: T, opts?: SignalOptions<T>): Signal<T> {
 	const node: SignalNode<T> = {
 		currentValue: initial,
 		pendingValue: initial,
-		defaultValue: initial ?? undefined,
+		defaultValue: initial,
 		hasDefault: initial !== undefined,
 		equalsFn: opts?.equals ?? undefined,
 		isReadonly: !!opts?.readonly,

--- a/packages/core/src/shared/signals/signal.ts
+++ b/packages/core/src/shared/signals/signal.ts
@@ -331,7 +331,13 @@ export interface Signal<T> {
 }
 
 export type SignalValues<T> = {
-	[K in keyof T]: T[K] extends Signal<infer V> | Computed<infer V> ? V : never
+	[K in keyof T]: T[K] extends Signal<infer V> | Computed<infer V> ? V : T[K]
+}
+
+export function isReactive(fn: unknown): fn is Signal<unknown> | Computed<unknown> {
+	if (typeof fn !== 'function') return false
+	const name = (fn as {name: string}).name
+	return name === 'bound ' + signalOper.name || name === 'bound ' + computedOper.name
 }
 
 interface SignalOptions<T> {

--- a/packages/core/src/shared/signals/signal.ts
+++ b/packages/core/src/shared/signals/signal.ts
@@ -206,15 +206,12 @@ function signalOper<T>(this: SignalNode<T>, ...value: [T | undefined] | []): T |
 		if (this.isReadonly && !mutableScope) return
 		const v = value[0]
 		if (v === undefined) {
-			if (this.hasDefault) {
-				if (this.pendingValue === undefined || this.pendingValue === this.defaultValue) return
-				// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- undefined is valid for T when reverting to default
-				this.pendingValue = undefined as T
-			} else {
-				if (this.pendingValue === undefined) return
-				// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- undefined is valid for T when clearing value
-				this.pendingValue = undefined as T
-			}
+			const isAtDefault = this.hasDefault
+				? this.pendingValue === undefined || this.pendingValue === this.defaultValue
+				: this.pendingValue === undefined
+			if (isAtDefault) return
+			// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- undefined is valid for T when reverting to default
+			this.pendingValue = undefined as T
 		} else {
 			const current = this.pendingValue
 			const effectiveCurrent = current === undefined && this.hasDefault ? this.defaultValue : current

--- a/packages/core/src/shared/signals/signals.spec.ts
+++ b/packages/core/src/shared/signals/signals.spec.ts
@@ -256,6 +256,24 @@ describe('signal<T>', () => {
 			expect(captured).toBe(42)
 		})
 	})
+
+	describe('null initial value', () => {
+		it('should treat null as a valid default', () => {
+			const s = signal<string | null>(null)
+			expect(s()).toBeNull()
+			s('hello')
+			expect(s()).toBe('hello')
+			s(undefined)
+			expect(s()).toBeNull()
+		})
+
+		it('should not conflate null with undefined for hasDefault', () => {
+			const s = signal<string | null>(null)
+			s('world')
+			s(undefined)
+			expect(s()).toBeNull()
+		})
+	})
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/shared/signals/signals.spec.ts
+++ b/packages/core/src/shared/signals/signals.spec.ts
@@ -1,6 +1,6 @@
 import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest'
 
-import {signal, watch, event, batch, effect, effectScope, listen} from './signal'
+import {signal, computed, watch, event, batch, effect, effectScope, listen, isReactive} from './signal'
 
 // Helper to track and dispose effects created during tests
 let disposers: (() => void)[]
@@ -687,5 +687,42 @@ describe('listen()', () => {
 		})()
 
 		expect(addSpy).toHaveBeenCalledWith('click', handler, {capture: true})
+	})
+})
+
+// ---------------------------------------------------------------------------
+// isReactive
+// ---------------------------------------------------------------------------
+
+describe('isReactive', () => {
+	it('returns true for a signal', () => {
+		expect(isReactive(signal(0))).toBe(true)
+	})
+
+	it('returns true for a computed', () => {
+		const c = computed(() => 1)
+		expect(isReactive(c)).toBe(true)
+	})
+
+	it('returns false for a plain function', () => {
+		expect(isReactive(() => 0)).toBe(false)
+	})
+
+	it('returns false for a plain object', () => {
+		expect(isReactive({foo: 'bar'})).toBe(false)
+	})
+
+	it('returns false for null', () => {
+		expect(isReactive(null)).toBe(false)
+	})
+
+	it('returns false for an event callable', () => {
+		const e = event()
+		expect(isReactive(e)).toBe(false)
+	})
+
+	it('returns false for event.read', () => {
+		const e = event()
+		expect(isReactive(e.read)).toBe(false)
 	})
 })

--- a/packages/core/src/shared/signals/signals.spec.ts
+++ b/packages/core/src/shared/signals/signals.spec.ts
@@ -1,6 +1,7 @@
 import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest'
 
 import {signal, computed, watch, event, batch, effect, effectScope, listen, isReactive} from './signal'
+import type {SignalValues, Signal} from './signal'
 
 // Helper to track and dispose effects created during tests
 let disposers: (() => void)[]
@@ -724,5 +725,20 @@ describe('isReactive', () => {
 	it('returns false for event.read', () => {
 		const e = event()
 		expect(isReactive(e.read)).toBe(false)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// SignalValues
+// ---------------------------------------------------------------------------
+
+describe('SignalValues passthrough', () => {
+	it('preserves non-signal value types', () => {
+		type Input = {count: Signal<number>; label: string}
+		type Result = SignalValues<Input>
+		// At runtime: just verify the type resolves — no assertion needed
+		// The test exists to document and protect the T[K] fallback behaviour
+		const _: Result = {count: 0, label: 'hello'}
+		expect(true).toBe(true)
 	})
 })

--- a/packages/react/markput/src/components/Container.tsx
+++ b/packages/react/markput/src/components/Container.tsx
@@ -20,7 +20,7 @@ export const Container = memo(() => {
 
 	useLayoutEffect(() => {
 		event.afterTokensRendered()
-	}, [tokens])
+	}, [tokens, event])
 
 	return (
 		<Component ref={(el: HTMLDivElement | null) => (refs.container = el)} {...props}>

--- a/packages/react/markput/src/components/Container.tsx
+++ b/packages/react/markput/src/components/Container.tsx
@@ -2,16 +2,16 @@ import type {ElementType} from 'react'
 import {memo, useLayoutEffect} from 'react'
 
 import {useMarkput} from '../lib/hooks/useMarkput'
-import {useStore} from '../lib/providers/StoreContext'
 import {Block} from './Block'
 import {Token} from './Token'
 
 export const Container = memo(() => {
-	const store = useStore()
-
-	const {drag, tokens} = useMarkput(s => ({
+	const {drag, tokens, key, refs, event} = useMarkput(s => ({
 		drag: s.props.drag,
 		tokens: s.state.tokens,
+		key: s.key,
+		refs: s.refs,
+		event: s.event,
 	}))
 
 	// oxlint-disable-next-line no-unsafe-type-assertion -- containerComponent returns unknown in core; React ElementType asserted here
@@ -19,11 +19,8 @@ export const Container = memo(() => {
 	const props = useMarkput(s => s.computed.containerProps)
 
 	useLayoutEffect(() => {
-		store.event.afterTokensRendered()
+		event.afterTokensRendered()
 	}, [tokens])
-
-	const key = store.key
-	const refs = store.refs
 
 	return (
 		<Component ref={(el: HTMLDivElement | null) => (refs.container = el)} {...props}>

--- a/packages/react/markput/src/lib/hooks/useMarkput.ts
+++ b/packages/react/markput/src/lib/hooks/useMarkput.ts
@@ -1,11 +1,11 @@
-import {computed, watch} from '@markput/core'
+import {computed, watch, isReactive} from '@markput/core'
 import type {Signal, Computed, SignalValues, Store} from '@markput/core'
 import {useSyncExternalStore, useRef} from 'react'
 
 import {useStore} from '../providers/StoreContext'
 
 type Selectable<T> = Signal<T> | Computed<T>
-type ObjectSelector = Record<string, Selectable<unknown>>
+type ObjectSelector = Record<string, Selectable<unknown> | unknown>
 
 type StableRef = {
 	derived: Computed<unknown>
@@ -26,13 +26,12 @@ export function useMarkput(selector: (store: Store) => Selectable<unknown> | Obj
 
 		const derived = computed((): unknown => {
 			if (typeof target === 'function') {
-				// Single Signal<T> or Computed<T>
 				return target()
 			}
-			// Object of signals — unwrap each entry
 			const out: Record<string, unknown> = {}
-			for (const key in target) {
-				out[key] = target[key]()
+			for (const k in target) {
+				const val = target[k]
+				out[k] = isReactive(val) ? (val as () => unknown)() : val
 			}
 			return out
 		})

--- a/packages/vue/markput/src/components/Container.vue
+++ b/packages/vue/markput/src/components/Container.vue
@@ -2,20 +2,25 @@
 import {watch} from 'vue'
 
 import {useMarkput} from '../lib/hooks/useMarkput'
-import {useStore} from '../lib/hooks/useStore'
 import Block from './Block.vue'
 import Token from './Token.vue'
 
-const store = useStore()
+const result = useMarkput(s => ({
+	drag: s.props.drag,
+	tokens: s.state.tokens,
+	key: s.key,
+	refs: s.refs,
+	event: s.event,
+}))
 
-const drag = useMarkput(s => s.props.drag)
-const tokens = useMarkput(s => s.state.tokens)
 const containerComponent = useMarkput(s => s.computed.containerComponent)
 const containerProps = useMarkput(s => s.computed.containerProps)
 
-watch(tokens, () => store.event.afterTokensRendered(), {flush: 'post', immediate: true})
-
-const key = store.key
+watch(
+	() => result.value.tokens,
+	() => result.value.event.afterTokensRendered(),
+	{flush: 'post', immediate: true}
+)
 </script>
 
 <template>
@@ -23,16 +28,21 @@ const key = store.key
 		:is="containerComponent"
 		:ref="
 			(el: any) => {
-				store.refs.container = el?.$el ?? el
+				result.refs.container = el?.$el ?? el
 			}
 		"
 		v-bind="containerProps"
 	>
-		<template v-if="drag">
-			<Block v-for="(token, index) in tokens" :key="key.get(token)" :token="token" :block-index="index" />
+		<template v-if="result.drag">
+			<Block
+				v-for="(token, index) in result.tokens"
+				:key="result.key.get(token)"
+				:token="token"
+				:block-index="index"
+			/>
 		</template>
 		<template v-else>
-			<Token v-for="token in tokens" :key="key.get(token)" :mark="token" />
+			<Token v-for="token in result.tokens" :key="result.key.get(token)" :mark="token" />
 		</template>
 	</component>
 </template>

--- a/packages/vue/markput/src/lib/hooks/useMarkput.ts
+++ b/packages/vue/markput/src/lib/hooks/useMarkput.ts
@@ -30,7 +30,7 @@ export function useMarkput(selector: (store: Store) => Selectable<unknown> | Obj
 
 	// shallowRef + alien-signals effect bridges the two reactive systems.
 	// The effect re-runs whenever tracked signals change, updating the ref.
-	const r = shallowRef(getValue())
+	const r = shallowRef<unknown>(undefined)
 	const stop = alienEffect(() => {
 		r.value = getValue()
 	})

--- a/packages/vue/markput/src/lib/hooks/useMarkput.ts
+++ b/packages/vue/markput/src/lib/hooks/useMarkput.ts
@@ -1,11 +1,11 @@
-import {effect as alienEffect} from '@markput/core'
+import {effect as alienEffect, isReactive} from '@markput/core'
 import type {Signal, Computed, SignalValues, Store} from '@markput/core'
 import {shallowRef, onUnmounted, type Ref} from 'vue'
 
 import {useStore} from './useStore'
 
 type Selectable<T> = Signal<T> | Computed<T>
-type ObjectSelector = Record<string, Selectable<unknown>>
+type ObjectSelector = Record<string, Selectable<unknown> | unknown>
 
 export function useMarkput<T>(selector: (store: Store) => Selectable<T>): Ref<T>
 export function useMarkput<R extends ObjectSelector>(selector: (store: Store) => R): Ref<SignalValues<R>>
@@ -21,8 +21,9 @@ export function useMarkput(selector: (store: Store) => Selectable<unknown> | Obj
 			return target()
 		}
 		const out: Record<string, unknown> = {}
-		for (const key in target) {
-			out[key] = target[key]()
+		for (const k in target) {
+			const val = target[k]
+			out[k] = isReactive(val) ? (val as () => unknown)() : val
 		}
 		return out
 	}


### PR DESCRIPTION
## Summary

- Add `isReactive` type guard to distinguish Signal/Computed from plain values in object selectors
- Fix `useMarkput` hooks (React + Vue) to skip non-reactive values instead of calling them as functions
- Refactor Container components to use `useMarkput` exclusively, removing direct `useStore` imports
- Preserve `null` as valid signal default value (was incorrectly conflated with `undefined`)
- Collapse duplicated undefined branches in `signalOper` for clarity
- Add `SignalValues` passthrough for non-signal types (`T[K]` fallback instead of `never`)
- Fix `useLayoutEffect` exhaustive-deps compliance in React Container
- Eliminate double signal read on mount in Vue `useMarkput`

## Test plan

- [x] All existing unit tests pass
- [x] New tests for `isReactive`, `null` signal default, and `SignalValues` passthrough
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run build` passes