### PR TITLE
refactor(core): reactive parse pipeline, overlay & MarkHandler cleanup

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -21,7 +21,7 @@ pnpm add @markput/core
 ## Usage
 
 ```typescript
-import {annotate, denote, Parser, getTokensByValue, Store, Caret, TriggerFinder, EventBus} from '@markput/core'
+import {annotate, denote, Parser, computeTokensFromValue, Store, Caret, TriggerFinder, EventBus} from '@markput/core'
 
 // Annotate text with markup
 const annotated = annotate('@[__label__](__value__)', 'Hello', 'world')
@@ -57,7 +57,7 @@ const store = new Store()
 ### Parsing & Tokenization
 
 - `Parser` - Main parsing class for markup processing
-- `getTokensByValue(value)` - Extract tokens from annotated text
+- `computeTokensFromValue(value)` - Extract tokens from annotated text
 - `getTokensByUI(pieces)` - Convert UI pieces to tokens
 
 ### Preprocessing

--- a/packages/core/src/features/block-editing/BlockEditFeature.ts
+++ b/packages/core/src/features/block-editing/BlockEditFeature.ts
@@ -71,7 +71,7 @@ export class BlockEditFeature {
 		if (blockIndex >= rows.length) return
 
 		const token = rows[blockIndex]
-		const value = this.store.state.previousValue() ?? this.store.props.value() ?? ''
+		const value = this.store.computed.currentValue()
 		if (!this.store.props.onChange()) return
 
 		if (event.key === KEYBOARD.BACKSPACE) {
@@ -222,7 +222,7 @@ export class BlockEditFeature {
 		const rows = this.store.state.tokens()
 		const token = rows[blockIndex]
 		const blockDiv = blockDivs[blockIndex]
-		const value = this.store.state.previousValue() ?? this.store.props.value() ?? ''
+		const value = this.store.computed.currentValue()
 
 		if (!this.store.props.onChange()) return
 
@@ -348,7 +348,7 @@ export class BlockEditFeature {
 		if (blockIndex >= rows.length) return
 
 		const token = rows[blockIndex]
-		const value = this.store.state.previousValue() ?? this.store.props.value() ?? ''
+		const value = this.store.computed.currentValue()
 
 		const focusAndSetCaret = (newRawPos: number) => {
 			queueMicrotask(() => {

--- a/packages/core/src/features/clipboard/CopyFeature.ts
+++ b/packages/core/src/features/clipboard/CopyFeature.ts
@@ -59,7 +59,7 @@ export class CopyFeature {
 					first.type === 'text' ? first.position.start + result.startOffset : first.position.start
 				const rawEnd = last.type === 'text' ? last.position.start + result.endOffset : last.position.end
 
-				const value = this.store.state.previousValue() ?? this.store.props.value() ?? ''
+				const value = this.store.computed.currentValue()
 				if (rawStart === rawEnd) return
 
 				const newValue = value.slice(0, rawStart) + value.slice(rawEnd)

--- a/packages/core/src/features/editing/utils/deleteMark.spec.ts
+++ b/packages/core/src/features/editing/utils/deleteMark.spec.ts
@@ -50,7 +50,6 @@ describe('deleteMark', () => {
 		span2.parentElement = container
 
 		// oxlint-disable-next-line no-unsafe-type-assertion
-		// oxlint-disable-next-line no-unsafe-type-assertion
 		store.refs.container = container as unknown as HTMLDivElement
 		// oxlint-disable-next-line no-unsafe-type-assertion
 		store.nodes.focus.target = mark as unknown as HTMLElement

--- a/packages/core/src/features/editing/utils/deleteMark.spec.ts
+++ b/packages/core/src/features/editing/utils/deleteMark.spec.ts
@@ -1,0 +1,96 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest'
+
+import {Store} from '../../../store/Store'
+import type {Token} from '../../parsing'
+import {deleteMark} from './deleteMark'
+
+class MockHTMLElement {
+	textContent = ''
+	isContentEditable = true
+	parentElement: MockHTMLElement | null = null
+	children: MockHTMLElement[] = []
+	focus = vi.fn()
+}
+
+beforeEach(() => {
+	vi.stubGlobal('HTMLElement', MockHTMLElement)
+})
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+})
+
+describe('deleteMark', () => {
+	let store: Store
+
+	beforeEach(() => {
+		store = new Store()
+		const features = store.features as Record<string, {enable(): void; disable(): void}>
+		for (const key of Object.keys(features)) {
+			if (key === 'system') continue
+			vi.spyOn(features[key], 'enable').mockImplementation(() => {})
+			vi.spyOn(features[key], 'disable').mockImplementation(() => {})
+		}
+		store.features.system.enable()
+	})
+
+	function setupDOM() {
+		const span1 = new MockHTMLElement()
+		span1.textContent = 'hi '
+		const mark = new MockHTMLElement()
+		mark.textContent = '@user'
+		mark.isContentEditable = false
+		const span2 = new MockHTMLElement()
+		span2.textContent = ' there'
+
+		const container = new MockHTMLElement()
+		container.children = [span1, mark, span2]
+		span1.parentElement = container
+		mark.parentElement = container
+		span2.parentElement = container
+
+		// oxlint-disable-next-line no-unsafe-type-assertion
+		// oxlint-disable-next-line no-unsafe-type-assertion
+		store.refs.container = container as unknown as HTMLDivElement
+		// oxlint-disable-next-line no-unsafe-type-assertion
+		store.nodes.focus.target = mark as unknown as HTMLElement
+	}
+
+	function makeTokens(): Token[] {
+		const textToken1 = {type: 'text' as const, content: 'hi ', position: {start: 0, end: 3}}
+		// oxlint-disable-next-line no-unsafe-type-assertion
+		const markToken = {
+			type: 'mark' as const,
+			content: '@user',
+			value: 'user',
+			descriptor: {index: 0},
+			children: [],
+			position: {start: 3, end: 8},
+		} as unknown as Token
+		const textToken2 = {type: 'text' as const, content: ' there', position: {start: 8, end: 14}}
+		return [textToken1, markToken, textToken2]
+	}
+
+	it('should fire event.change after deleting a mark', () => {
+		const onChange = vi.fn()
+		store.setProps({onChange})
+		setupDOM()
+		store.state.tokens(makeTokens())
+
+		deleteMark('self', store)
+
+		expect(onChange).toHaveBeenCalled()
+	})
+
+	it('should merge adjacent text spans after deletion', () => {
+		const onChange = vi.fn()
+		store.setProps({onChange})
+		setupDOM()
+		store.state.tokens(makeTokens())
+
+		deleteMark('self', store)
+
+		expect(store.state.tokens()).toHaveLength(1)
+		expect(store.state.tokens()[0].content).toBe('hi  there')
+	})
+})

--- a/packages/core/src/features/editing/utils/deleteMark.ts
+++ b/packages/core/src/features/editing/utils/deleteMark.ts
@@ -1,6 +1,5 @@
 import {childAt} from '../../../shared/checkers'
 import type {Store} from '../../../store'
-import {toString} from '../../parsing'
 
 export function deleteMark(place: 'prev' | 'self' | 'next', store: Store) {
 	const placeMap = {
@@ -37,7 +36,7 @@ export function deleteMark(place: 'prev' | 'self' | 'next', store: Store) {
 
 	store.state.recovery({anchor: caretAnchor.prev, caret})
 
-	store.props.onChange()?.(toString(store.state.tokens()))
+	store.event.change()
 
 	queueMicrotask(() => {
 		const target = childAt(store.refs.container, targetIndex)

--- a/packages/core/src/features/events/SystemListenerFeature.ts
+++ b/packages/core/src/features/events/SystemListenerFeature.ts
@@ -24,7 +24,7 @@ export class SystemListenerFeature {
 					const serialized = toString(tokens)
 					onChange?.(serialized)
 					this.store.state.previousValue(serialized)
-					this.store.state.tokens([...tokens])
+					this.store.bumpTokens()
 					return
 				}
 

--- a/packages/core/src/features/events/SystemListenerFeature.ts
+++ b/packages/core/src/features/events/SystemListenerFeature.ts
@@ -30,6 +30,7 @@ export class SystemListenerFeature {
 
 				// User typed in a contentEditable element: sync DOM content → token state.
 				const tokens = this.store.state.tokens()
+				if (focus.index >= tokens.length) return
 				const token = tokens[focus.index]
 				if (token.type === 'text') {
 					token.content = focus.content

--- a/packages/core/src/features/input/InputFeature.ts
+++ b/packages/core/src/features/input/InputFeature.ts
@@ -141,7 +141,7 @@ function handleMarkputSpanPaste(store: Store, focus: NodeProxy, event: InputEven
 	const tokens = store.state.tokens()
 	const token = tokens[focus.index]
 	const offset = focus.caret
-	const currentValue = store.state.previousValue() ?? store.props.value() ?? ''
+	const currentValue = store.computed.currentValue()
 
 	const ranges = event.getTargetRanges()
 	const childElement = container.children[focus.index]

--- a/packages/core/src/features/mark/MarkHandler.spec.ts
+++ b/packages/core/src/features/mark/MarkHandler.spec.ts
@@ -1,0 +1,89 @@
+import {describe, it, expect} from 'vitest'
+
+import {Store} from '../../store/Store'
+import type {MarkToken} from '../parsing'
+import {MarkHandler} from './MarkHandler'
+
+function createMarkToken(overrides: Partial<MarkToken> = {}): MarkToken {
+	return {
+		type: 'mark',
+		content: '@user',
+		value: 'user',
+		descriptor: {
+			index: 0,
+			markup: '@[__value__]' as MarkToken['descriptor']['markup'],
+			segments: [],
+			gapTypes: [],
+			hasSlot: false,
+			hasTwoValues: false,
+			segmentGlobalIndices: [],
+		},
+		children: [],
+		position: {start: 0, end: 5},
+		...overrides,
+	}
+}
+
+describe('MarkHandler', () => {
+	it('should return depth 0 for top-level mark', () => {
+		const store = new Store()
+		const markToken = createMarkToken()
+		store.state.tokens([{type: 'text', content: 'hi ', position: {start: 0, end: 3}}, markToken])
+
+		const handler = new MarkHandler({ref: {current: null}, store, token: markToken})
+
+		expect(handler.depth).toBe(0)
+	})
+
+	it('should return parent as undefined for top-level mark', () => {
+		const store = new Store()
+		const markToken = createMarkToken()
+		store.state.tokens([markToken])
+
+		const handler = new MarkHandler({ref: {current: null}, store, token: markToken})
+
+		expect(handler.parent).toBeUndefined()
+	})
+
+	it('should return depth 1 for nested mark', () => {
+		const store = new Store()
+		const innerMark = createMarkToken({content: '#tag', value: 'tag', position: {start: 0, end: 4}})
+		const outerMark = createMarkToken({
+			content: '@user #tag',
+			value: 'user',
+			children: [innerMark],
+			position: {start: 0, end: 9},
+		})
+		store.state.tokens([outerMark])
+
+		const handler = new MarkHandler({ref: {current: null}, store, token: innerMark})
+
+		expect(handler.depth).toBe(1)
+	})
+
+	it('should return parent for nested mark', () => {
+		const store = new Store()
+		const innerMark = createMarkToken({content: '#tag', value: 'tag', position: {start: 0, end: 4}})
+		const outerMark = createMarkToken({
+			content: '@user #tag',
+			value: 'user',
+			children: [innerMark],
+			position: {start: 0, end: 9},
+		})
+		store.state.tokens([outerMark])
+
+		const handler = new MarkHandler({ref: {current: null}, store, token: innerMark})
+
+		expect(handler.parent).toBe(outerMark)
+	})
+
+	it('should return depth 0 when token not found in state', () => {
+		const store = new Store()
+		const markToken = createMarkToken()
+		store.state.tokens([{type: 'text', content: 'other', position: {start: 0, end: 5}}])
+
+		const handler = new MarkHandler({ref: {current: null}, store, token: markToken})
+
+		expect(handler.depth).toBe(0)
+	})
+})

--- a/packages/core/src/features/mark/MarkHandler.ts
+++ b/packages/core/src/features/mark/MarkHandler.ts
@@ -57,8 +57,12 @@ export class MarkHandler<T extends HTMLElement = HTMLElement> {
 		return this.#token.slot?.content
 	}
 
+	get #tokenInfo() {
+		return findToken(this.#store.state.tokens(), this.#token)
+	}
+
 	get depth(): number {
-		return findToken(this.#store.state.tokens(), this.#token)?.depth ?? 0
+		return this.#tokenInfo?.depth ?? 0
 	}
 
 	get hasChildren(): boolean {
@@ -66,7 +70,7 @@ export class MarkHandler<T extends HTMLElement = HTMLElement> {
 	}
 
 	get parent(): MarkToken | undefined {
-		return findToken(this.#store.state.tokens(), this.#token)?.parent
+		return this.#tokenInfo?.parent
 	}
 
 	get tokens(): Token[] {

--- a/packages/core/src/features/overlay/OverlayFeature.spec.ts
+++ b/packages/core/src/features/overlay/OverlayFeature.spec.ts
@@ -39,20 +39,12 @@ describe('OverlayFeature', () => {
 	})
 
 	describe('enable()', () => {
-		it('sets default overlayTrigger extractor', () => {
+		it('sets overlay trigger behavior for checkOverlay', () => {
 			controller.enable()
 
-			const getTrigger = store.state.overlayTrigger()
-			expect(getTrigger).toBeDefined()
+			store.event.checkOverlay()
 
-			const option = {overlay: {trigger: '@'}}
-			expect(getTrigger!(option)).toBe('@')
-
-			const optionWithoutTrigger = {overlay: {}}
-			expect(getTrigger!(optionWithoutTrigger)).toBeUndefined()
-
-			const optionWithoutOverlay = {}
-			expect(getTrigger!(optionWithoutOverlay)).toBeUndefined()
+			expect(store.state.overlayMatch()).toBeUndefined()
 
 			controller.disable()
 		})
@@ -110,14 +102,6 @@ describe('OverlayFeature', () => {
 	})
 
 	describe('disable()', () => {
-		it('clears overlayTrigger on disable', () => {
-			controller.enable()
-			expect(store.state.overlayTrigger()).toBeDefined()
-
-			controller.disable()
-			expect(store.state.overlayTrigger()).toBeUndefined()
-		})
-
 		it('should stop reacting to events after disable', () => {
 			controller.enable()
 			controller.disable()

--- a/packages/core/src/features/overlay/OverlayFeature.ts
+++ b/packages/core/src/features/overlay/OverlayFeature.ts
@@ -12,17 +12,13 @@ export class OverlayFeature {
 	enable() {
 		if (this.#scope) return
 
-		this.store.state.overlayTrigger(option => option.overlay?.trigger)
-
 		this.#scope = effectScope(() => {
 			watch(this.store.event.clearOverlay, () => {
 				this.store.state.overlayMatch(undefined)
 			})
 
 			watch(this.store.event.checkOverlay, () => {
-				const getTrigger = this.store.state.overlayTrigger()
-				if (!getTrigger) return
-				const match = TriggerFinder.find(this.store.props.options(), getTrigger)
+				const match = TriggerFinder.find(this.store.props.options(), option => option.overlay?.trigger)
 				this.store.state.overlayMatch(match)
 			})
 
@@ -79,7 +75,6 @@ export class OverlayFeature {
 	}
 
 	disable() {
-		this.store.state.overlayTrigger(undefined)
 		this.#scope?.()
 		this.#scope = undefined
 	}

--- a/packages/core/src/features/parsing/ParseFeature.spec.ts
+++ b/packages/core/src/features/parsing/ParseFeature.spec.ts
@@ -77,59 +77,6 @@ describe('ParseFeature', () => {
 		})
 	})
 
-	describe('hasChanged()', () => {
-		it('returns true before sync() is called', () => {
-			expect(store.features.parse.hasChanged()).toBe(true)
-		})
-
-		it('returns false after sync() with no value/parser change', () => {
-			store.features.parse.enable()
-			store.setProps({value: 'hello'})
-			store.features.parse.sync()
-
-			expect(store.features.parse.hasChanged()).toBe(false)
-
-			store.features.parse.disable()
-		})
-
-		it('returns true when value changes after sync()', () => {
-			store.features.parse.enable()
-			store.setProps({value: 'hello'})
-			store.features.parse.sync()
-
-			store.setProps({value: 'world'})
-
-			expect(store.features.parse.hasChanged()).toBe(true)
-
-			store.features.parse.disable()
-		})
-
-		it('returns true when parser changes after sync()', () => {
-			store.features.parse.enable()
-			store.setProps({Mark: () => null, options: [{markup: '@[__value__]'}], value: 'hello'})
-			store.features.parse.sync()
-
-			store.setProps({options: [{markup: '#[__value__]'}]})
-
-			expect(store.features.parse.hasChanged()).toBe(true)
-
-			store.features.parse.disable()
-		})
-
-		it('updates internal cache as side effect', () => {
-			store.features.parse.enable()
-			store.setProps({value: 'hello'})
-			store.features.parse.sync()
-
-			store.setProps({value: 'world'})
-			store.features.parse.hasChanged()
-
-			expect(store.features.parse.hasChanged()).toBe(false)
-
-			store.features.parse.disable()
-		})
-	})
-
 	describe('enable() / disable()', () => {
 		it('is idempotent — calling enable twice does not double-subscribe', () => {
 			store.features.parse.enable()
@@ -175,6 +122,34 @@ describe('ParseFeature', () => {
 			store.features.parse.sync()
 
 			expect(store.state.tokens()).toEqual([{type: 'text', content: 'second', position: {start: 0, end: 6}}])
+
+			store.features.parse.disable()
+		})
+	})
+
+	describe('reactive parse', () => {
+		it('reactively re-parses when props.value changes', () => {
+			store.features.parse.enable()
+			store.setProps({value: 'hello'})
+			store.features.parse.sync()
+
+			store.setProps({value: 'world'})
+
+			expect(store.state.tokens()).toEqual([{type: 'text', content: 'world', position: {start: 0, end: 5}}])
+			expect(store.state.previousValue()).toBe('world')
+
+			store.features.parse.disable()
+		})
+
+		it('does not re-parse in recovery mode when props.value changes', () => {
+			store.features.parse.enable()
+			store.setProps({value: 'hello'})
+			store.features.parse.sync()
+
+			store.state.recovery({caret: 0, anchor: store.nodes.focus})
+			store.setProps({value: 'world'})
+
+			expect(store.state.tokens()).toEqual([{type: 'text', content: 'hello', position: {start: 0, end: 5}}])
 
 			store.features.parse.disable()
 		})

--- a/packages/core/src/features/parsing/ParseFeature.ts
+++ b/packages/core/src/features/parsing/ParseFeature.ts
@@ -1,7 +1,7 @@
 import {computed, effectScope, watch} from '../../shared/signals/index.js'
 import type {Store} from '../../store/Store'
 import {toString} from './parser/utils/toString'
-import {getTokensByUI, getTokensByValue, parseWithParser} from './utils/valueParser'
+import {getTokensByUI, computeTokensFromValue, parseWithParser} from './utils/valueParser'
 
 export class ParseFeature {
 	#scope?: () => void
@@ -39,7 +39,7 @@ export class ParseFeature {
 				store.state.previousValue(text)
 				return
 			}
-			store.state.tokens(store.nodes.focus.target ? getTokensByUI(store) : getTokensByValue(store))
+			store.state.tokens(store.nodes.focus.target ? getTokensByUI(store) : computeTokensFromValue(store))
 		})
 	}
 

--- a/packages/core/src/features/parsing/ParseFeature.ts
+++ b/packages/core/src/features/parsing/ParseFeature.ts
@@ -50,9 +50,7 @@ export class ParseFeature {
 
 		watch(deps, () => {
 			if (!store.state.recovery()) {
-				const value = store.props.value() ?? ''
-				store.state.tokens(parseWithParser(store, value))
-				store.state.previousValue(value)
+				store.event.parse()
 			}
 		})
 	}

--- a/packages/core/src/features/parsing/ParseFeature.ts
+++ b/packages/core/src/features/parsing/ParseFeature.ts
@@ -1,14 +1,10 @@
-import {effectScope, watch} from '../../shared/signals/index.js'
+import {computed, effectScope, watch} from '../../shared/signals/index.js'
 import type {Store} from '../../store/Store'
-import type {Parser} from './parser/Parser'
 import {toString} from './parser/utils/toString'
 import {getTokensByUI, getTokensByValue, parseWithParser} from './utils/valueParser'
 
 export class ParseFeature {
 	#scope?: () => void
-	#initialized = false
-	#lastValue: string | undefined
-	#lastParser: Parser | undefined
 
 	constructor(private readonly store: Store) {}
 
@@ -17,12 +13,11 @@ export class ParseFeature {
 		this.sync()
 		this.#scope = effectScope(() => {
 			this.#subscribeParse()
-			this.#subscribeUpdated()
+			this.#subscribeReactiveParse()
 		})
 	}
 
 	disable() {
-		this.#initialized = false
 		this.#scope?.()
 		this.#scope = undefined
 	}
@@ -32,18 +27,6 @@ export class ParseFeature {
 		const inputValue = store.props.value() ?? store.props.defaultValue() ?? ''
 		store.state.tokens(parseWithParser(store, inputValue))
 		store.state.previousValue(inputValue)
-		this.#lastValue = store.props.value()
-		this.#lastParser = store.computed.parser()
-		this.#initialized = true
-	}
-
-	hasChanged(): boolean {
-		const value = this.store.props.value()
-		const parser = this.store.computed.parser()
-		if (this.#initialized && value === this.#lastValue && parser === this.#lastParser) return false
-		this.#lastValue = value
-		this.#lastParser = parser
-		return true
 	}
 
 	#subscribeParse() {
@@ -60,13 +43,16 @@ export class ParseFeature {
 		})
 	}
 
-	#subscribeUpdated() {
+	#subscribeReactiveParse() {
 		const {store} = this
 
-		watch(store.event.updated, () => {
-			if (!this.hasChanged()) return
+		const deps = computed(() => [store.props.value(), store.computed.parser()] as const)
+
+		watch(deps, () => {
 			if (!store.state.recovery()) {
-				store.event.parse()
+				const value = store.props.value() ?? ''
+				store.state.tokens(parseWithParser(store, value))
+				store.state.previousValue(value)
 			}
 		})
 	}

--- a/packages/core/src/features/parsing/index.ts
+++ b/packages/core/src/features/parsing/index.ts
@@ -8,5 +8,11 @@ export {denote} from './parser/utils/denote'
 export {toString} from './parser/utils/toString'
 export {findToken} from './utils/findToken'
 export type {TokenContext} from './utils/findToken'
-export {getTokensByUI, getTokensByValue, parseUnionLabels, getRangeMap, parseWithParser} from './utils/valueParser'
+export {
+	getTokensByUI,
+	computeTokensFromValue,
+	parseUnionLabels,
+	getRangeMap,
+	parseWithParser,
+} from './utils/valueParser'
 export {ParseFeature} from './ParseFeature'

--- a/packages/core/src/features/parsing/utils/valueParser.ts
+++ b/packages/core/src/features/parsing/utils/valueParser.ts
@@ -20,15 +20,21 @@ export function getTokensByUI(store: Store): Token[] {
 
 export function computeTokensFromValue(store: Store): Token[] {
 	const value = store.props.value()
-	const ranges = getRangeMap(store)
-	const gap = findGap(store.state.previousValue(), value)
+	const previousValue = store.state.previousValue()
+	const gap = findGap(previousValue, value)
 
 	if (!gap.left && !gap.right) {
 		store.state.previousValue(value)
 		return store.state.tokens()
 	}
 
+	if (gap.left === 0 && previousValue !== undefined && gap.right !== undefined && gap.right >= previousValue.length) {
+		store.state.previousValue(value)
+		return parseWithParser(store, value ?? '')
+	}
+
 	store.state.previousValue(value)
+	const ranges = getRangeMap(store)
 	const tokens = store.state.tokens()
 
 	if (
@@ -38,8 +44,10 @@ export function computeTokensFromValue(store: Store): Token[] {
 		Math.abs(gap.left - gap.right) > 1
 	) {
 		const updatedIndex = ranges.indexOf(gap.left)
-		const parsed = parseUnionLabels(store, updatedIndex - 1, updatedIndex)
-		return tokens.toSpliced(updatedIndex - 1, 2, ...parsed)
+		if (updatedIndex > 0) {
+			const parsed = parseUnionLabels(store, updatedIndex - 1, updatedIndex)
+			return tokens.toSpliced(updatedIndex - 1, 2, ...parsed)
+		}
 	}
 	if (gap.left !== undefined) {
 		const [updatedIndex] = getClosestIndexes(ranges, gap.left)

--- a/packages/core/src/features/parsing/utils/valueParser.ts
+++ b/packages/core/src/features/parsing/utils/valueParser.ts
@@ -28,6 +28,7 @@ export function computeTokensFromValue(store: Store): Token[] {
 		return store.state.tokens()
 	}
 
+	// Full value replacement — incremental diff won't work, re-parse from scratch
 	if (gap.left === 0 && previousValue !== undefined && gap.right !== undefined && gap.right >= previousValue.length) {
 		store.state.previousValue(value)
 		return parseWithParser(store, value ?? '')

--- a/packages/core/src/features/parsing/utils/valueParser.ts
+++ b/packages/core/src/features/parsing/utils/valueParser.ts
@@ -6,15 +6,9 @@ export function getTokensByUI(store: Store): Token[] {
 	const {focus} = store.nodes
 	const parser = store.computed.parser()
 	const tokens = store.state.tokens()
-
-	if (!parser) {
-		return tokens
-	}
-
+	if (!parser) return tokens
 	const parsed = parser.parse(focus.content)
-
-	if (parsed.length === 1) return tokens
-
+	if (parsed.length <= 1) return tokens
 	return tokens.toSpliced(focus.index, 1, ...parsed)
 }
 

--- a/packages/core/src/features/parsing/utils/valueParser.ts
+++ b/packages/core/src/features/parsing/utils/valueParser.ts
@@ -18,7 +18,7 @@ export function getTokensByUI(store: Store): Token[] {
 	return tokens.toSpliced(focus.index, 1, ...parsed)
 }
 
-export function getTokensByValue(store: Store): Token[] {
+export function computeTokensFromValue(store: Store): Token[] {
 	const value = store.props.value()
 	const ranges = getRangeMap(store)
 	const gap = findGap(store.state.previousValue(), value)

--- a/packages/core/src/store/README.md
+++ b/packages/core/src/store/README.md
@@ -5,9 +5,9 @@ The central orchestrator of the markput system. Aggregates reactive state, compu
 ## Components
 
 - **Store**: Main state container that manages:
-    - **Internal state** (`store.state`) — signals owned by features: tokens, previous value, inner value, recovery, selection mode, overlay match/trigger
+    - **Internal state** (`store.state`) — signals owned by features: tokens, previous value, inner value, recovery, selection mode, overlay match
     - **Props** (`store.props`) — readonly signals written only via `setProps()` (value, options, readOnly, drag, slots, etc.)
-    - **Computed** (`store.computed`) — derived values: `hasMark`, `parser`, `containerClass`, `containerStyle`, slot resolvers
+    - **Computed** (`store.computed`) — derived values: `hasMark`, `parser`, `currentValue`, `containerComponent`, `containerProps`, slot resolvers
     - **Events** (`store.event`) — typed events: change, parse, delete, select, overlay, sync, focus, drag, lifecycle, and more
     - **DOM refs** (`store.refs`) — container and overlay HTMLElement references
     - **Node proxies** (`store.nodes`) — `focus` and `input` NodeProxy instances

--- a/packages/core/src/store/Store.spec.ts
+++ b/packages/core/src/store/Store.spec.ts
@@ -460,4 +460,45 @@ describe('Store', () => {
 			expect(props).toEqual({})
 		})
 	})
+
+	describe('currentValue (computed)', () => {
+		it('should return empty string when both previousValue and value are undefined', () => {
+			const store = new Store()
+			expect(store.computed.currentValue()).toBe('')
+		})
+
+		it('should return previousValue when set', () => {
+			const store = new Store()
+			store.state.previousValue('cached')
+			expect(store.computed.currentValue()).toBe('cached')
+		})
+
+		it('should fall back to props.value when previousValue is undefined', () => {
+			const store = new Store()
+			store.setProps({value: 'prop-value'})
+			expect(store.computed.currentValue()).toBe('prop-value')
+		})
+
+		it('should prefer previousValue over props.value', () => {
+			const store = new Store()
+			store.state.previousValue('cached')
+			store.setProps({value: 'prop-value'})
+			expect(store.computed.currentValue()).toBe('cached')
+		})
+
+		it('should react to previousValue changes', () => {
+			const store = new Store()
+			expect(store.computed.currentValue()).toBe('')
+			store.state.previousValue('updated')
+			expect(store.computed.currentValue()).toBe('updated')
+		})
+
+		it('should react to props.value changes when previousValue is undefined', () => {
+			const store = new Store()
+			store.setProps({value: 'initial'})
+			expect(store.computed.currentValue()).toBe('initial')
+			store.setProps({value: 'changed'})
+			expect(store.computed.currentValue()).toBe('changed')
+		})
+	})
 })

--- a/packages/core/src/store/Store.ts
+++ b/packages/core/src/store/Store.ts
@@ -113,6 +113,7 @@ export class Store {
 		isBlock: Computed<boolean>
 		isDraggable: Computed<boolean>
 		parser: Computed<Parser | undefined>
+		currentValue: Computed<string>
 		containerComponent: Computed<unknown>
 		containerProps: Computed<{className: string | undefined; style?: CSSProperties; [key: string]: unknown}>
 		blockComponent: Computed<unknown>
@@ -137,6 +138,7 @@ export class Store {
 
 			return new Parser(markups, this.computed.isBlock() ? {skipEmptyText: true} : undefined)
 		}),
+		currentValue: computed(() => this.state.previousValue() ?? this.props.value() ?? ''),
 		containerComponent: computed(() => resolveSlot('container', this.props.slots())),
 		containerProps: computed(
 			() =>

--- a/packages/core/src/store/Store.ts
+++ b/packages/core/src/store/Store.ts
@@ -105,7 +105,6 @@ export class Store {
 
 		// Overlay (internally managed by OverlayFeature)
 		overlayMatch: signal<OverlayMatch | undefined>(undefined),
-		overlayTrigger: signal<((option: CoreOption) => string | undefined) | undefined>(undefined),
 	}
 
 	readonly computed: {

--- a/packages/core/src/store/Store.ts
+++ b/packages/core/src/store/Store.ts
@@ -238,4 +238,8 @@ export class Store {
 			{mutable: true}
 		)
 	}
+
+	bumpTokens(): void {
+		this.state.tokens([...this.state.tokens()])
+	}
 }

--- a/packages/react/markput/src/components/Suggestions/Suggestions.tsx
+++ b/packages/react/markput/src/components/Suggestions/Suggestions.tsx
@@ -11,8 +11,8 @@ export const Suggestions = () => {
 	const store = useStore()
 	const {match, select, style, ref} = useOverlay()
 	const [active, setActive] = useState(NaN)
-	const data = match.option.overlay?.data ?? []
-	const filtered = useMemo(() => filterSuggestions(data, match.value), [match.value, data])
+	const data = match?.option.overlay?.data ?? []
+	const filtered = useMemo(() => (match ? filterSuggestions(data, match.value) : []), [match, data])
 	const length = filtered.length
 
 	// Refs let the handler always read the latest values without re-registering

--- a/packages/react/markput/src/lib/hooks/useOverlay.tsx
+++ b/packages/react/markput/src/lib/hooks/useOverlay.tsx
@@ -14,19 +14,23 @@ export interface OverlayHandler {
 	}
 	close: () => void
 	select: (value: {value: string; meta?: string}) => void
-	match: OverlayMatch<Option>
+	match: OverlayMatch<Option> | undefined
 	ref: RefObject<HTMLElement | null>
 }
 
 export function useOverlay(): OverlayHandler {
 	const store = useStore()
 	const match = useMarkput(s => s.state.overlayMatch)
-	if (!match) throw new Error('useOverlay requires an active overlay match')
-	const style = useMemo(() => Caret.getAbsolutePosition(), [match])
+
+	const style = useMemo(() => {
+		if (!match) return {left: 0, top: 0}
+		return Caret.getAbsolutePosition()
+	}, [match])
 
 	const close = useCallback(() => store.event.clearOverlay(), [])
 	const select = useCallback(
 		(value: {value: string; meta?: string}) => {
+			if (!match) return
 			const mark = createMarkFromOverlay(match, value.value, value.meta)
 			store.event.select({mark, match})
 			store.event.clearOverlay()

--- a/packages/storybook/src/pages/Material/components/MaterialMentions/UserList/UserList.tsx
+++ b/packages/storybook/src/pages/Material/components/MaterialMentions/UserList/UserList.tsx
@@ -6,12 +6,9 @@ import {useFetch} from '../utils/useFetch'
 import {UserItem} from './UserItem'
 
 export const UserList = () => {
-	const {
-		select,
-		match: {value},
-		style,
-	} = useOverlay()
-	const [data] = useFetch<{items: SearchUser[]}>(`https://api.github.com/search/users?q=${value}`, [value])
+	const {select, match, style} = useOverlay()
+	const matchValue = match?.value
+	const [data] = useFetch<{items: SearchUser[]}>(`https://api.github.com/search/users?q=${matchValue}`, [matchValue])
 	const users = data?.items ?? []
 
 	if (users.length === 0) return null

