### PR TITLE
refactor: rename Store.features to feature, store.event to emit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ Shared dependency versions live in pnpm catalog (`pnpm-workspace.yaml`), not in 
 
 ## Architecture
 
-Summary: Store orchestrates reactive Signals, DOM refs (NodeProxy), 10 features, BlockRegistry, and event bus. Features are decoupled — they communicate only through `store.state`, `store.computed`, `store.event`, and `store.nodes`. The parser is a computed derived from options/drag/Mark. Features are enabled/disabled by Store watching `mounted`/`unmounted` events directly.
+Summary: Store orchestrates reactive Signals, DOM refs (NodeProxy), 10 features, BlockRegistry, and event bus. Features are decoupled — they communicate only through `store.state`, `store.computed`, `store.emit`, and `store.nodes`. The parser is a computed derived from options/drag/Mark. Features are enabled/disabled by Store watching `mounted`/`unmounted` events directly.
 
 For full architecture details, read `packages/website/src/content/docs/development/architecture.md`.
 
@@ -76,7 +76,7 @@ Detailed docs live in `packages/website/src/content/docs/`:
 
 ### Do NOT
 
-- Do not add direct imports between features — all communication goes through `store.state`, `store.event`, or `store.nodes`
+- Do not add direct imports between features — all communication goes through `store.state`, `store.emit`, or `store.nodes`
 - Do not manually create Signals for new state — add new state keys to either `state` (internal, feature-managed) or `props` (external, framework-provided) in `Store.ts`. Features write to `state`; framework adapters write to `props` via `setProps()`.
 - Do not install new dependencies without asking first
 - Do not modify `pnpm-workspace.yaml` catalog entries without asking first

--- a/packages/core/src/features/drag/DragFeature.spec.ts
+++ b/packages/core/src/features/drag/DragFeature.spec.ts
@@ -8,12 +8,12 @@ describe('DragFeature', () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
 		store = new Store()
-		// Disable all features except drag so their enable() side-effects don't interfere
-		const features = store.features as Record<string, {enable(): void; disable(): void}>
-		for (const key of Object.keys(features)) {
+		// Disable all feature except drag so their enable() side-effects don't interfere
+		const feature = store.feature as Record<string, {enable(): void; disable(): void}>
+		for (const key of Object.keys(feature)) {
 			if (key === 'drag') continue
-			vi.spyOn(features[key], 'enable').mockImplementation(() => {})
-			vi.spyOn(features[key], 'disable').mockImplementation(() => {})
+			vi.spyOn(feature[key], 'enable').mockImplementation(() => {})
+			vi.spyOn(feature[key], 'disable').mockImplementation(() => {})
 		}
 	})
 
@@ -25,12 +25,12 @@ describe('DragFeature', () => {
 				onChange: () => {}, // onChange is required for operations to proceed
 			})
 
-			store.features.drag.enable()
-			store.features.drag.enable() // second call — must not overwrite #unsub
+			store.feature.drag.enable()
+			store.feature.drag.enable() // second call — must not overwrite #unsub
 
 			// After a single disable, the watcher must be gone.
 			// If double-enable leaked, the first watcher would still fire.
-			store.features.drag.disable()
+			store.feature.drag.disable()
 
 			const reorderSpy = vi.spyOn(store.state, 'innerValue')
 			store.event.drag({type: 'delete', index: 0})

--- a/packages/core/src/features/drag/DragFeature.spec.ts
+++ b/packages/core/src/features/drag/DragFeature.spec.ts
@@ -33,7 +33,7 @@ describe('DragFeature', () => {
 			store.feature.drag.disable()
 
 			const reorderSpy = vi.spyOn(store.state, 'innerValue')
-			store.event.drag({type: 'delete', index: 0})
+			store.emit.drag({type: 'delete', index: 0})
 			expect(reorderSpy).not.toHaveBeenCalled()
 		})
 	})

