### PR TITLE
refactor(react): remove useStore hook, consolidate into useMarkput

### DIFF
--- a/packages/react/markput/src/components/Block.tsx
+++ b/packages/react/markput/src/components/Block.tsx
@@ -4,7 +4,6 @@ import type {CSSProperties} from 'react'
 import {memo} from 'react'
 
 import {useMarkput} from '../lib/hooks/useMarkput'
-import {useStore} from '../lib/providers/StoreContext'
 import {BlockMenu} from './BlockMenu'
 import {DragHandle} from './DragHandle'
 import {DropIndicator} from './DropIndicator'
@@ -17,18 +16,19 @@ interface BlockProps {
 }
 
 export const Block = memo(({token}: BlockProps) => {
-	const store = useStore()
-	const blockStore = store.blocks.get(token)
-
-	const Component = useMarkput(s => s.computed.blockComponent)
-	const slotProps = useMarkput(s => s.computed.blockProps)
-	const isDragging = useMarkput(() => blockStore.state.isDragging)
-	const tokens = useMarkput(s => s.state.tokens)
+	const {blockStore, event, Component, slotProps, isDragging, tokens} = useMarkput(s => ({
+		blockStore: s.blocks.get(token),
+		event: s.event,
+		Component: s.computed.blockComponent,
+		slotProps: s.computed.blockProps,
+		isDragging: s.blocks.get(token).state.isDragging,
+		tokens: s.state.tokens,
+	}))
 	const blockIndex = tokens.indexOf(token)
 
 	return (
 		<Component
-			ref={(el: HTMLElement | null) => blockStore.attachContainer(el, blockIndex, store.event)}
+			ref={(el: HTMLElement | null) => blockStore.attachContainer(el, blockIndex, event)}
 			data-testid="block"
 			{...slotProps}
 			// oxlint-disable-next-line no-unsafe-type-assertion -- slotProps.className is raw and needs casting to string

--- a/packages/react/markput/src/components/BlockMenu.tsx
+++ b/packages/react/markput/src/components/BlockMenu.tsx
@@ -3,7 +3,6 @@ import type {Token} from '@markput/core'
 import {memo} from 'react'
 
 import {useMarkput} from '../lib/hooks/useMarkput'
-import {useStore} from '../lib/providers/StoreContext'
 import {List} from './Popup/List'
 import {ListItem} from './Popup/ListItem'
 import {Popup} from './Popup/Popup'
@@ -11,11 +10,10 @@ import {Popup} from './Popup/Popup'
 import styles from '@markput/core/styles.module.css'
 
 export const BlockMenu = memo(({token}: {token: Token}) => {
-	const store = useStore()
-	const blockStore = store.blocks.get(token)
-	const {menuOpen, menuPosition} = useMarkput(() => ({
-		menuOpen: blockStore.state.menuOpen,
-		menuPosition: blockStore.state.menuPosition,
+	const {blockStore, menuOpen, menuPosition} = useMarkput(s => ({
+		blockStore: s.blocks.get(token),
+		menuOpen: s.blocks.get(token).state.menuOpen,
+		menuPosition: s.blocks.get(token).state.menuPosition,
 	}))
 
 	if (!menuOpen) return null

--- a/packages/react/markput/src/components/DragHandle.tsx
+++ b/packages/react/markput/src/components/DragHandle.tsx
@@ -3,22 +3,20 @@ import type {Token as TokenType} from '@markput/core'
 import {memo, useMemo} from 'react'
 
 import {useMarkput} from '../lib/hooks/useMarkput'
-import {useStore} from '../lib/providers/StoreContext'
 
 import styles from '@markput/core/styles.module.css'
 
 const iconGrip = `${styles.Icon} ${styles.IconGrip}`
 
 export const DragHandle = memo(({token, blockIndex}: {token: TokenType; blockIndex: number}) => {
-	const store = useStore()
-	const blockStore = store.blocks.get(token)
-
-	const {readOnly, draggable} = useMarkput(s => ({
+	const {blockStore, event, readOnly, draggable, isDragging, isHovered} = useMarkput(s => ({
+		blockStore: s.blocks.get(token),
+		event: s.event,
 		readOnly: s.props.readOnly,
 		draggable: s.props.draggable,
+		isDragging: s.blocks.get(token).state.isDragging,
+		isHovered: s.blocks.get(token).state.isHovered,
 	}))
-	const isDragging = useMarkput(() => blockStore.state.isDragging)
-	const isHovered = useMarkput(() => blockStore.state.isHovered)
 	const alwaysShowHandle = useMemo(() => getAlwaysShowHandle(draggable), [draggable])
 
 	if (readOnly) return null
@@ -31,7 +29,7 @@ export const DragHandle = memo(({token, blockIndex}: {token: TokenType; blockInd
 			)}
 		>
 			<button
-				ref={(el: HTMLButtonElement | null) => blockStore.attachGrip(el, blockIndex, store.event)}
+				ref={(el: HTMLButtonElement | null) => blockStore.attachGrip(el, blockIndex, event)}
 				type="button"
 				draggable
 				className={cx(styles.GripButton, isDragging && styles.GripButtonDragging)}

--- a/packages/react/markput/src/components/DropIndicator.tsx
+++ b/packages/react/markput/src/components/DropIndicator.tsx
@@ -2,13 +2,11 @@ import type {Token as TokenType} from '@markput/core'
 import {memo} from 'react'
 
 import {useMarkput} from '../lib/hooks/useMarkput'
-import {useStore} from '../lib/providers/StoreContext'
 
 import styles from '@markput/core/styles.module.css'
 
 export const DropIndicator = memo(({token, position}: {token: TokenType; position: 'before' | 'after'}) => {
-	const blockStore = useStore().blocks.get(token)
-	const dropPosition = useMarkput(() => blockStore.state.dropPosition)
+	const dropPosition = useMarkput(s => s.blocks.get(token).state.dropPosition)
 
 	if (dropPosition !== position) return null
 

--- a/packages/react/markput/src/components/OverlayRenderer.tsx
+++ b/packages/react/markput/src/components/OverlayRenderer.tsx
@@ -1,15 +1,20 @@
 import {memo, useMemo} from 'react'
 
 import {useMarkput} from '../lib/hooks/useMarkput'
-import {useStore} from '../lib/providers/StoreContext'
 import {Suggestions} from './Suggestions'
 
 export const OverlayRenderer = memo(() => {
-	const store = useStore()
-	const overlayMatch = useMarkput(s => s.state.overlayMatch)
-	const key = useMemo(() => (overlayMatch ? store.key.get(overlayMatch.option) : undefined), [overlayMatch])
+	const {
+		overlayMatch,
+		key: keyGen,
+		resolveOverlay,
+	} = useMarkput(s => ({
+		overlayMatch: s.state.overlayMatch,
+		key: s.key,
+		resolveOverlay: s.computed.overlay,
+	}))
+	const key = useMemo(() => (overlayMatch ? keyGen.get(overlayMatch.option) : undefined), [overlayMatch])
 
-	const resolveOverlay = useMarkput(s => s.computed.overlay)
 	const [Overlay, props] = resolveOverlay(overlayMatch?.option, Suggestions)
 
 	if (!key) return

--- a/packages/react/markput/src/components/Suggestions/Suggestions.tsx
+++ b/packages/react/markput/src/components/Suggestions/Suggestions.tsx
@@ -1,29 +1,27 @@
 import {filterSuggestions, navigateSuggestions} from '@markput/core'
 import {useEffect, useMemo, useRef, useState} from 'react'
 
+import {useMarkput} from '../../lib/hooks/useMarkput'
 import {useOverlay} from '../../lib/hooks/useOverlay'
-import {useStore} from '../../lib/providers/StoreContext'
 import {List} from '../Popup/List'
 import {ListItem} from '../Popup/ListItem'
 import {Popup} from '../Popup/Popup'
 
 export const Suggestions = () => {
-	const store = useStore()
+	const {state} = useMarkput(s => ({state: s.state}))
 	const {match, select, style, ref} = useOverlay()
 	const [active, setActive] = useState(NaN)
 	const data = match?.option.overlay?.data ?? []
 	const filtered = useMemo(() => (match ? filterSuggestions(data, match.value) : []), [match, data])
 	const length = filtered.length
 
-	// Refs let the handler always read the latest values without re-registering
-	// the listener on every keypress (which happened when `active` was a dep).
 	const activeRef = useRef(active)
 	activeRef.current = active
 	const filteredRef = useRef(filtered)
 	filteredRef.current = filtered
 
 	useEffect(() => {
-		const container = store.state.container()
+		const container = state.container()
 		if (!container) return
 
 		const handler = (event: KeyboardEvent) => {

--- a/packages/react/markput/src/components/Token.tsx
+++ b/packages/react/markput/src/components/Token.tsx
@@ -2,17 +2,18 @@ import type {Token as TokenType} from '@markput/core'
 import {memo} from 'react'
 
 import {useMarkput} from '../lib/hooks/useMarkput'
-import {useStore} from '../lib/providers/StoreContext'
 import {TokenContext} from '../lib/providers/TokenContext'
 
 export const Token = memo(({mark}: {mark: TokenType}) => {
-	const store = useStore()
-	const resolveMarkSlot = useMarkput(s => s.computed.mark)
+	const {resolveMarkSlot, key} = useMarkput(s => ({
+		resolveMarkSlot: s.computed.mark,
+		key: s.key,
+	}))
 	const [Component, props] = resolveMarkSlot(mark)
 
 	const children =
 		mark.type === 'mark' && mark.children.length > 0
-			? mark.children.map(child => <Token key={store.key.get(child)} mark={child} />)
+			? mark.children.map(child => <Token key={key.get(child)} mark={child} />)
 			: undefined
 
 	return (

--- a/packages/react/markput/src/lib/hooks/useMark.tsx
+++ b/packages/react/markput/src/lib/hooks/useMark.tsx
@@ -2,12 +2,11 @@ import type {MarkOptions, MarkToken} from '@markput/core'
 import {MarkHandler} from '@markput/core'
 import {useEffect, useMemo, useRef} from 'react'
 
-import {useStore} from '../providers/StoreContext'
 import {useToken} from '../providers/TokenContext'
 import {useMarkput} from './useMarkput'
 
 export const useMark = <T extends HTMLElement = HTMLElement>(options: MarkOptions = {}): MarkHandler<T> => {
-	const store = useStore()
+	const {store, readOnly} = useMarkput(s => ({store: s, readOnly: s.props.readOnly}))
 	const token = useToken()
 	if (token.type !== 'mark') throw new Error('useMark must be called within a mark token context')
 	const ref = useRef<T>(null)
@@ -16,7 +15,6 @@ export const useMark = <T extends HTMLElement = HTMLElement>(options: MarkOption
 
 	useUncontrolledInit(ref, options, token)
 
-	const readOnly = useMarkput(s => s.props.readOnly)
 	useEffect(() => {
 		mark.readOnly = readOnly
 	}, [mark, readOnly])

--- a/packages/react/markput/src/lib/hooks/useMarkput.ts
+++ b/packages/react/markput/src/lib/hooks/useMarkput.ts
@@ -1,8 +1,8 @@
 import {computed, watch, isReactive} from '@markput/core'
 import type {Signal, Computed, SignalValues, Store} from '@markput/core'
-import {useSyncExternalStore, useRef} from 'react'
+import {useSyncExternalStore, useContext, useRef} from 'react'
 
-import {useStore} from '../providers/StoreContext'
+import {StoreContext} from '../providers/StoreContext'
 
 type Selectable<T> = Signal<T> | Computed<T>
 type ObjectSelector = Record<string, Selectable<unknown> | unknown>
@@ -16,7 +16,8 @@ type StableRef = {
 export function useMarkput<T>(selector: (store: Store) => Selectable<T>): T
 export function useMarkput<R extends ObjectSelector>(selector: (store: Store) => R): SignalValues<R>
 export function useMarkput(selector: (store: Store) => Selectable<unknown> | ObjectSelector): unknown {
-	const store = useStore()
+	const store = useContext(StoreContext)
+	if (store === undefined) throw new Error('Store not found. Make sure to wrap component in StoreContext.')
 
 	// Holds stable computed + subscribe + snapshot — created once, never recreated.
 	const stableRef = useRef<StableRef | null>(null)

--- a/packages/react/markput/src/lib/hooks/useOverlay.tsx
+++ b/packages/react/markput/src/lib/hooks/useOverlay.tsx
@@ -4,7 +4,6 @@ import type {RefObject} from 'react'
 import {useCallback, useMemo} from 'react'
 
 import type {Option} from '../../types'
-import {useStore} from '../providers/StoreContext'
 import {useMarkput} from './useMarkput'
 
 export interface OverlayHandler {
@@ -19,21 +18,24 @@ export interface OverlayHandler {
 }
 
 export function useOverlay(): OverlayHandler {
-	const store = useStore()
-	const match = useMarkput(s => s.state.overlayMatch)
+	const {match, event, state} = useMarkput(s => ({
+		match: s.state.overlayMatch,
+		event: s.event,
+		state: s.state,
+	}))
 
 	const style = useMemo(() => {
 		if (!match) return {left: 0, top: 0}
 		return Caret.getAbsolutePosition()
 	}, [match])
 
-	const close = useCallback(() => store.event.overlayClose(), [])
+	const close = useCallback(() => event.overlayClose(), [])
 	const select = useCallback(
 		(value: {value: string; meta?: string}) => {
 			if (!match) return
 			const mark = createMarkFromOverlay(match, value.value, value.meta)
-			store.event.overlaySelect({mark, match})
-			store.event.overlayClose()
+			event.overlaySelect({mark, match})
+			event.overlayClose()
 		},
 		[match]
 	)
@@ -41,10 +43,10 @@ export function useOverlay(): OverlayHandler {
 	const ref = useMemo(
 		(): RefObject<HTMLElement | null> => ({
 			get current() {
-				return store.state.overlay()
+				return state.overlay()
 			},
 			set current(v: HTMLElement | null) {
-				store.state.overlay(v)
+				state.overlay(v)
 			},
 		}),
 		[]

--- a/packages/react/markput/src/lib/providers/StoreContext.ts
+++ b/packages/react/markput/src/lib/providers/StoreContext.ts
@@ -1,13 +1,5 @@
 import type {Store} from '@markput/core'
-import {createContext, useContext} from 'react'
+import {createContext} from 'react'
 
 export const StoreContext = createContext<Store | undefined>(undefined)
 StoreContext.displayName = 'StoreContext'
-
-export function useStore(): Store {
-	const store = useContext(StoreContext)
-	if (store === undefined) {
-		throw new Error('Store not found. Make sure to wrap component in StoreContext.')
-	}
-	return store
-}

--- a/packages/website/src/content/docs/api/functions/useMark.md
+++ b/packages/website/src/content/docs/api/functions/useMark.md
@@ -9,7 +9,7 @@ title: "useMark"
 function useMark<T>(options?): MarkHandler<T>;
 ```
 
-Defined in: [react/markput/src/lib/hooks/useMark.tsx:9](https://github.com/Nowely/marked-input/blob/next/packages/react/markput/src/lib/hooks/useMark.tsx#L9)
+Defined in: [react/markput/src/lib/hooks/useMark.tsx:8](https://github.com/Nowely/marked-input/blob/next/packages/react/markput/src/lib/hooks/useMark.tsx#L8)
 
 ## Type Parameters
 

--- a/packages/website/src/content/docs/api/functions/useOverlay.md
+++ b/packages/website/src/content/docs/api/functions/useOverlay.md
@@ -9,7 +9,7 @@ title: "useOverlay"
 function useOverlay(): OverlayHandler;
 ```
 
-Defined in: [react/markput/src/lib/hooks/useOverlay.tsx:21](https://github.com/Nowely/marked-input/blob/next/packages/react/markput/src/lib/hooks/useOverlay.tsx#L21)
+Defined in: [react/markput/src/lib/hooks/useOverlay.tsx:20](https://github.com/Nowely/marked-input/blob/next/packages/react/markput/src/lib/hooks/useOverlay.tsx#L20)
 
 ## Returns
 

--- a/packages/website/src/content/docs/api/interfaces/OverlayHandler.md
+++ b/packages/website/src/content/docs/api/interfaces/OverlayHandler.md
@@ -5,7 +5,7 @@ prev: false
 title: "OverlayHandler"
 ---
 
-Defined in: [react/markput/src/lib/hooks/useOverlay.tsx:10](https://github.com/Nowely/marked-input/blob/next/packages/react/markput/src/lib/hooks/useOverlay.tsx#L10)
+Defined in: [react/markput/src/lib/hooks/useOverlay.tsx:9](https://github.com/Nowely/marked-input/blob/next/packages/react/markput/src/lib/hooks/useOverlay.tsx#L9)
 
 ## Properties
 
@@ -15,7 +15,7 @@ Defined in: [react/markput/src/lib/hooks/useOverlay.tsx:10](https://github.com/N
 close: () => void;
 ```
 
-Defined in: [react/markput/src/lib/hooks/useOverlay.tsx:15](https://github.com/Nowely/marked-input/blob/next/packages/react/markput/src/lib/hooks/useOverlay.tsx#L15)
+Defined in: [react/markput/src/lib/hooks/useOverlay.tsx:14](https://github.com/Nowely/marked-input/blob/next/packages/react/markput/src/lib/hooks/useOverlay.tsx#L14)
 
 #### Returns
 
@@ -31,7 +31,7 @@ match:
   | undefined;
 ```
 
-Defined in: [react/markput/src/lib/hooks/useOverlay.tsx:17](https://github.com/Nowely/marked-input/blob/next/packages/react/markput/src/lib/hooks/useOverlay.tsx#L17)
+Defined in: [react/markput/src/lib/hooks/useOverlay.tsx:16](https://github.com/Nowely/marked-input/blob/next/packages/react/markput/src/lib/hooks/useOverlay.tsx#L16)
 
 ***
 
@@ -41,7 +41,7 @@ Defined in: [react/markput/src/lib/hooks/useOverlay.tsx:17](https://github.com/N
 ref: RefObject<HTMLElement | null>;
 ```
 
-Defined in: [react/markput/src/lib/hooks/useOverlay.tsx:18](https://github.com/Nowely/marked-input/blob/next/packages/react/markput/src/lib/hooks/useOverlay.tsx#L18)
+Defined in: [react/markput/src/lib/hooks/useOverlay.tsx:17](https://github.com/Nowely/marked-input/blob/next/packages/react/markput/src/lib/hooks/useOverlay.tsx#L17)
 
 ***
 
@@ -51,7 +51,7 @@ Defined in: [react/markput/src/lib/hooks/useOverlay.tsx:18](https://github.com/N
 select: (value) => void;
 ```
 
-Defined in: [react/markput/src/lib/hooks/useOverlay.tsx:16](https://github.com/Nowely/marked-input/blob/next/packages/react/markput/src/lib/hooks/useOverlay.tsx#L16)
+Defined in: [react/markput/src/lib/hooks/useOverlay.tsx:15](https://github.com/Nowely/marked-input/blob/next/packages/react/markput/src/lib/hooks/useOverlay.tsx#L15)
 
 #### Parameters
 
@@ -73,7 +73,7 @@ Defined in: [react/markput/src/lib/hooks/useOverlay.tsx:16](https://github.com/N
 style: object;
 ```
 
-Defined in: [react/markput/src/lib/hooks/useOverlay.tsx:11](https://github.com/Nowely/marked-input/blob/next/packages/react/markput/src/lib/hooks/useOverlay.tsx#L11)
+Defined in: [react/markput/src/lib/hooks/useOverlay.tsx:10](https://github.com/Nowely/marked-input/blob/next/packages/react/markput/src/lib/hooks/useOverlay.tsx#L10)
 
 #### left
 


### PR DESCRIPTION
## Summary

- Remove `useStore` hook entirely from the React package — inline `useContext(StoreContext)` into `useMarkput` and delete the function
- Migrate all 9 files that used `useStore()` to use `useMarkput` object selectors instead, leveraging the existing `isReactive` check to pass non-reactive values (BlockStore, KeyGenerator, event bus) through unchanged
- `useMarkput` is now the single entry point for accessing both reactive and imperative Store APIs

## Changes

**Component migrations (single `useMarkput` selector):**
- `Block.tsx`, `DragHandle.tsx`, `DropIndicator.tsx`, `BlockMenu.tsx`, `Token.tsx`, `OverlayRenderer.tsx` — removed `useStore`, consolidated into one `useMarkput(s => ({...}))` call

**Hook/internal migrations:**
- `useOverlay.tsx` — `useMarkput(s => ({match, event, state}))` where `state.overlay` retains getter+setter
- `useMark.tsx` — `useMarkput(s => ({store: s, readOnly: s.props.readOnly}))` where `s` passes through as raw Store
- `Suggestions.tsx` — `useMarkput(s => ({state: s.state}))` where `state.container()` retains imperative access

**Infrastructure:**
- `useMarkput.ts` — inlined `useContext(StoreContext)` + null check, removed `useStore` import
- `StoreContext.ts` — deleted `useStore` function, keeps only `StoreContext` export

## Test plan

- [x] All 567 tests pass (core unit + React/Vue storybook browser)
- [x] `pnpm run build` passes
- [x] `pnpm run typecheck` passes (tsc + vue-tsc)
- [x] `pnpm run lint` passes
- [x] `pnpm run format` passes