--- a/packages/storybook/src/pages/Overlay/Overlay.vue.stories.ts
+++ b/packages/storybook/src/pages/Overlay/Overlay.vue.stories.ts
@@ -67,8 +67,8 @@ const Tooltip = defineComponent({
 				{
 					style: {
 						position: 'absolute',
-						left: style.value.left,
-						top: style.value.top,
+						left: `${style.value.left}px`,
+						top: `${style.value.top}px`,
 					},
 				},
 				'I am the overlay'

--- a/packages/storybook/src/pages/Rsuite/Rsuite.react.stories.tsx
+++ b/packages/storybook/src/pages/Rsuite/Rsuite.react.stories.tsx
@@ -21,6 +21,7 @@ const Overlay = () => {
 		const handleEnter = (ev: KeyboardEvent) => {
 			if (ev.key === 'Enter') {
 				ev.preventDefault()
+				if (!match) return
 				select({value: match.value})
 				close()
 			}
@@ -34,7 +35,7 @@ const Overlay = () => {
 		<Popover style={style} visible>
 			<i>
 				{' '}
-				Press the <b>'Enter'</b> to create: <b>{match.value}</b>{' '}
+				Press the <b>'Enter'</b> to create: <b>{match?.value}</b>{' '}
 			</i>
 		</Popover>
 	)

--- a/packages/vue/markput/src/lib/hooks/useOverlay.ts
+++ b/packages/vue/markput/src/lib/hooks/useOverlay.ts
@@ -8,8 +8,8 @@ import {useStore} from './useStore'
 
 export interface OverlayHandler {
 	style: ComputedRef<{
-		left: string
-		top: string
+		left: number
+		top: number
 	}>
 	close: () => void
 	select: (value: {value: string; meta?: string}) => void
@@ -28,11 +28,8 @@ export function useOverlay(): OverlayHandler {
 		// Depend on matchRef so position recalculates as user types/moves caret
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		const _ = matchRef.value
-		const pos = Caret.getAbsolutePosition()
-		return {
-			left: `${pos.left}px`,
-			top: `${pos.top}px`,
-		}
+		if (!matchRef.value) return {left: 0, top: 0}
+		return Caret.getAbsolutePosition()
 	})
 
 	const close = () => store.event.clearOverlay()

--- a/packages/website/src/components/demos/Step3Demo.tsx
+++ b/packages/website/src/components/demos/Step3Demo.tsx
@@ -13,11 +13,11 @@ const CustomOverlay = () => {
 	const [users, setUsers] = useState<{login: string; avatar_url: string}[]>([])
 
 	useEffect(() => {
-		if (!match.value) return
+		if (!match?.value) return
 		fetch(`https://api.github.com/search/users?q=${match.value}`)
 			.then(res => res.json())
 			.then(data => setUsers(data.items?.slice(0, 10) || []))
-	}, [match.value])
+	}, [match?.value])
 
 	return (
 		<div

--- a/packages/website/src/content/docs/api/classes/MarkHandler.md
+++ b/packages/website/src/content/docs/api/classes/MarkHandler.md
@@ -86,7 +86,7 @@ Defined in: [core/src/features/mark/MarkHandler.ts:33](https://github.com/Nowely
 get depth(): number;
 ```
 
-Defined in: [core/src/features/mark/MarkHandler.ts:60](https://github.com/Nowely/marked-input/blob/next/packages/core/src/features/mark/MarkHandler.ts#L60)
+Defined in: [core/src/features/mark/MarkHandler.ts:64](https://github.com/Nowely/marked-input/blob/next/packages/core/src/features/mark/MarkHandler.ts#L64)
 
 ##### Returns
 
@@ -102,7 +102,7 @@ Defined in: [core/src/features/mark/MarkHandler.ts:60](https://github.com/Nowely
 get hasChildren(): boolean;
 ```
 
-Defined in: [core/src/features/mark/MarkHandler.ts:64](https://github.com/Nowely/marked-input/blob/next/packages/core/src/features/mark/MarkHandler.ts#L64)
+Defined in: [core/src/features/mark/MarkHandler.ts:68](https://github.com/Nowely/marked-input/blob/next/packages/core/src/features/mark/MarkHandler.ts#L68)
 
 ##### Returns
 
@@ -152,7 +152,7 @@ Defined in: [core/src/features/mark/MarkHandler.ts:51](https://github.com/Nowely
 get parent(): MarkToken | undefined;
 ```
 
-Defined in: [core/src/features/mark/MarkHandler.ts:68](https://github.com/Nowely/marked-input/blob/next/packages/core/src/features/mark/MarkHandler.ts#L68)
+Defined in: [core/src/features/mark/MarkHandler.ts:72](https://github.com/Nowely/marked-input/blob/next/packages/core/src/features/mark/MarkHandler.ts#L72)
 
 ##### Returns
 
@@ -218,7 +218,7 @@ Defined in: [core/src/features/mark/MarkHandler.ts:56](https://github.com/Nowely
 get tokens(): Token[];
 ```
 
-Defined in: [core/src/features/mark/MarkHandler.ts:72](https://github.com/Nowely/marked-input/blob/next/packages/core/src/features/mark/MarkHandler.ts#L72)
+Defined in: [core/src/features/mark/MarkHandler.ts:76](https://github.com/Nowely/marked-input/blob/next/packages/core/src/features/mark/MarkHandler.ts#L76)
 
 ##### Returns
 
@@ -266,7 +266,7 @@ Defined in: [core/src/features/mark/MarkHandler.ts:42](https://github.com/Nowely
 change(props): void;
 ```
 
-Defined in: [core/src/features/mark/MarkHandler.ts:76](https://github.com/Nowely/marked-input/blob/next/packages/core/src/features/mark/MarkHandler.ts#L76)
+Defined in: [core/src/features/mark/MarkHandler.ts:80](https://github.com/Nowely/marked-input/blob/next/packages/core/src/features/mark/MarkHandler.ts#L80)
 
 #### Parameters
 
@@ -289,7 +289,7 @@ Defined in: [core/src/features/mark/MarkHandler.ts:76](https://github.com/Nowely
 remove(): void;
 ```
 
-Defined in: [core/src/features/mark/MarkHandler.ts:85](https://github.com/Nowely/marked-input/blob/next/packages/core/src/features/mark/MarkHandler.ts#L85)
+Defined in: [core/src/features/mark/MarkHandler.ts:89](https://github.com/Nowely/marked-input/blob/next/packages/core/src/features/mark/MarkHandler.ts#L89)
 
 #### Returns
 

--- a/packages/website/src/content/docs/api/interfaces/OverlayHandler.md
+++ b/packages/website/src/content/docs/api/interfaces/OverlayHandler.md
@@ -26,7 +26,9 @@ Defined in: [react/markput/src/lib/hooks/useOverlay.tsx:15](https://github.com/N
 ### match
 
 ```ts
-match: OverlayMatch<Option<MarkProps, OverlayProps>>;
+match: 
+  | OverlayMatch<Option<MarkProps, OverlayProps>>
+  | undefined;
 ```
 
 Defined in: [react/markput/src/lib/hooks/useOverlay.tsx:17](https://github.com/Nowely/marked-input/blob/next/packages/react/markput/src/lib/hooks/useOverlay.tsx#L17)

--- a/packages/website/src/content/docs/development/architecture.md
+++ b/packages/website/src/content/docs/development/architecture.md
@@ -98,7 +98,7 @@ Both framework adapters share the same component structure:
 9. FocusFeature restores caret position via store.event.recoverFocus
 ```
 
-There are **two parse paths**: `getTokensByUI` (user editing — re-parses only the focused element) and `getTokensByValue` (prop change — diffs old vs new value, re-parses changed range).
+There are **two parse paths**: `getTokensByUI` (user editing — re-parses only the focused element) and `computeTokensFromValue` (prop change — diffs old vs new value, re-parses changed range).
 
 ### Trigger Flow (Overlay Opens)
 


### PR DESCRIPTION
## Summary

- Replace `ParseFeature.hasChanged()` manual caching with reactive `computed` watch on `value`/`parser` — removes stale-state bugs and simplifies the parse pipeline
- Add `store.computed.currentValue` to deduplicate `previousValue() ?? props.value() ?? ''` expressions across BlockEditFeature, CopyFeature, InputFeature, and deleteMark
- Rename `getTokensByValue` → `computeTokensFromValue` and fix full-replacement crash when the entire value is overwritten
- Route `deleteMark` through `store.event.change()` instead of calling `onChange` directly
- Extract `store.bumpTokens()` helper and use it in SystemListenerFeature
- Remove `overlayTrigger` from store state — inline the extractor in `OverlayFeature.checkOverlay`, guard null match in `useOverlay` (React + Vue), switch to numeric style values
- Deduplicate `MarkHandler.findToken` calls via shared `#tokenInfo` getter
- Update docs (README, API references, architecture) to reflect all renames and signature changes
- Add unit tests for `deleteMark`, `MarkHandler.depth/parent`, `Store.currentValue`, and reactive parse behavior