--- a/packages/core/src/features/drag/DragFeature.ts
+++ b/packages/core/src/features/drag/DragFeature.ts
@@ -13,7 +13,7 @@ export class DragFeature {
 	enable() {
 		if (this.#unsub) return
 
-		this.#unsub = watch(this.store.event.drag, action => {
+		this.#unsub = watch(this.store.emit.drag, action => {
 			switch (action.type) {
 				case 'reorder':
 					this.#reorder(action.source, action.target)

--- a/packages/core/src/features/drag/README.md
+++ b/packages/core/src/features/drag/README.md
@@ -4,7 +4,7 @@ Manages the drag-and-drop block editing mode where each row/token is rendered as
 
 ## Components
 
-- **DragFeature**: Feature class that subscribes to `store.event.drag` and dispatches drag operations
+- **DragFeature**: Feature class that subscribes to `store.emit.drag` and dispatches drag operations
 - **getAlwaysShowHandle**: Extracts `alwaysShowHandle` from `DraggableConfig`
 - **EMPTY_TEXT_TOKEN**: Constant used as placeholder when no rows exist
 
@@ -14,4 +14,4 @@ The feature uses pure functions from `operations.ts` for manipulating the raw va
 
 ## Usage
 
-The feature is registered by the Store and activates when drag mode is enabled. Drag actions are dispatched via `store.event.drag`.
+The feature is registered by the Store and activates when drag mode is enabled. Drag actions are dispatched via `store.emit.drag`.

--- a/packages/core/src/features/editable/ContentEditableFeature.spec.ts
+++ b/packages/core/src/features/editable/ContentEditableFeature.spec.ts
@@ -10,7 +10,7 @@ describe('ContentEditableFeature', () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
 		store = new Store()
-		controller = store.features.contentEditable
+		controller = store.feature.contentEditable
 	})
 
 	it('enable() calls sync() immediately (effect fires on creation)', () => {

--- a/packages/core/src/features/editable/ContentEditableFeature.ts
+++ b/packages/core/src/features/editable/ContentEditableFeature.ts
@@ -20,7 +20,7 @@ export class ContentEditableFeature {
 			effect(() => {
 				if (this.store.state.selecting() === undefined) this.sync()
 			})
-			watch(this.store.event.sync, () => {
+			watch(this.store.emit.sync, () => {
 				this.sync()
 			})
 		})

--- a/packages/core/src/features/editing/utils/deleteMark.spec.ts
+++ b/packages/core/src/features/editing/utils/deleteMark.spec.ts
@@ -25,13 +25,13 @@ describe('deleteMark', () => {
 
 	beforeEach(() => {
 		store = new Store()
-		const features = store.features as Record<string, {enable(): void; disable(): void}>
-		for (const key of Object.keys(features)) {
+		const feature = store.feature as Record<string, {enable(): void; disable(): void}>
+		for (const key of Object.keys(feature)) {
 			if (key === 'system') continue
-			vi.spyOn(features[key], 'enable').mockImplementation(() => {})
-			vi.spyOn(features[key], 'disable').mockImplementation(() => {})
+			vi.spyOn(feature[key], 'enable').mockImplementation(() => {})
+			vi.spyOn(feature[key], 'disable').mockImplementation(() => {})
 		}
-		store.features.system.enable()
+		store.feature.system.enable()
 	})
 
 	function setupDOM() {

--- a/packages/core/src/features/editing/utils/deleteMark.ts
+++ b/packages/core/src/features/editing/utils/deleteMark.ts
@@ -36,7 +36,7 @@ export function deleteMark(place: 'prev' | 'self' | 'next', store: Store) {
 
 	store.state.recovery({anchor: caretAnchor.prev, caret})
 
-	store.event.change()
+	store.emit.change()
 
 	queueMicrotask(() => {
 		const container = store.state.container()

--- a/packages/core/src/features/events/SystemListenerFeature.spec.ts
+++ b/packages/core/src/features/events/SystemListenerFeature.spec.ts
@@ -10,7 +10,7 @@ describe('SystemListenerFeature', () => {
 
 	beforeEach(() => {
 		store = new Store()
-		controller = store.features.system
+		controller = store.feature.system
 	})
 
 	describe('enable()', () => {

--- a/packages/core/src/features/events/SystemListenerFeature.spec.ts
+++ b/packages/core/src/features/events/SystemListenerFeature.spec.ts
@@ -22,7 +22,7 @@ describe('SystemListenerFeature', () => {
 			controller.enable()
 
 			// Emit change — handler should serialize tokens and call onChange
-			store.event.change()
+			store.emit.change()
 
 			expect(onChange).toHaveBeenCalled()
 		})
@@ -35,7 +35,7 @@ describe('SystemListenerFeature', () => {
 			controller.enable()
 			controller.enable()
 
-			store.event.change()
+			store.emit.change()
 
 			expect(onChange).toHaveBeenCalledTimes(1)
 		})
@@ -49,7 +49,7 @@ describe('SystemListenerFeature', () => {
 
 			controller.enable()
 
-			store.event.markRemove({token})
+			store.emit.markRemove({token})
 
 			// After markRemove, the token should be removed from the tokens array
 			expect(store.state.tokens()).toEqual([
@@ -72,7 +72,7 @@ describe('SystemListenerFeature', () => {
 
 			controller.enable()
 
-			store.event.markRemove({token: missingToken})
+			store.emit.markRemove({token: missingToken})
 
 			expect(store.state.tokens()).toEqual([token, token2])
 			expect(onChange).not.toHaveBeenCalled()
@@ -100,7 +100,7 @@ describe('SystemListenerFeature', () => {
 				node: {} as unknown as Node,
 			} as unknown as OverlayMatch
 
-			store.event.overlaySelect({mark, match})
+			store.emit.overlaySelect({mark, match})
 		})
 	})
 
@@ -113,7 +113,7 @@ describe('SystemListenerFeature', () => {
 			controller.enable()
 			controller.disable()
 
-			store.event.change()
+			store.emit.change()
 
 			expect(onChange).not.toHaveBeenCalled()
 		})
@@ -127,7 +127,7 @@ describe('SystemListenerFeature', () => {
 			controller.enable()
 			controller.disable()
 
-			store.event.markRemove({token})
+			store.emit.markRemove({token})
 
 			expect(onChange).not.toHaveBeenCalled()
 		})
@@ -141,7 +141,7 @@ describe('SystemListenerFeature', () => {
 			controller.disable()
 			controller.enable()
 
-			store.event.change()
+			store.emit.change()
 
 			expect(onChange).toHaveBeenCalledTimes(1)
 		})

--- a/packages/core/src/features/events/SystemListenerFeature.ts
+++ b/packages/core/src/features/events/SystemListenerFeature.ts
@@ -12,7 +12,7 @@ export class SystemListenerFeature {
 		if (this.#scope) return
 
 		this.#scope = effectScope(() => {
-			watch(this.store.event.change, () => {
+			watch(this.store.emit.change, () => {
 				const onChange = this.store.props.onChange()
 				const {focus} = this.store.nodes
 
@@ -39,10 +39,10 @@ export class SystemListenerFeature {
 				}
 
 				onChange?.(toString(tokens))
-				this.store.event.reparse()
+				this.store.emit.reparse()
 			})
 
-			watch(this.store.event.markRemove, payload => {
+			watch(this.store.emit.markRemove, payload => {
 				const {token} = payload
 				const tokens = this.store.state.tokens()
 				if (!findToken(tokens, token)) return
@@ -62,7 +62,7 @@ export class SystemListenerFeature {
 				this.store.props.onChange()?.(newValue)
 			})
 
-			watch(this.store.event.overlaySelect, event => {
+			watch(this.store.emit.overlaySelect, event => {
 				const Mark = this.store.props.Mark()
 				const onChange = this.store.props.onChange()
 				const {
@@ -107,7 +107,7 @@ export class SystemListenerFeature {
 					this.store.nodes.focus.target = this.store.nodes.input.target
 					this.store.nodes.input.clear()
 					onChange?.(toString(tokens))
-					this.store.event.reparse()
+					this.store.emit.reparse()
 				}
 			})
 		})

--- a/packages/core/src/features/focus/FocusFeature.spec.ts
+++ b/packages/core/src/features/focus/FocusFeature.spec.ts
@@ -36,29 +36,29 @@ describe('FocusFeature', () => {
 		vi.clearAllMocks()
 		store = new Store()
 		store.state.container(stubContainer)
-		const features = store.features as Record<string, {enable(): void; disable(): void}>
-		for (const key of Object.keys(features)) {
+		const feature = store.feature as Record<string, {enable(): void; disable(): void}>
+		for (const key of Object.keys(feature)) {
 			if (key === 'focus') continue
-			vi.spyOn(features[key], 'enable').mockImplementation(() => {})
-			vi.spyOn(features[key], 'disable').mockImplementation(() => {})
+			vi.spyOn(feature[key], 'enable').mockImplementation(() => {})
+			vi.spyOn(feature[key], 'disable').mockImplementation(() => {})
 		}
 	})
 
 	describe('rendered handler', () => {
 		it('always emits sync', () => {
-			store.features.focus.enable()
+			store.feature.focus.enable()
 
 			const syncSpy = vi.spyOn(store.event, 'sync')
 			store.event.rendered()
 
 			expect(syncSpy).toHaveBeenCalledOnce()
 
-			store.features.focus.disable()
+			store.feature.focus.disable()
 		})
 
 		it('runs caret recovery and clears recovery state when Mark is set', () => {
 			store.setProps({Mark: () => null})
-			store.features.focus.enable()
+			store.feature.focus.enable()
 
 			// Set up a recovery state so #recover has work to do.
 			// #recover() clears the recovery state on the happy path.
@@ -76,11 +76,11 @@ describe('FocusFeature', () => {
 			// #recover clears recovery after running.
 			expect(store.state.recovery()).toBeUndefined()
 
-			store.features.focus.disable()
+			store.feature.focus.disable()
 		})
 
 		it('does not run recovery when Mark is not set', () => {
-			store.features.focus.enable()
+			store.feature.focus.enable()
 
 			store.state.recovery({
 				anchor: store.nodes.focus,
@@ -92,14 +92,14 @@ describe('FocusFeature', () => {
 			// #recover was NOT called, so recovery state is preserved.
 			expect(store.state.recovery()).toBeDefined()
 
-			store.features.focus.disable()
+			store.feature.focus.disable()
 		})
 	})
 
 	describe('subscription lifecycle', () => {
 		it('does not fire rendered watcher after disable', () => {
-			store.features.focus.enable()
-			store.features.focus.disable()
+			store.feature.focus.enable()
+			store.feature.focus.disable()
 
 			const syncSpy = vi.spyOn(store.event, 'sync')
 			store.event.rendered()
@@ -110,12 +110,12 @@ describe('FocusFeature', () => {
 
 	describe('disable()', () => {
 		it('clears nodes.focus.target', () => {
-			store.features.focus.enable()
+			store.feature.focus.enable()
 
 			store.nodes.focus.target = document.createElement('div')
 			expect(store.nodes.focus.target).toBeDefined()
 
-			store.features.focus.disable()
+			store.feature.focus.disable()
 
 			expect(store.nodes.focus.target).toBeUndefined()
 		})

--- a/packages/core/src/features/focus/FocusFeature.spec.ts
+++ b/packages/core/src/features/focus/FocusFeature.spec.ts
@@ -48,8 +48,8 @@ describe('FocusFeature', () => {
 		it('always emits sync', () => {
 			store.feature.focus.enable()
 
-			const syncSpy = vi.spyOn(store.event, 'sync')
-			store.event.rendered()
+			const syncSpy = vi.spyOn(store.emit, 'sync')
+			store.emit.rendered()
 
 			expect(syncSpy).toHaveBeenCalledOnce()
 
@@ -71,7 +71,7 @@ describe('FocusFeature', () => {
 				caret: 0,
 			})
 
-			store.event.rendered()
+			store.emit.rendered()
 
 			// #recover clears recovery after running.
 			expect(store.state.recovery()).toBeUndefined()
@@ -87,7 +87,7 @@ describe('FocusFeature', () => {
 				caret: 0,
 			})
 
-			store.event.rendered()
+			store.emit.rendered()
 
 			// #recover was NOT called, so recovery state is preserved.
 			expect(store.state.recovery()).toBeDefined()
@@ -101,8 +101,8 @@ describe('FocusFeature', () => {
 			store.feature.focus.enable()
 			store.feature.focus.disable()
 
-			const syncSpy = vi.spyOn(store.event, 'sync')
-			store.event.rendered()
+			const syncSpy = vi.spyOn(store.emit, 'sync')
+			store.emit.rendered()
 
 			expect(syncSpy).not.toHaveBeenCalled()
 		})

--- a/packages/core/src/features/focus/FocusFeature.ts
+++ b/packages/core/src/features/focus/FocusFeature.ts
@@ -32,8 +32,8 @@ export class FocusFeature {
 				}
 			})
 
-			watch(this.store.event.rendered, () => {
-				this.store.event.sync()
+			watch(this.store.emit.rendered, () => {
+				this.store.emit.sync()
 				if (!this.store.props.Mark()) return
 				this.#recover()
 			})

--- a/packages/core/src/features/input/InputFeature.ts
+++ b/packages/core/src/features/input/InputFeature.ts
@@ -85,14 +85,14 @@ export class InputFeature {
 				event.preventDefault()
 				focus.content = content.slice(0, caret - 1) + content.slice(caret)
 				focus.caret = caret - 1
-				this.store.event.change()
+				this.store.emit.change()
 				return
 			}
 			if (event.key === KEYBOARD.DELETE && caret >= 0 && caret < content.length) {
 				event.preventDefault()
 				focus.content = content.slice(0, caret) + content.slice(caret + 1)
 				focus.caret = caret
-				this.store.event.change()
+				this.store.emit.change()
 				return
 			}
 		}
@@ -126,7 +126,7 @@ export function handleBeforeInput(store: Store, event: InputEvent): void {
 	}
 
 	if (applySpanInput(focus, event)) {
-		store.event.change()
+		store.emit.change()
 	}
 }
 

--- a/packages/core/src/features/lifecycle/README.md
+++ b/packages/core/src/features/lifecycle/README.md
@@ -3,8 +3,8 @@
 The Store does not use a dedicated `Lifecycle` class. Feature enable/disable is driven directly by Store in its constructor:
 
 ```ts
-watch(this.event.mounted, () => Object.values(this.features).forEach(f => f.enable()))
-watch(this.event.unmounted, () => Object.values(this.features).forEach(f => f.disable()))
+watch(this.event.mounted, () => Object.values(this.feature).forEach(f => f.enable()))
+watch(this.event.unmounted, () => Object.values(this.feature).forEach(f => f.disable()))
 ```
 
 Framework adapters emit:

--- a/packages/core/src/features/lifecycle/README.md
+++ b/packages/core/src/features/lifecycle/README.md
@@ -3,13 +3,13 @@
 The Store does not use a dedicated `Lifecycle` class. Feature enable/disable is driven directly by Store in its constructor:
 
 ```ts
-watch(this.event.mounted, () => Object.values(this.feature).forEach(f => f.enable()))
-watch(this.event.unmounted, () => Object.values(this.feature).forEach(f => f.disable()))
+watch(this.emit.mounted, () => Object.values(this.feature).forEach(f => f.enable()))
+watch(this.emit.unmounted, () => Object.values(this.feature).forEach(f => f.disable()))
 ```
 
 Framework adapters emit:
 
-- `store.event.mounted()` on initial mount (enables features)
-- `store.event.unmounted()` on unmount (disables features and disposes subscriptions)
+- `store.emit.mounted()` on initial mount (enables features)
+- `store.emit.unmounted()` on unmount (disables features and disposes subscriptions)
 
 Reactive re-parse on prop changes is handled inside `ParseFeature` by watching a computed over `props.value` and `computed.parser`; there is no separate "updated" event.

--- a/packages/core/src/features/mark/MarkHandler.ts
+++ b/packages/core/src/features/mark/MarkHandler.ts
@@ -86,9 +86,9 @@ export class MarkHandler<T extends HTMLElement = HTMLElement> {
 		this.#emitChange()
 	}
 
-	remove = () => this.#store.event.markRemove({token: this.#token})
+	remove = () => this.#store.emit.markRemove({token: this.#token})
 
 	#emitChange(): void {
-		this.#store.event.change()
+		this.#store.emit.change()
 	}
 }

--- a/packages/core/src/features/overlay/OverlayFeature.spec.ts
+++ b/packages/core/src/features/overlay/OverlayFeature.spec.ts
@@ -42,7 +42,7 @@ describe('OverlayFeature', () => {
 		it('probes overlay trigger on change when showOverlayOn includes change', () => {
 			controller.enable()
 
-			store.event.change()
+			store.emit.change()
 
 			expect(store.state.overlayMatch()).toBeUndefined()
 
@@ -54,7 +54,7 @@ describe('OverlayFeature', () => {
 
 			store.state.overlayMatch(stubMatch)
 
-			store.event.overlayClose()
+			store.emit.overlayClose()
 
 			expect(store.state.overlayMatch()).toBeUndefined()
 		})
@@ -65,7 +65,7 @@ describe('OverlayFeature', () => {
 
 			store.state.overlayMatch(stubMatch)
 
-			store.event.change()
+			store.emit.change()
 
 			expect(store.state.overlayMatch()).toBeUndefined()
 		})
@@ -76,7 +76,7 @@ describe('OverlayFeature', () => {
 
 			store.state.overlayMatch(stubMatch)
 
-			store.event.change()
+			store.emit.change()
 
 			expect(store.state.overlayMatch()).toBe(stubMatch)
 		})
@@ -87,7 +87,7 @@ describe('OverlayFeature', () => {
 
 			store.state.overlayMatch(stubMatch)
 
-			store.event.overlayClose()
+			store.emit.overlayClose()
 
 			expect(store.state.overlayMatch()).toBeUndefined()
 		})
@@ -100,8 +100,8 @@ describe('OverlayFeature', () => {
 
 			store.state.overlayMatch(stubMatch)
 
-			store.event.overlayClose()
-			store.event.change()
+			store.emit.overlayClose()
+			store.emit.change()
 
 			expect(store.state.overlayMatch()).toBe(stubMatch)
 		})
@@ -113,7 +113,7 @@ describe('OverlayFeature', () => {
 
 			store.state.overlayMatch(stubMatch)
 
-			store.event.overlayClose()
+			store.emit.overlayClose()
 
 			expect(store.state.overlayMatch()).toBeUndefined()
 		})

--- a/packages/core/src/features/overlay/OverlayFeature.spec.ts
+++ b/packages/core/src/features/overlay/OverlayFeature.spec.ts
@@ -35,7 +35,7 @@ describe('OverlayFeature', () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
 		store = new Store()
-		controller = store.features.overlay
+		controller = store.feature.overlay
 	})
 
 	describe('enable()', () => {

--- a/packages/core/src/features/overlay/OverlayFeature.ts
+++ b/packages/core/src/features/overlay/OverlayFeature.ts
@@ -18,11 +18,11 @@ export class OverlayFeature {
 		if (this.#scope) return
 
 		this.#scope = effectScope(() => {
-			watch(this.store.event.overlayClose, () => {
+			watch(this.store.emit.overlayClose, () => {
 				this.store.state.overlayMatch(undefined)
 			})
 
-			watch(this.store.event.change, () => {
+			watch(this.store.emit.change, () => {
 				const showOverlayOn = this.store.props.showOverlayOn()
 				const type: OverlayTrigger = 'change'
 
@@ -39,7 +39,7 @@ export class OverlayFeature {
 
 					listen(window, 'keydown', e => {
 						if (e.key === KEYBOARD.ESC) {
-							this.store.event.overlayClose()
+							this.store.emit.overlayClose()
 						}
 					})
 
@@ -50,7 +50,7 @@ export class OverlayFeature {
 							const target = e.target instanceof HTMLElement ? e.target : null
 							if (this.store.state.overlay()?.contains(target)) return
 							if (this.store.state.container()?.contains(target)) return
-							this.store.event.overlayClose()
+							this.store.emit.overlayClose()
 						},
 						true
 					)

--- a/packages/core/src/features/parsing/ParseFeature.spec.ts
+++ b/packages/core/src/features/parsing/ParseFeature.spec.ts
@@ -7,82 +7,82 @@ describe('ParseFeature', () => {
 
 	beforeEach(() => {
 		store = new Store()
-		const features = store.features as Record<string, {enable(): void; disable(): void}>
-		for (const key of Object.keys(features)) {
+		const feature = store.feature as Record<string, {enable(): void; disable(): void}>
+		for (const key of Object.keys(feature)) {
 			if (key === 'parse') continue
-			vi.spyOn(features[key], 'enable').mockImplementation(() => {})
-			vi.spyOn(features[key], 'disable').mockImplementation(() => {})
+			vi.spyOn(feature[key], 'enable').mockImplementation(() => {})
+			vi.spyOn(feature[key], 'disable').mockImplementation(() => {})
 		}
 	})
 
 	describe('sync()', () => {
 		it('sets tokens from value signal', () => {
-			store.features.parse.enable()
+			store.feature.parse.enable()
 			store.setProps({value: 'hello'})
-			store.features.parse.sync()
+			store.feature.parse.sync()
 
 			expect(store.state.tokens()).toEqual([{type: 'text', content: 'hello', position: {start: 0, end: 5}}])
 
-			store.features.parse.disable()
+			store.feature.parse.disable()
 		})
 
 		it('falls back to defaultValue when value is undefined', () => {
-			store.features.parse.enable()
+			store.feature.parse.enable()
 			store.setProps({defaultValue: 'default'})
-			store.features.parse.sync()
+			store.feature.parse.sync()
 
 			expect(store.state.tokens()).toEqual([{type: 'text', content: 'default', position: {start: 0, end: 7}}])
 
-			store.features.parse.disable()
+			store.feature.parse.disable()
 		})
 
 		it('falls back to empty string when both are undefined', () => {
-			store.features.parse.enable()
-			store.features.parse.sync()
+			store.feature.parse.enable()
+			store.feature.parse.sync()
 
 			expect(store.state.tokens()).toEqual([{type: 'text', content: '', position: {start: 0, end: 0}}])
 
-			store.features.parse.disable()
+			store.feature.parse.disable()
 		})
 
 		it('sets previousValue to the parsed input', () => {
-			store.features.parse.enable()
+			store.feature.parse.enable()
 			store.setProps({value: 'test'})
-			store.features.parse.sync()
+			store.feature.parse.sync()
 
 			expect(store.state.previousValue()).toBe('test')
 
-			store.features.parse.disable()
+			store.feature.parse.disable()
 		})
 
 		it('skips markup when no Mark override and no per-option Mark', () => {
-			store.features.parse.enable()
+			store.feature.parse.enable()
 			store.setProps({options: [{markup: '@[__value__]'}], value: '@hello'})
-			store.features.parse.sync()
+			store.feature.parse.sync()
 
 			expect(store.computed.parser()).toBeUndefined()
 			expect(store.state.tokens()).toEqual([{type: 'text', content: '@hello', position: {start: 0, end: 6}}])
 
-			store.features.parse.disable()
+			store.feature.parse.disable()
 		})
 
 		it('uses markup when Mark override is set', () => {
-			store.features.parse.enable()
+			store.feature.parse.enable()
 			store.setProps({Mark: () => null, options: [{markup: '@[__value__]'}], value: '@hello'})
-			store.features.parse.sync()
+			store.feature.parse.sync()
 
 			expect(store.computed.parser()).toBeDefined()
 
-			store.features.parse.disable()
+			store.feature.parse.disable()
 		})
 	})
 
 	describe('enable() / disable()', () => {
 		it('is idempotent — calling enable twice does not double-subscribe', () => {
-			store.features.parse.enable()
-			store.features.parse.enable()
+			store.feature.parse.enable()
+			store.feature.parse.enable()
 			store.setProps({value: 'hello'})
-			store.features.parse.sync()
+			store.feature.parse.sync()
 
 			let callCount = 0
 			const original = store.state.tokens
@@ -96,15 +96,15 @@ describe('ParseFeature', () => {
 			expect(callCount).toBe(1)
 
 			;(store.state as Record<string, unknown>).tokens = original
-			store.features.parse.disable()
+			store.feature.parse.disable()
 		})
 
 		it('stops parse subscription after disable', () => {
-			store.features.parse.enable()
+			store.feature.parse.enable()
 			store.setProps({value: 'hello'})
-			store.features.parse.sync()
+			store.feature.parse.sync()
 
-			store.features.parse.disable()
+			store.feature.parse.disable()
 
 			const tokensBefore = store.state.tokens()
 			store.event.reparse()
@@ -112,54 +112,54 @@ describe('ParseFeature', () => {
 		})
 
 		it('resets initialized state — re-enable and sync works fresh', () => {
-			store.features.parse.enable()
+			store.feature.parse.enable()
 			store.setProps({value: 'first'})
-			store.features.parse.sync()
-			store.features.parse.disable()
+			store.feature.parse.sync()
+			store.feature.parse.disable()
 
-			store.features.parse.enable()
+			store.feature.parse.enable()
 			store.setProps({value: 'second'})
-			store.features.parse.sync()
+			store.feature.parse.sync()
 
 			expect(store.state.tokens()).toEqual([{type: 'text', content: 'second', position: {start: 0, end: 6}}])
 
-			store.features.parse.disable()
+			store.feature.parse.disable()
 		})
 	})
 
 	describe('reactive parse', () => {
 		it('reactively re-parses when props.value changes', () => {
-			store.features.parse.enable()
+			store.feature.parse.enable()
 			store.setProps({value: 'hello'})
-			store.features.parse.sync()
+			store.feature.parse.sync()
 
 			store.setProps({value: 'world'})
 
 			expect(store.state.tokens()).toEqual([{type: 'text', content: 'world', position: {start: 0, end: 5}}])
 			expect(store.state.previousValue()).toBe('world')
 
-			store.features.parse.disable()
+			store.feature.parse.disable()
 		})
 
 		it('does not re-parse in recovery mode when props.value changes', () => {
-			store.features.parse.enable()
+			store.feature.parse.enable()
 			store.setProps({value: 'hello'})
-			store.features.parse.sync()
+			store.feature.parse.sync()
 
 			store.state.recovery({caret: 0, anchor: store.nodes.focus})
 			store.setProps({value: 'world'})
 
 			expect(store.state.tokens()).toEqual([{type: 'text', content: 'hello', position: {start: 0, end: 5}}])
 
-			store.features.parse.disable()
+			store.feature.parse.disable()
 		})
 	})
 
 	describe('parse handler', () => {
 		it('in recovery mode — re-parses from token text', () => {
-			store.features.parse.enable()
+			store.feature.parse.enable()
 			store.setProps({value: 'test'})
-			store.features.parse.sync()
+			store.feature.parse.sync()
 
 			store.state.recovery({caret: 0, anchor: store.nodes.focus})
 			store.event.reparse()
@@ -167,13 +167,13 @@ describe('ParseFeature', () => {
 			expect(store.state.tokens()).toEqual([{type: 'text', content: 'test', position: {start: 0, end: 4}}])
 			expect(store.state.previousValue()).toBe('test')
 
-			store.features.parse.disable()
+			store.feature.parse.disable()
 		})
 
 		it('does not re-run parse subscription when recovery changes after parse event', () => {
-			store.features.parse.enable()
+			store.feature.parse.enable()
 			store.setProps({value: 'hello'})
-			store.features.parse.sync()
+			store.feature.parse.sync()
 			store.state.recovery({caret: 0, anchor: store.nodes.focus})
 
 			let callCount = 0
@@ -192,7 +192,7 @@ describe('ParseFeature', () => {
 			expect(callCount).toBe(0)
 
 			;(store.state as Record<string, unknown>).tokens = original
-			store.features.parse.disable()
+			store.feature.parse.disable()
 		})
 	})
 })

--- a/packages/core/src/features/parsing/ParseFeature.spec.ts
+++ b/packages/core/src/features/parsing/ParseFeature.spec.ts
@@ -92,7 +92,7 @@ describe('ParseFeature', () => {
 			}
 			;(store.state as Record<string, unknown>).tokens = tokensWrapper
 
-			store.event.reparse()
+			store.emit.reparse()
 			expect(callCount).toBe(1)
 
 			;(store.state as Record<string, unknown>).tokens = original
@@ -107,7 +107,7 @@ describe('ParseFeature', () => {
 			store.feature.parse.disable()
 
 			const tokensBefore = store.state.tokens()
-			store.event.reparse()
+			store.emit.reparse()
 			expect(store.state.tokens()).toBe(tokensBefore)
 		})
 
@@ -162,7 +162,7 @@ describe('ParseFeature', () => {
 			store.feature.parse.sync()
 
 			store.state.recovery({caret: 0, anchor: store.nodes.focus})
-			store.event.reparse()
+			store.emit.reparse()
 
 			expect(store.state.tokens()).toEqual([{type: 'text', content: 'test', position: {start: 0, end: 4}}])
 			expect(store.state.previousValue()).toBe('test')
@@ -184,7 +184,7 @@ describe('ParseFeature', () => {
 			}
 			;(store.state as Record<string, unknown>).tokens = tokensWrapper
 
-			store.event.reparse()
+			store.emit.reparse()
 			expect(callCount).toBe(1)
 
 			callCount = 0

--- a/packages/core/src/features/parsing/ParseFeature.ts
+++ b/packages/core/src/features/parsing/ParseFeature.ts
@@ -32,7 +32,7 @@ export class ParseFeature {
 	#subscribeParse() {
 		const {store} = this
 
-		watch(store.event.reparse, () => {
+		watch(store.emit.reparse, () => {
 			if (store.state.recovery()) {
 				const text = toString(store.state.tokens())
 				store.state.tokens(parseWithParser(store, text))
@@ -50,7 +50,7 @@ export class ParseFeature {
 
 		watch(deps, () => {
 			if (!store.state.recovery()) {
-				store.event.reparse()
+				store.emit.reparse()
 			}
 		})
 	}

--- a/packages/core/src/features/selection/TextSelectionFeature.spec.ts
+++ b/packages/core/src/features/selection/TextSelectionFeature.spec.ts
@@ -31,14 +31,14 @@ describe('TextSelectionFeature', () => {
 	})
 
 	it('enable() sets up the selecting subscription via effect', () => {
-		const controller = store.features.textSelection
+		const controller = store.feature.textSelection
 		controller.enable()
 		// The effect runs immediately; no error means subscription is established.
 		expect(mockDocument.addEventListener).toHaveBeenCalledTimes(4)
 	})
 
 	it('enable() is idempotent — calling twice does not double-subscribe', () => {
-		const controller = store.features.textSelection
+		const controller = store.feature.textSelection
 		controller.enable()
 		const callCount = mockDocument.addEventListener.mock.calls.length
 		controller.enable()
@@ -46,7 +46,7 @@ describe('TextSelectionFeature', () => {
 	})
 
 	it('disable() removes the reactive subscription', () => {
-		const controller = store.features.textSelection
+		const controller = store.feature.textSelection
 		controller.enable()
 		controller.disable()
 		// After disable, setting selecting to "drag" should not cause errors
@@ -54,7 +54,7 @@ describe('TextSelectionFeature', () => {
 	})
 
 	it('disable() resets selecting from drag to undefined', () => {
-		const controller = store.features.textSelection
+		const controller = store.feature.textSelection
 		controller.enable()
 		store.state.selecting('drag')
 		controller.disable()
@@ -70,7 +70,7 @@ describe('TextSelectionFeature', () => {
 		// oxlint-disable-next-line no-unsafe-type-assertion -- minimal stub object satisfies the API surface used by TextSelectionFeature in tests
 		store.state.container(container as unknown as HTMLDivElement)
 
-		const controller = store.features.textSelection
+		const controller = store.feature.textSelection
 		controller.enable()
 		store.state.selecting('drag')
 

--- a/packages/core/src/store/README.md
+++ b/packages/core/src/store/README.md
@@ -11,7 +11,7 @@ The central orchestrator of the markput system. Aggregates reactive state, compu
     - **Events** (`store.event`) — typed events: change, parse, delete, select, overlay, sync, focus, drag, lifecycle, and more
     - **DOM refs** (`store.state.container`, `store.state.overlay`) — reactive signals holding container and overlay HTMLElement references
     - **Node proxies** (`store.nodes`) — `focus` and `input` NodeProxy instances
-    - **Features** (`store.features`) — all feature instances
+    - **Features** (`store.feature`) — all feature instances
     - **`setProps()`** — batch update for framework-provided prop signals (used by React/Vue `MarkedInput`)
 
 Features update internal state by calling each signal, e.g. `store.state.tokens(next)`. For multiple internal updates in one tick, wrap in `batch()` from `@markput/core` (same module as `Store`).

--- a/packages/core/src/store/README.md
+++ b/packages/core/src/store/README.md
@@ -8,7 +8,7 @@ The central orchestrator of the markput system. Aggregates reactive state, compu
     - **Internal state** (`store.state`) — signals owned by features: tokens, previous value, inner value, recovery, selection mode, overlay match
     - **Props** (`store.props`) — readonly signals written only via `setProps()` (value, options, readOnly, drag, slots, etc.)
     - **Computed** (`store.computed`) — derived values: `hasMark`, `parser`, `currentValue`, `containerComponent`, `containerProps`, slot resolvers
-    - **Events** (`store.event`) — typed events: change, parse, delete, select, overlay, sync, focus, drag, lifecycle, and more
+    - **Events** (`store.emit`) — typed events: change, parse, delete, select, overlay, sync, focus, drag, lifecycle, and more
     - **DOM refs** (`store.state.container`, `store.state.overlay`) — reactive signals holding container and overlay HTMLElement references
     - **Node proxies** (`store.nodes`) — `focus` and `input` NodeProxy instances
     - **Features** (`store.feature`) — all feature instances
@@ -30,7 +30,7 @@ batch(() => {
 })
 ```
 
-The Store is created by framework wrappers and passed to all features. Features communicate through `store.state`, `store.props`, `store.event`, and `store.nodes`.
+The Store is created by framework wrappers and passed to all features. Features communicate through `store.state`, `store.props`, `store.emit`, and `store.nodes`.
 
 ## Readonly Props
 

--- a/packages/core/src/store/Store.spec.ts
+++ b/packages/core/src/store/Store.spec.ts
@@ -24,9 +24,9 @@ describe('Store', () => {
 
 	it('should have events', () => {
 		const store = new Store()
-		expect(typeof store.event.reparse).toBe('function')
-		expect(typeof store.event.change).toBe('function')
-		expect(typeof store.event.markRemove).toBe('function')
+		expect(typeof store.emit.reparse).toBe('function')
+		expect(typeof store.emit.change).toBe('function')
+		expect(typeof store.emit.markRemove).toBe('function')
 	})
 
 	describe('handler', () => {

--- a/packages/core/src/store/Store.ts
+++ b/packages/core/src/store/Store.ts
@@ -168,7 +168,7 @@ export class Store {
 		}),
 	}
 
-	readonly event = {
+	readonly emit = {
 		/** Fires after user input or programmatic mark change — triggers serialization, `onChange`, and re-parse */
 		change: event(),
 		/** Triggers a re-parse of tokens from the current content */
@@ -208,8 +208,8 @@ export class Store {
 	}
 
 	constructor() {
-		watch(this.event.mounted, () => Object.values(this.feature).forEach(f => f.enable()))
-		watch(this.event.unmounted, () => Object.values(this.feature).forEach(f => f.disable()))
+		watch(this.emit.mounted, () => Object.values(this.feature).forEach(f => f.enable()))
+		watch(this.emit.unmounted, () => Object.values(this.feature).forEach(f => f.disable()))
 	}
 
 	setProps(values: Partial<SignalValues<typeof this.props>>): void {

--- a/packages/core/src/store/Store.ts
+++ b/packages/core/src/store/Store.ts
@@ -193,7 +193,7 @@ export class Store {
 
 	readonly handler = new MarkputHandler(this)
 
-	readonly features = {
+	readonly feature = {
 		overlay: new OverlayFeature(this),
 		focus: new FocusFeature(this),
 		input: new InputFeature(this),
@@ -208,8 +208,8 @@ export class Store {
 	}
 
 	constructor() {
-		watch(this.event.mounted, () => Object.values(this.features).forEach(f => f.enable()))
-		watch(this.event.unmounted, () => Object.values(this.features).forEach(f => f.disable()))
+		watch(this.event.mounted, () => Object.values(this.feature).forEach(f => f.enable()))
+		watch(this.event.unmounted, () => Object.values(this.feature).forEach(f => f.disable()))
 	}
 
 	setProps(values: Partial<SignalValues<typeof this.props>>): void {

--- a/packages/react/markput/src/components/Block.tsx
+++ b/packages/react/markput/src/components/Block.tsx
@@ -16,9 +16,9 @@ interface BlockProps {
 }
 
 export const Block = memo(({token}: BlockProps) => {
-	const {blockStore, event, Component, slotProps, isDragging, tokens} = useMarkput(s => ({
+	const {blockStore, emit, Component, slotProps, isDragging, tokens} = useMarkput(s => ({
 		blockStore: s.blocks.get(token),
-		event: s.event,
+		emit: s.emit,
 		Component: s.computed.blockComponent,
 		slotProps: s.computed.blockProps,
 		isDragging: s.blocks.get(token).state.isDragging,
@@ -28,7 +28,7 @@ export const Block = memo(({token}: BlockProps) => {
 
 	return (
 		<Component
-			ref={(el: HTMLElement | null) => blockStore.attachContainer(el, blockIndex, event)}
+			ref={(el: HTMLElement | null) => blockStore.attachContainer(el, blockIndex, emit)}
 			data-testid="block"
 			{...slotProps}
 			// oxlint-disable-next-line no-unsafe-type-assertion -- slotProps.className is raw and needs casting to string

--- a/packages/react/markput/src/components/Container.tsx
+++ b/packages/react/markput/src/components/Container.tsx
@@ -5,19 +5,19 @@ import {Block} from './Block'
 import {Token} from './Token'
 
 export const Container = memo(() => {
-	const {isBlock, tokens, key, state, event, Component, props} = useMarkput(s => ({
+	const {isBlock, tokens, key, state, emit, Component, props} = useMarkput(s => ({
 		isBlock: s.computed.isBlock,
 		tokens: s.state.tokens,
 		key: s.key,
 		state: s.state,
-		event: s.event,
+		emit: s.emit,
 		Component: s.computed.containerComponent,
 		props: s.computed.containerProps,
 	}))
 
 	useLayoutEffect(() => {
-		event.rendered()
-	}, [tokens, event])
+		emit.rendered()
+	}, [tokens, emit])
 
 	return (
 		<Component ref={state.container} {...props}>

--- a/packages/react/markput/src/components/DragHandle.tsx
+++ b/packages/react/markput/src/components/DragHandle.tsx
@@ -9,9 +9,9 @@ import styles from '@markput/core/styles.module.css'
 const iconGrip = `${styles.Icon} ${styles.IconGrip}`
 
 export const DragHandle = memo(({token, blockIndex}: {token: TokenType; blockIndex: number}) => {
-	const {blockStore, event, readOnly, draggable, isDragging, isHovered} = useMarkput(s => ({
+	const {blockStore, emit, readOnly, draggable, isDragging, isHovered} = useMarkput(s => ({
 		blockStore: s.blocks.get(token),
-		event: s.event,
+		emit: s.emit,
 		readOnly: s.props.readOnly,
 		draggable: s.props.draggable,
 		isDragging: s.blocks.get(token).state.isDragging,
@@ -29,7 +29,7 @@ export const DragHandle = memo(({token, blockIndex}: {token: TokenType; blockInd
 			)}
 		>
 			<button
-				ref={(el: HTMLButtonElement | null) => blockStore.attachGrip(el, blockIndex, event)}
+				ref={(el: HTMLButtonElement | null) => blockStore.attachGrip(el, blockIndex, emit)}
 				type="button"
 				draggable
 				className={cx(styles.GripButton, isDragging && styles.GripButtonDragging)}

--- a/packages/react/markput/src/components/MarkedInput.tsx
+++ b/packages/react/markput/src/components/MarkedInput.tsx
@@ -84,8 +84,8 @@ export function MarkedInput<TMarkProps = MarkProps, TOverlayProps extends CoreOp
 	store.setProps(props)
 
 	useLayoutEffect(() => {
-		store.event.mounted()
-		return () => store.event.unmounted()
+		store.emit.mounted()
+		return () => store.emit.unmounted()
 	}, [])
 
 	useImperativeHandle(props.ref, () => store.handler, [store])

--- a/packages/react/markput/src/lib/hooks/useOverlay.tsx
+++ b/packages/react/markput/src/lib/hooks/useOverlay.tsx
@@ -18,9 +18,9 @@ export interface OverlayHandler {
 }
 
 export function useOverlay(): OverlayHandler {
-	const {match, event, state} = useMarkput(s => ({
+	const {match, emit, state} = useMarkput(s => ({
 		match: s.state.overlayMatch,
-		event: s.event,
+		emit: s.emit,
 		state: s.state,
 	}))
 
@@ -29,13 +29,13 @@ export function useOverlay(): OverlayHandler {
 		return Caret.getAbsolutePosition()
 	}, [match])
 
-	const close = useCallback(() => event.overlayClose(), [])
+	const close = useCallback(() => emit.overlayClose(), [])
 	const select = useCallback(
 		(value: {value: string; meta?: string}) => {
 			if (!match) return
 			const mark = createMarkFromOverlay(match, value.value, value.meta)
-			event.overlaySelect({mark, match})
-			event.overlayClose()
+			emit.overlaySelect({mark, match})
+			emit.overlayClose()
 		},
 		[match]
 	)

--- a/packages/vue/markput/src/components/Block.vue
+++ b/packages/vue/markput/src/components/Block.vue
@@ -36,7 +36,7 @@ const otherSlotProps = computed(() => {
 <template>
 	<component
 		:is="blockComponent"
-		:ref="(el: any) => blockStore.attachContainer(el?.$el ?? el, props.blockIndex, store.event)"
+		:ref="(el: any) => blockStore.attachContainer(el?.$el ?? el, props.blockIndex, store.emit)"
 		data-testid="block"
 		v-bind="otherSlotProps"
 		:class="[styles.Block, slotProps?.className as string | undefined]"

--- a/packages/vue/markput/src/components/Container.vue
+++ b/packages/vue/markput/src/components/Container.vue
@@ -10,7 +10,7 @@ const result = useMarkput(s => ({
 	tokens: s.state.tokens,
 	key: s.key,
 	state: s.state,
-	event: s.event,
+	emit: s.emit,
 }))
 
 const setContainerRef = (el: unknown) => {
@@ -23,7 +23,7 @@ const containerProps = useMarkput(s => s.computed.containerProps)
 
 watch(
 	() => result.value.tokens,
-	() => result.value.event.rendered(),
+	() => result.value.emit.rendered(),
 	{flush: 'post', immediate: true}
 )
 </script>

--- a/packages/vue/markput/src/components/DragHandle.vue
+++ b/packages/vue/markput/src/components/DragHandle.vue
@@ -28,7 +28,7 @@ const alwaysShowHandle = computed(() => getAlwaysShowHandle(draggable.value))
 		]"
 	>
 		<button
-			:ref="el => blockStore.attachGrip(el as HTMLButtonElement | null, props.blockIndex, store.event)"
+			:ref="el => blockStore.attachGrip(el as HTMLButtonElement | null, props.blockIndex, store.emit)"
 			type="button"
 			draggable="true"
 			:class="[styles.GripButton, isDragging && styles.GripButtonDragging]"

--- a/packages/vue/markput/src/components/MarkedInput.vue
+++ b/packages/vue/markput/src/components/MarkedInput.vue
@@ -60,9 +60,9 @@ watch(
 )
 
 onMounted(() => {
-	store.value.event.mounted()
+	store.value.emit.mounted()
 })
-onUnmounted(() => store.value.event.unmounted())
+onUnmounted(() => store.value.emit.unmounted())
 
 defineExpose(store.value.handler)
 </script>

--- a/packages/vue/markput/src/lib/hooks/useOverlay.ts
+++ b/packages/vue/markput/src/lib/hooks/useOverlay.ts
@@ -32,13 +32,13 @@ export function useOverlay(): OverlayHandler {
 		return Caret.getAbsolutePosition()
 	})
 
-	const close = () => store.event.overlayClose()
+	const close = () => store.emit.overlayClose()
 	const select = (value: {value: string; meta?: string}) => {
 		const match = matchRef.value
 		if (!match) return
 		const mark = createMarkFromOverlay(match, value.value, value.meta)
-		store.event.overlaySelect({mark, match})
-		store.event.overlayClose()
+		store.emit.overlaySelect({mark, match})
+		store.emit.overlayClose()
 	}
 
 	const ref = {

--- a/packages/website/src/content/docs/development/architecture.md
+++ b/packages/website/src/content/docs/development/architecture.md
@@ -83,11 +83,11 @@ Both framework adapters share the same component structure:
         ↓
 2. ContentEditableFeature detects input
         ↓
-3. store.event.change() emitted
+3. store.emit.change() emitted
         ↓
 4. SystemListenerFeature reads DOM, mutates focused token in-place
         ↓
-5. store.event.reparse() emitted
+5. store.emit.reparse() emitted
         ↓
 6. getTokensByUI() re-parses that token's content
         ↓
@@ -105,7 +105,7 @@ There are **two parse paths**: `getTokensByUI` (user editing — re-parses only 
 ```
 1. User types trigger character (e.g., '@')
         ↓
-2. OverlayFeature runs a trigger probe (on `store.event.change()`, or on `selectionchange` when `showOverlayOn` includes `selectionChange`)
+2. OverlayFeature runs a trigger probe (on `store.emit.change()`, or on `selectionchange` when `showOverlayOn` includes `selectionChange`)
         ↓
 3. If found:
    - store.state.overlayMatch set
@@ -117,11 +117,11 @@ There are **two parse paths**: `getTokensByUI` (user editing — re-parses only 
 6. User selects item:
    - Overlay calls select({ value, meta })
         ↓
-7. store.event.overlaySelect() emitted
+7. store.emit.overlaySelect() emitted
         ↓
 8. Markup inserted, onChange called with new text
         ↓
-9. store.event.overlayClose() closes overlay
+9. store.emit.overlayClose() closes overlay
 ```
 
 ## Parsing Pipeline
@@ -232,17 +232,17 @@ Events use `event<T>()` to create typed emitters backed by reactive signals:
 
 ```typescript
 // Emit a void event
-store.event.change()
+store.emit.change()
 
 // Emit a payload event
-store.event.markRemove({ token })
+store.emit.markRemove({ token })
 
 // Subscribe to an event
 import {watch, effectScope} from '@markput/core'
 
 const dispose = effectScope(() => {
     watch(
-        store.event.change,
+        store.emit.change,
         () => {
             console.log('Text changed')
         }
@@ -359,7 +359,7 @@ const tokens = store.state.tokens.use()
 
 ## Features
 
-10 features, each with `enable()`/`disable()`. They never import each other — all communication goes through `store.state` (internal signals), `store.props` (framework-provided signals), `store.event` (emitters), and `store.nodes` (DOM refs):
+10 features, each with `enable()`/`disable()`. They never import each other — all communication goes through `store.state` (internal signals), `store.props` (framework-provided signals), `store.emit` (emitters), and `store.nodes` (DOM refs):
 
 | Feature                       | Responsibility                                           |
 | ----------------------------- | -------------------------------------------------------- |
@@ -381,18 +381,18 @@ The original `KeyDownController` was decomposed into three focused features: `In
 React/Vue render asynchronously, so initialization order matters:
 
 ```typescript
-// 1. Framework emits store.event.mounted() on initial mount
+// 1. Framework emits store.emit.mounted() on initial mount
 //    → Store enables all features (DOM listeners, reactive subscriptions)
 
 // 2. After mount, ParseFeature reactively watches [props.value, computed.parser]
-//    → emits store.event.reparse() when either changes
+//    → emits store.emit.reparse() when either changes
 
 // 3. Sync contenteditable attributes (layout effect)
 //    → ContentEditableFeature.sync()
 
-// 4. Framework emits store.event.rendered() after tokens render
+// 4. Framework emits store.emit.rendered() after tokens render
 
-// 5. Framework emits store.event.unmounted() on unmount
+// 5. Framework emits store.emit.unmounted() on unmount
 //    → Store disables all features (cleanup DOM listeners, dispose scopes)
 ```
 


### PR DESCRIPTION
## Summary

- Rename `Store.features` → `Store.feature` (property already used singular internally)
- Rename `store.event` → `store.emit` for clearer semantics — `emit` better describes the action of firing/triggering events

## Changes

- `Store.ts`: property declarations + constructor
- 9 core feature files + 6 test files
- React adapter (5 files) + Vue adapter (5 files)
- Documentation (architecture.md, AGENTS.md, READMEs)

## Notes

- `Event<T>` type and `event()` factory function are **unchanged** — only the Store property is renamed
- 34 files changed, 187 insertions(+), 187 deletions(-) (pure rename, no behavior change)