### PR TITLE
refactor(core): rename reactive symbols for clarity across 4 features

### DIFF
--- a/packages/core/src/features/clipboard/ClipboardFeature.ts
+++ b/packages/core/src/features/clipboard/ClipboardFeature.ts
@@ -59,11 +59,11 @@ export class ClipboardFeature {
 					first.type === 'text' ? first.position.start + result.startOffset : first.position.start
 				const rawEnd = last.type === 'text' ? last.position.start + result.endOffset : last.position.end
 
-				const value = this.store.value.currentValue()
+				const value = this.store.value.current()
 				if (rawStart === rawEnd) return
 
 				const newValue = value.slice(0, rawStart) + value.slice(rawEnd)
-				this.store.value.innerValue(newValue)
+				this.store.value.next(newValue)
 
 				const newTokens = this.store.parsing.tokens()
 				let targetIdx = newTokens.findIndex(

--- a/packages/core/src/features/drag/DragFeature.spec.ts
+++ b/packages/core/src/features/drag/DragFeature.spec.ts
@@ -43,13 +43,13 @@ describe('DragFeature', () => {
 			store.drag.disable()
 
 			const reorderSpy = vi.spyOn(store.value, 'next')
-			store.drag.drag({type: 'delete', index: 0})
+			store.drag.action({type: 'delete', index: 0})
 			expect(reorderSpy).not.toHaveBeenCalled()
 		})
 	})
 
 	it('owns the drag event', () => {
 		const store = new Store()
-		expect(typeof store.drag.drag).toBe('function')
+		expect(typeof store.drag.action).toBe('function')
 	})
 })

--- a/packages/core/src/features/drag/DragFeature.spec.ts
+++ b/packages/core/src/features/drag/DragFeature.spec.ts
@@ -29,7 +29,7 @@ describe('DragFeature', () => {
 
 	describe('enable()', () => {
 		it('is a no-op when already enabled (does not leak a watcher)', () => {
-			// Set up minimal props so the delete handler will actually call innerValue
+			// Set up minimal props so the delete handler will actually call next
 			store.props.set({
 				value: 'test',
 				onChange: () => {}, // onChange is required for operations to proceed
@@ -42,7 +42,7 @@ describe('DragFeature', () => {
 			// If double-enable leaked, the first watcher would still fire.
 			store.drag.disable()
 
-			const reorderSpy = vi.spyOn(store.value, 'innerValue')
+			const reorderSpy = vi.spyOn(store.value, 'next')
 			store.drag.drag({type: 'delete', index: 0})
 			expect(reorderSpy).not.toHaveBeenCalled()
 		})

--- a/packages/core/src/features/drag/DragFeature.ts
+++ b/packages/core/src/features/drag/DragFeature.ts
@@ -44,7 +44,7 @@ export class DragFeature {
 		if (value == null || !this.store.props.onChange()) return
 		const rows = this.store.parsing.tokens()
 		const newValue = reorderDragRows(value, rows, sourceIndex, targetIndex)
-		if (newValue !== value) this.store.value.innerValue(newValue)
+		if (newValue !== value) this.store.value.next(newValue)
 	}
 
 	#add(afterIndex: number) {
@@ -53,7 +53,7 @@ export class DragFeature {
 		const rawRows = this.store.parsing.tokens()
 		const rows = rawRows.length > 0 ? rawRows : [EMPTY_TEXT_TOKEN]
 		const newRowContent = createRowContent(this.store.props.options())
-		this.store.value.innerValue(addDragRow(value, rows, afterIndex, newRowContent))
+		this.store.value.next(addDragRow(value, rows, afterIndex, newRowContent))
 		queueMicrotask(() => {
 			const container = this.store.slots.container()
 			if (!container) return
@@ -66,13 +66,13 @@ export class DragFeature {
 		const value = this.store.props.value()
 		if (value == null || !this.store.props.onChange()) return
 		const rows = this.store.parsing.tokens()
-		this.store.value.innerValue(deleteDragRow(value, rows, index))
+		this.store.value.next(deleteDragRow(value, rows, index))
 	}
 
 	#duplicate(index: number) {
 		const value = this.store.props.value()
 		if (value == null || !this.store.props.onChange()) return
 		const rows = this.store.parsing.tokens()
-		this.store.value.innerValue(duplicateDragRow(value, rows, index))
+		this.store.value.next(duplicateDragRow(value, rows, index))
 	}
 }

--- a/packages/core/src/features/drag/DragFeature.ts
+++ b/packages/core/src/features/drag/DragFeature.ts
@@ -7,7 +7,7 @@ import {addDragRow, deleteDragRow, duplicateDragRow, reorderDragRows} from './op
 import {EMPTY_TEXT_TOKEN} from './tokens'
 
 export class DragFeature {
-	readonly drag = event<DragAction>()
+	readonly action = event<DragAction>()
 
 	constructor(private readonly store: Store) {}
 
@@ -16,7 +16,7 @@ export class DragFeature {
 	enable() {
 		if (this.#unsub) return
 
-		this.#unsub = watch(this.drag, action => {
+		this.#unsub = watch(this.action, action => {
 			switch (action.type) {
 				case 'reorder':
 					this.#reorder(action.source, action.target)

--- a/packages/core/src/features/drag/README.md
+++ b/packages/core/src/features/drag/README.md
@@ -4,7 +4,7 @@ Manages the drag-and-drop block editing mode where each row/token is rendered as
 
 ## Components
 
-- **DragFeature**: Feature class that subscribes to `store.emit.drag` and dispatches drag operations
+- **DragFeature**: Feature class that subscribes to `store.drag.action` and dispatches drag operations
 - **getAlwaysShowHandle**: Extracts `alwaysShowHandle` from `DraggableConfig`
 - **EMPTY_TEXT_TOKEN**: Constant used as placeholder when no rows exist
 
@@ -14,4 +14,4 @@ The feature uses pure functions from `operations.ts` for manipulating the raw va
 
 ## Usage
 
-The feature is registered by the Store and activates when drag mode is enabled. Drag actions are dispatched via `store.emit.drag`.
+The feature is registered by the Store and activates when drag mode is enabled. Drag actions are dispatched via `store.drag.action`.

--- a/packages/core/src/features/keyboard/blockEdit.ts
+++ b/packages/core/src/features/keyboard/blockEdit.ts
@@ -61,7 +61,7 @@ function handleDelete(store: Store, event: KeyboardEvent) {
 	if (blockIndex >= rows.length) return
 
 	const token = rows[blockIndex]
-	const value = store.value.currentValue()
+	const value = store.value.current()
 	if (!store.props.onChange()) return
 
 	if (event.key === KEYBOARD.BACKSPACE) {
@@ -81,7 +81,7 @@ function handleDelete(store: Store, event: KeyboardEvent) {
 								value.slice(rows[blockIndex + 1].position.start)
 							)
 						})()
-			store.value.innerValue(newValue)
+			store.value.next(newValue)
 			queueMicrotask(() => {
 				const targetIndex = Math.max(0, blockIndex - 1)
 				const target = childAt(container, targetIndex)
@@ -100,7 +100,7 @@ function handleDelete(store: Store, event: KeyboardEvent) {
 				event.preventDefault()
 				const joinPos = getMergeDragRowJoinPos(rows, blockIndex)
 				const newValue = mergeDragRows(value, rows, blockIndex)
-				store.value.innerValue(newValue)
+				store.value.next(newValue)
 				queueMicrotask(() => {
 					const target = childAt(container, blockIndex - 1)
 					if (target) {
@@ -135,7 +135,7 @@ function handleDelete(store: Store, event: KeyboardEvent) {
 				event.preventDefault()
 				const joinPos = getMergeDragRowJoinPos(rows, blockIndex)
 				const newValue = mergeDragRows(value, rows, blockIndex)
-				store.value.innerValue(newValue)
+				store.value.next(newValue)
 				queueMicrotask(() => {
 					const target = childAt(container, blockIndex - 1)
 					if (target) {
@@ -163,7 +163,7 @@ function handleDelete(store: Store, event: KeyboardEvent) {
 				event.preventDefault()
 				const joinPos = getMergeDragRowJoinPos(rows, blockIndex + 1)
 				const newValue = mergeDragRows(value, rows, blockIndex + 1)
-				store.value.innerValue(newValue)
+				store.value.next(newValue)
 				queueMicrotask(() => {
 					const target = childAt(container, blockIndex)
 					if (target) {
@@ -211,7 +211,7 @@ function handleEnter(store: Store, event: KeyboardEvent) {
 	const rows = store.parsing.tokens()
 	const token = rows[blockIndex]
 	const blockDiv = blockDivs[blockIndex]
-	const value = store.value.currentValue()
+	const value = store.value.current()
 
 	if (!store.props.onChange()) return
 
@@ -219,7 +219,7 @@ function handleEnter(store: Store, event: KeyboardEvent) {
 
 	if (!isTextLikeRow(token)) {
 		const newValue = addDragRow(value, rows, blockIndex, newRowContent)
-		store.value.innerValue(newValue)
+		store.value.next(newValue)
 		queueMicrotask(() => {
 			const newBlockIndex = blockIndex + 1
 			if (newBlockIndex < container.children.length) {
@@ -235,7 +235,7 @@ function handleEnter(store: Store, event: KeyboardEvent) {
 
 	const absolutePos = getCaretRawPosInBlock(blockDiv, token)
 	const newValue = value.slice(0, absolutePos) + newRowContent + value.slice(absolutePos)
-	store.value.innerValue(newValue)
+	store.value.next(newValue)
 
 	queueMicrotask(() => {
 		const newBlockIndex = blockIndex + 1
@@ -337,7 +337,7 @@ function handleBlockBeforeInput(store: Store, event: InputEvent) {
 	if (blockIndex >= rows.length) return
 
 	const token = rows[blockIndex]
-	const value = store.value.currentValue()
+	const value = store.value.current()
 
 	const focusAndSetCaret = (newRawPos: number) => {
 		queueMicrotask(() => {
@@ -364,7 +364,7 @@ function handleBlockBeforeInput(store: Store, event: InputEvent) {
 			} else {
 				rawFrom = rawTo = getCaretRawPosInBlock(blockDiv, token)
 			}
-			store.value.innerValue(value.slice(0, rawFrom) + data + value.slice(rawTo))
+			store.value.next(value.slice(0, rawFrom) + data + value.slice(rawTo))
 			focusAndSetCaret(rawFrom + data.length)
 			break
 		}
@@ -384,7 +384,7 @@ function handleBlockBeforeInput(store: Store, event: InputEvent) {
 			} else {
 				rawFrom = rawTo = getCaretRawPosInBlock(blockDiv, token)
 			}
-			store.value.innerValue(value.slice(0, rawFrom) + pasteData + value.slice(rawTo))
+			store.value.next(value.slice(0, rawFrom) + pasteData + value.slice(rawTo))
 			focusAndSetCaret(rawFrom + pasteData.length)
 			break
 		}
@@ -401,7 +401,7 @@ function handleBlockBeforeInput(store: Store, event: InputEvent) {
 			const [rawFrom, rawTo] = rawStart <= rawEnd ? [rawStart, rawEnd] : [rawEnd, rawStart]
 			if (rawFrom === rawTo) return
 			event.preventDefault()
-			store.value.innerValue(value.slice(0, rawFrom) + value.slice(rawTo))
+			store.value.next(value.slice(0, rawFrom) + value.slice(rawTo))
 			focusAndSetCaret(rawFrom)
 			break
 		}

--- a/packages/core/src/features/keyboard/input.spec.ts
+++ b/packages/core/src/features/keyboard/input.spec.ts
@@ -24,14 +24,14 @@ describe('applySpanInput()', () => {
 })
 
 describe('replaceAllContentWith()', () => {
-	it('sets previousValue to the new content', () => {
+	it('sets last to the new content', () => {
 		const store = new Store()
 		// oxlint-disable-next-line no-unsafe-type-assertion -- minimal container stub
 		store.slots.container({firstChild: null} as unknown as HTMLDivElement)
-		store.value.previousValue('old value')
+		store.value.last('old value')
 
 		replaceAllContentWith(store, 'new content')
 
-		expect(store.value.previousValue()).toBe('new content')
+		expect(store.value.last()).toBe('new content')
 	})
 })

--- a/packages/core/src/features/keyboard/input.ts
+++ b/packages/core/src/features/keyboard/input.ts
@@ -130,7 +130,7 @@ function handleMarkputSpanPaste(store: Store, focus: NodeProxy, event: InputEven
 	const tokens = store.parsing.tokens()
 	const token = tokens[focus.index]
 	const offset = focus.caret
-	const currentValue = store.value.currentValue()
+	const currentValue = store.value.current()
 
 	const ranges = event.getTargetRanges()
 	const childElement = container.children[focus.index]
@@ -148,7 +148,7 @@ function handleMarkputSpanPaste(store: Store, focus: NodeProxy, event: InputEven
 
 	const caretPos = rawInsertPos + markup.length
 	const newValue = currentValue.slice(0, rawInsertPos) + markup + currentValue.slice(rawEndPos)
-	store.value.innerValue(newValue)
+	store.value.next(newValue)
 
 	const newTokens = store.parsing.tokens()
 	let targetIdx = newTokens.findIndex(
@@ -245,7 +245,7 @@ export function handlePaste(store: Store, event: ClipboardEvent): void {
 export function replaceAllContentWith(store: Store, newContent: string): void {
 	store.nodes.focus.target = null
 	store.caret.selecting(undefined)
-	store.value.previousValue(newContent)
+	store.value.last(newContent)
 
 	store.props.onChange()?.(newContent)
 

--- a/packages/core/src/features/mark/MarkFeature.spec.ts
+++ b/packages/core/src/features/mark/MarkFeature.spec.ts
@@ -3,25 +3,25 @@ import {describe, it, expect, beforeEach, vi} from 'vitest'
 import {Store} from '../../store/Store'
 
 describe('MarkFeature', () => {
-	it('hasMark is false when no Mark is configured', () => {
+	it('enabled is false when no Mark is configured', () => {
 		const store = new Store()
-		expect(store.mark.hasMark()).toBe(false)
+		expect(store.mark.enabled()).toBe(false)
 	})
 
-	it('hasMark is true when Mark prop is set', () => {
+	it('enabled is true when Mark prop is set', () => {
 		const store = new Store()
 		store.props.set({Mark: () => null})
-		expect(store.mark.hasMark()).toBe(true)
+		expect(store.mark.enabled()).toBe(true)
 	})
 
-	it('exposes hasMark, mark, markRemove', () => {
+	it('exposes enabled, slot, remove', () => {
 		const store = new Store()
-		expect(typeof store.mark.hasMark).toBe('function')
-		expect(typeof store.mark.mark).toBe('function')
-		expect(typeof store.mark.markRemove).toBe('function')
+		expect(typeof store.mark.enabled).toBe('function')
+		expect(typeof store.mark.slot).toBe('function')
+		expect(typeof store.mark.remove).toBe('function')
 	})
 
-	describe('markRemove handler', () => {
+	describe('remove handler', () => {
 		let store: Store
 
 		beforeEach(() => {
@@ -38,7 +38,7 @@ describe('MarkFeature', () => {
 
 			store.mark.enable()
 
-			store.mark.markRemove({token})
+			store.mark.remove({token})
 
 			expect(store.parsing.tokens()).toEqual([
 				{
@@ -50,7 +50,7 @@ describe('MarkFeature', () => {
 			expect(onChange).toHaveBeenCalled()
 		})
 
-		it('ignore markRemove events for tokens that are not in state', () => {
+		it('ignore remove events for tokens that are not in state', () => {
 			const onChange = vi.fn()
 			store.props.set({onChange})
 			const token = {type: 'text' as const, content: 'a', position: {start: 0, end: 1}}
@@ -60,7 +60,7 @@ describe('MarkFeature', () => {
 
 			store.mark.enable()
 
-			store.mark.markRemove({token: missingToken})
+			store.mark.remove({token: missingToken})
 
 			expect(store.parsing.tokens()).toEqual([token, token2])
 			expect(onChange).not.toHaveBeenCalled()
@@ -68,7 +68,7 @@ describe('MarkFeature', () => {
 	})
 
 	describe('disable()', () => {
-		it('stop reacting to markRemove events after disable', () => {
+		it('stop reacting to remove events after disable', () => {
 			const store = new Store()
 			const onChange = vi.fn()
 			store.props.set({onChange})
@@ -79,7 +79,7 @@ describe('MarkFeature', () => {
 			store.mark.enable()
 			store.mark.disable()
 
-			store.mark.markRemove({token})
+			store.mark.remove({token})
 
 			expect(onChange).not.toHaveBeenCalled()
 		})

--- a/packages/core/src/features/mark/MarkFeature.ts
+++ b/packages/core/src/features/mark/MarkFeature.ts
@@ -37,7 +37,7 @@ export class MarkFeature implements Feature {
 				if (!findToken(tokens, token)) return
 				const value = toString(tokens)
 				const nextValue = value.slice(0, token.position.start) + value.slice(token.position.end)
-				this._store.value.innerValue(nextValue)
+				this._store.value.next(nextValue)
 			})
 		})
 	}

--- a/packages/core/src/features/mark/MarkFeature.ts
+++ b/packages/core/src/features/mark/MarkFeature.ts
@@ -9,20 +9,20 @@ import {resolveMarkSlot} from '../slots'
 import type {MarkSlot} from '../slots'
 
 export class MarkFeature implements Feature {
-	readonly hasMark: Computed<boolean> = computed(() => {
+	readonly enabled: Computed<boolean> = computed(() => {
 		const Mark = this._store.props.Mark()
 		if (Mark) return true
 		return this._store.props.options().some(opt => 'Mark' in opt && opt.Mark != null)
 	})
 
-	readonly mark: MarkSlot = computed(() => {
+	readonly slot: MarkSlot = computed(() => {
 		const options = this._store.props.options()
 		const Mark = this._store.props.Mark()
 		const Span = this._store.props.Span()
 		return (token: Token) => resolveMarkSlot(token, options, Mark, Span)
 	})
 
-	readonly markRemove = event<{token: Token}>()
+	readonly remove = event<{token: Token}>()
 
 	#scope?: () => void
 
@@ -31,7 +31,7 @@ export class MarkFeature implements Feature {
 	enable() {
 		if (this.#scope) return
 		this.#scope = effectScope(() => {
-			watch(this.markRemove, payload => {
+			watch(this.remove, payload => {
 				const {token} = payload
 				const tokens = this._store.parsing.tokens()
 				if (!findToken(tokens, token)) return

--- a/packages/core/src/features/mark/MarkHandler.ts
+++ b/packages/core/src/features/mark/MarkHandler.ts
@@ -86,7 +86,7 @@ export class MarkHandler<T extends HTMLElement = HTMLElement> {
 		this.#emitChange()
 	}
 
-	remove = () => this.#store.mark.markRemove({token: this.#token})
+	remove = () => this.#store.mark.remove({token: this.#token})
 
 	#emitChange(): void {
 		this.#store.value.change()

--- a/packages/core/src/features/overlay/OverlayFeature.spec.ts
+++ b/packages/core/src/features/overlay/OverlayFeature.spec.ts
@@ -24,12 +24,12 @@ describe('OverlayFeature', () => {
 	})
 
 	describe('ownership', () => {
-		it('owns overlayMatch, overlay (DOM ref), overlay (computed), overlaySelect, overlayClose', () => {
-			expect(typeof store.overlay.overlayMatch).toBe('function')
-			expect(typeof store.overlay.overlay).toBe('function')
-			expect(typeof store.overlay.overlaySlot).toBe('function')
-			expect(typeof store.overlay.overlaySelect).toBe('function')
-			expect(typeof store.overlay.overlayClose).toBe('function')
+		it('owns match, element (DOM ref), slot (computed), select, close', () => {
+			expect(typeof store.overlay.match).toBe('function')
+			expect(typeof store.overlay.element).toBe('function')
+			expect(typeof store.overlay.slot).toBe('function')
+			expect(typeof store.overlay.select).toBe('function')
+			expect(typeof store.overlay.close).toBe('function')
 		})
 	})
 
@@ -39,52 +39,52 @@ describe('OverlayFeature', () => {
 
 			store.value.change()
 
-			expect(store.overlay.overlayMatch()).toBeUndefined()
+			expect(store.overlay.match()).toBeUndefined()
 
 			controller.disable()
 		})
 
-		it('clear overlayMatch when overlayClose is emitted', () => {
+		it('clear match when close is emitted', () => {
 			controller.enable()
 
-			store.overlay.overlayMatch(stubMatch)
+			store.overlay.match(stubMatch)
 
-			store.overlay.overlayClose()
+			store.overlay.close()
 
-			expect(store.overlay.overlayMatch()).toBeUndefined()
+			expect(store.overlay.match()).toBeUndefined()
 		})
 
 		it('react to change event when showOverlayOn includes change', () => {
 			store.props.set({showOverlayOn: 'change'})
 			controller.enable()
 
-			store.overlay.overlayMatch(stubMatch)
+			store.overlay.match(stubMatch)
 
 			store.value.change()
 
-			expect(store.overlay.overlayMatch()).toBeUndefined()
+			expect(store.overlay.match()).toBeUndefined()
 		})
 
 		it('not react to change event when showOverlayOn does not include change', () => {
 			store.props.set({showOverlayOn: 'selectionChange'})
 			controller.enable()
 
-			store.overlay.overlayMatch(stubMatch)
+			store.overlay.match(stubMatch)
 
 			store.value.change()
 
-			expect(store.overlay.overlayMatch()).toBe(stubMatch)
+			expect(store.overlay.match()).toBe(stubMatch)
 		})
 
 		it('be idempotent — calling enable twice does not double-subscribe', () => {
 			controller.enable()
 			controller.enable()
 
-			store.overlay.overlayMatch(stubMatch)
+			store.overlay.match(stubMatch)
 
-			store.overlay.overlayClose()
+			store.overlay.close()
 
-			expect(store.overlay.overlayMatch()).toBeUndefined()
+			expect(store.overlay.match()).toBeUndefined()
 		})
 	})
 
@@ -93,12 +93,12 @@ describe('OverlayFeature', () => {
 			controller.enable()
 			controller.disable()
 
-			store.overlay.overlayMatch(stubMatch)
+			store.overlay.match(stubMatch)
 
-			store.overlay.overlayClose()
+			store.overlay.close()
 			store.value.change()
 
-			expect(store.overlay.overlayMatch()).toBe(stubMatch)
+			expect(store.overlay.match()).toBe(stubMatch)
 		})
 
 		it('allow re-enabling after disable', () => {
@@ -106,11 +106,11 @@ describe('OverlayFeature', () => {
 			controller.disable()
 			controller.enable()
 
-			store.overlay.overlayMatch(stubMatch)
+			store.overlay.match(stubMatch)
 
-			store.overlay.overlayClose()
+			store.overlay.close()
 
-			expect(store.overlay.overlayMatch()).toBeUndefined()
+			expect(store.overlay.match()).toBeUndefined()
 		})
 	})
 })

--- a/packages/core/src/features/overlay/OverlayFeature.ts
+++ b/packages/core/src/features/overlay/OverlayFeature.ts
@@ -10,16 +10,16 @@ import {resolveOverlaySlot} from '../slots'
 import type {OverlaySlot} from '../slots'
 
 export class OverlayFeature implements Feature {
-	readonly overlayMatch = signal<OverlayMatch | undefined>(undefined)
-	readonly overlay = signal<HTMLElement | null>(null)
+	readonly match = signal<OverlayMatch | undefined>(undefined)
+	readonly element = signal<HTMLElement | null>(null)
 
-	readonly overlaySlot: OverlaySlot = computed(() => {
+	readonly slot: OverlaySlot = computed(() => {
 		const Overlay = this._store.props.Overlay()
 		return (option?: CoreOption, defaultComponent?: Slot) => resolveOverlaySlot(Overlay, option, defaultComponent)
 	})
 
-	readonly overlaySelect = event<{mark: Token; match: OverlayMatch}>()
-	readonly overlayClose = event()
+	readonly select = event<{mark: Token; match: OverlayMatch}>()
+	readonly close = event()
 
 	#scope?: () => void
 
@@ -27,15 +27,15 @@ export class OverlayFeature implements Feature {
 
 	#probeTrigger() {
 		const match = TriggerFinder.find(this._store.props.options(), option => option.overlay?.trigger)
-		this.overlayMatch(match)
+		this.match(match)
 	}
 
 	enable() {
 		if (this.#scope) return
 
 		this.#scope = effectScope(() => {
-			watch(this.overlayClose, () => {
-				this.overlayMatch(undefined)
+			watch(this.close, () => {
+				this.match(undefined)
 			})
 
 			watch(this._store.value.change, () => {
@@ -48,13 +48,13 @@ export class OverlayFeature implements Feature {
 			})
 
 			effect(() => {
-				const match = this.overlayMatch()
+				const match = this.match()
 				if (match) {
 					this._store.nodes.input.target = this._store.nodes.focus.target
 
 					listen(window, 'keydown', e => {
 						if (e.key === KEYBOARD.ESC) {
-							this.overlayClose()
+							this.close()
 						}
 					})
 
@@ -63,9 +63,9 @@ export class OverlayFeature implements Feature {
 						'click',
 						e => {
 							const target = e.target instanceof HTMLElement ? e.target : null
-							if (this.overlay()?.contains(target)) return
+							if (this.element()?.contains(target)) return
 							if (this._store.slots.container()?.contains(target)) return
-							this.overlayClose()
+							this.close()
 						},
 						true
 					)
@@ -86,7 +86,7 @@ export class OverlayFeature implements Feature {
 
 			listen(document, 'selectionchange', selectionChangeHandler)
 
-			watch(this.overlaySelect, overlayEvent => {
+			watch(this.select, overlayEvent => {
 				const Mark = this._store.props.Mark()
 				const onChange = this._store.props.onChange()
 				const {

--- a/packages/core/src/features/parsing/ParseFeature.spec.ts
+++ b/packages/core/src/features/parsing/ParseFeature.spec.ts
@@ -55,12 +55,12 @@ describe('ParsingFeature', () => {
 			store.parsing.disable()
 		})
 
-		it('sets previousValue to the parsed input', () => {
+		it('sets last to the parsed input', () => {
 			store.parsing.enable()
 			store.props.set({value: 'test'})
 			store.parsing.sync()
 
-			expect(store.value.previousValue()).toBe('test')
+			expect(store.value.last()).toBe('test')
 
 			store.parsing.disable()
 		})
@@ -148,7 +148,7 @@ describe('ParsingFeature', () => {
 			store.props.set({value: 'world'})
 
 			expect(store.parsing.tokens()).toEqual([{type: 'text', content: 'world', position: {start: 0, end: 5}}])
-			expect(store.value.previousValue()).toBe('world')
+			expect(store.value.last()).toBe('world')
 
 			store.parsing.disable()
 		})
@@ -177,7 +177,7 @@ describe('ParsingFeature', () => {
 			store.parsing.reparse()
 
 			expect(store.parsing.tokens()).toEqual([{type: 'text', content: 'test', position: {start: 0, end: 4}}])
-			expect(store.value.previousValue()).toBe('test')
+			expect(store.value.last()).toBe('test')
 
 			store.parsing.disable()
 		})

--- a/packages/core/src/features/parsing/ParseFeature.ts
+++ b/packages/core/src/features/parsing/ParseFeature.ts
@@ -11,7 +11,7 @@ export class ParsingFeature implements Feature {
 	readonly tokens = signal<Token[]>([])
 
 	readonly parser: Computed<Parser | undefined> = computed(() => {
-		if (!this._store.mark.hasMark()) return
+		if (!this._store.mark.enabled()) return
 
 		const markups = this._store.props.options().map(opt => opt.markup)
 		if (!markups.some(Boolean)) return

--- a/packages/core/src/features/parsing/ParseFeature.ts
+++ b/packages/core/src/features/parsing/ParseFeature.ts
@@ -42,7 +42,7 @@ export class ParsingFeature implements Feature {
 	sync() {
 		const inputValue = this._store.props.value() ?? this._store.props.defaultValue() ?? ''
 		this.tokens(parseWithParser(this._store, inputValue))
-		this._store.value.previousValue(inputValue)
+		this._store.value.last(inputValue)
 	}
 
 	#subscribeParse() {
@@ -50,7 +50,7 @@ export class ParsingFeature implements Feature {
 			if (this._store.caret.recovery()) {
 				const text = toString(this.tokens())
 				this.tokens(parseWithParser(this._store, text))
-				this._store.value.previousValue(text)
+				this._store.value.last(text)
 				return
 			}
 			this.tokens(

--- a/packages/core/src/features/parsing/utils/valueParser.ts
+++ b/packages/core/src/features/parsing/utils/valueParser.ts
@@ -14,20 +14,20 @@ export function getTokensByUI(store: Store): Token[] {
 
 export function computeTokensFromValue(store: Store): Token[] {
 	const value = store.props.value()
-	const previousValue = store.value.previousValue()
+	const previousValue = store.value.last()
 	const gap = findGap(previousValue, value)
 
 	if (!gap.left && !gap.right) {
-		store.value.previousValue(value)
+		store.value.last(value)
 		return store.parsing.tokens()
 	}
 
 	if (gap.left === 0 && previousValue !== undefined && gap.right !== undefined && gap.right >= previousValue.length) {
-		store.value.previousValue(value)
+		store.value.last(value)
 		return parseWithParser(store, value ?? '')
 	}
 
-	store.value.previousValue(value)
+	store.value.last(value)
 	const ranges = getRangeMap(store)
 	const tokens = store.parsing.tokens()
 

--- a/packages/core/src/features/value/README.md
+++ b/packages/core/src/features/value/README.md
@@ -11,14 +11,14 @@ Owns the editable-value buffer and its primary mutation event.
 
 ## Computed
 
-| Value     | Formula                                                                               |
-| --------- | ------------------------------------------------------------------------------------- |
+| Value     | Formula                                                                                         |
+| --------- | ----------------------------------------------------------------------------------------------- |
 | `current` | `last() ?? props.value() ?? ''` — the editable string view used by paste, block edit, copy/cut. |
 
 ## Events
 
-| Event    | Fired by                                                                                           | Listened by                                                                |
-| -------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Event    | Fired by                                                                                           | Listened by                                                       |
+| -------- | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
 | `change` | `KeyboardFeature` internals, `MarkHandler`, `deleteMark` (multi-emitter, semantic "value mutated") | `ValueFeature` itself (reads DOM, writes `last`, fires `reparse`) |
 
 ## Effects (`enable()`)

--- a/packages/core/src/features/value/README.md
+++ b/packages/core/src/features/value/README.md
@@ -4,26 +4,26 @@ Owns the editable-value buffer and its primary mutation event.
 
 ## State
 
-| Signal          | Purpose                                                                                                                                                 |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `previousValue` | Last serialized value pushed to `onChange`. Used to suppress redundant emissions and to seed the next parse.                                            |
-| `innerValue`    | Intermediate value used by uncontrolled flows (drag reorder, clipboard cut, mark remove). Written by many features; watched by this feature to reparse. |
+| Signal | Purpose                                                                                                                                                 |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `last` | Last serialized value pushed to `onChange`. Used to suppress redundant emissions and to seed the next parse.                                            |
+| `next` | Intermediate value used by uncontrolled flows (drag reorder, clipboard cut, mark remove). Written by many features; watched by this feature to reparse. |
 
 ## Computed
 
-| Value          | Formula                                                                                                  |
-| -------------- | -------------------------------------------------------------------------------------------------------- |
-| `currentValue` | `previousValue() ?? props.value() ?? ''` — the editable string view used by paste, block edit, copy/cut. |
+| Value     | Formula                                                                               |
+| --------- | ------------------------------------------------------------------------------------- |
+| `current` | `last() ?? props.value() ?? ''` — the editable string view used by paste, block edit, copy/cut. |
 
 ## Events
 
 | Event    | Fired by                                                                                           | Listened by                                                                |
 | -------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| `change` | `KeyboardFeature` internals, `MarkHandler`, `deleteMark` (multi-emitter, semantic "value mutated") | `ValueFeature` itself (reads DOM, writes `previousValue`, fires `reparse`) |
+| `change` | `KeyboardFeature` internals, `MarkHandler`, `deleteMark` (multi-emitter, semantic "value mutated") | `ValueFeature` itself (reads DOM, writes `last`, fires `reparse`) |
 
 ## Effects (`enable()`)
 
-- Watch `emit.change` → read `nodes.focus.target`, tokenize focused span, write `previousValue`, emit `reparse`.
-- Watch `state.innerValue` → reparse via `parseWithParser`, write `tokens` + `previousValue`.
+- Watch `emit.change` → read `nodes.focus.target`, tokenize focused span, write `last`, emit `reparse`.
+- Watch `state.next` → reparse via `parseWithParser`, write `tokens` + `last`.
 
 Both handlers were moved here from `SystemListenerFeature`.

--- a/packages/core/src/features/value/ValueFeature.spec.ts
+++ b/packages/core/src/features/value/ValueFeature.spec.ts
@@ -3,35 +3,35 @@ import {describe, it, expect, beforeEach, vi} from 'vitest'
 import {Store} from '../../store/Store'
 
 describe('ValueFeature', () => {
-	it('exposes previousValue, innerValue signals', () => {
+	it('exposes last, next signals', () => {
 		const store = new Store()
-		expect(typeof store.value.previousValue).toBe('function')
-		expect(typeof store.value.innerValue).toBe('function')
+		expect(typeof store.value.last).toBe('function')
+		expect(typeof store.value.next).toBe('function')
 	})
 
-	it('exposes currentValue computed defaulting to empty string', () => {
+	it('exposes current computed defaulting to empty string', () => {
 		const store = new Store()
-		expect(store.value.currentValue()).toBe('')
+		expect(store.value.current()).toBe('')
 	})
 
-	it('currentValue falls back to props.value when previousValue is unset', () => {
+	it('current falls back to props.value when last is unset', () => {
 		const store = new Store()
 		store.props.set({value: 'hello'})
-		expect(store.value.currentValue()).toBe('hello')
+		expect(store.value.current()).toBe('hello')
 	})
 
-	it('currentValue returns previousValue when set', () => {
+	it('current returns last when set', () => {
 		const store = new Store()
 		store.props.set({value: 'hello'})
-		store.value.previousValue('world')
-		expect(store.value.currentValue()).toBe('world')
+		store.value.last('world')
+		expect(store.value.current()).toBe('world')
 	})
 
 	it('exposes signal and computed instances directly', () => {
 		const store = new Store()
-		expect(typeof store.value.previousValue).toBe('function')
-		expect(typeof store.value.innerValue).toBe('function')
-		expect(typeof store.value.currentValue).toBe('function')
+		expect(typeof store.value.last).toBe('function')
+		expect(typeof store.value.next).toBe('function')
+		expect(typeof store.value.current).toBe('function')
 		expect(typeof store.value.change).toBe('function')
 	})
 
@@ -68,23 +68,23 @@ describe('ValueFeature', () => {
 		})
 	})
 
-	describe('innerValue handler', () => {
+	describe('next handler', () => {
 		let store: Store
 
 		beforeEach(() => {
 			store = new Store()
 		})
 
-		it('parses innerValue and writes tokens + previousValue', () => {
+		it('parses next and writes tokens + last', () => {
 			const onChange = vi.fn()
 			store.props.set({onChange, Mark: () => null, options: [{markup: '@[__value__]'}]})
 
 			store.value.enable()
 
-			store.value.innerValue('hello @[world]')
+			store.value.next('hello @[world]')
 
 			expect(store.parsing.tokens().length).toBeGreaterThan(0)
-			expect(store.value.previousValue()).toBe('hello @[world]')
+			expect(store.value.last()).toBe('hello @[world]')
 			expect(onChange).toHaveBeenCalledWith('hello @[world]')
 		})
 	})

--- a/packages/core/src/features/value/ValueFeature.ts
+++ b/packages/core/src/features/value/ValueFeature.ts
@@ -4,10 +4,10 @@ import type {Store} from '../../store/Store'
 import {parseWithParser, toString} from '../parsing'
 
 export class ValueFeature implements Feature {
-	readonly previousValue = signal<string | undefined>(undefined)
-	readonly innerValue = signal<string | undefined>(undefined)
+	readonly last = signal<string | undefined>(undefined)
+	readonly next = signal<string | undefined>(undefined)
 
-	readonly currentValue = computed(() => this.previousValue() ?? this._store.props.value() ?? '')
+	readonly current = computed(() => this.last() ?? this._store.props.value() ?? '')
 
 	readonly change = event()
 
@@ -26,7 +26,7 @@ export class ValueFeature implements Feature {
 					const tokens = this._store.parsing.tokens()
 					const serialized = toString(tokens)
 					onChange?.(serialized)
-					this.previousValue(serialized)
+					this.last(serialized)
 					trigger(this._store.parsing.tokens)
 					return
 				}
@@ -44,12 +44,12 @@ export class ValueFeature implements Feature {
 				this._store.parsing.reparse()
 			})
 
-			watch(this.innerValue, newValue => {
+			watch(this.next, newValue => {
 				if (newValue === undefined) return
 				const newTokens = parseWithParser(this._store, newValue)
 				batch(() => {
 					this._store.parsing.tokens(newTokens)
-					this.previousValue(newValue)
+					this.last(newValue)
 				})
 				this._store.props.onChange()?.(newValue)
 			})

--- a/packages/core/src/shared/classes/MarkputHandler.ts
+++ b/packages/core/src/shared/classes/MarkputHandler.ts
@@ -8,7 +8,7 @@ export class MarkputHandler {
 	}
 
 	get overlay() {
-		return this.store.overlay.overlay()
+		return this.store.overlay.element()
 	}
 
 	focus() {

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -68,7 +68,7 @@ export interface MarkputState {
 	last: string | undefined
 	recovery: Recovery | undefined
 	selecting: 'drag' | 'all' | undefined
-	overlayMatch: OverlayMatch | undefined
+	match: OverlayMatch | undefined
 	/** Annotated text with markups for mark */
 	value: string | undefined
 	/** Default value */

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -159,7 +159,7 @@ export type DragAction =
 	| {type: 'duplicate'; index: number}
 
 export interface DragActions {
-	drag: {(action: DragAction): void}
+	action: {(action: DragAction): void}
 }
 
 export interface Feature {

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -65,7 +65,7 @@ export interface CoreOption {
 export interface MarkputState {
 	tokens: Token[]
 	parser: Parser | undefined
-	previousValue: string | undefined
+	last: string | undefined
 	recovery: Recovery | undefined
 	selecting: 'drag' | 'all' | undefined
 	overlayMatch: OverlayMatch | undefined

--- a/packages/core/src/store/BlockStore.ts
+++ b/packages/core/src/store/BlockStore.ts
@@ -19,14 +19,14 @@ export class BlockStore {
 	}
 
 	#blockIndex = 0
-	#dragAction: DragActions['drag'] | null = null
+	#dragAction: DragActions['action'] | null = null
 	#cleanupContainer?: () => void
 	#cleanupGrip?: () => void
 	#cleanupMenu?: () => void
 
 	attachContainer(el: HTMLElement | null, blockIndex: number, actions: DragActions) {
 		this.#blockIndex = blockIndex
-		this.#dragAction = actions.drag
+		this.#dragAction = actions.action
 		if (el === this.refs.container) return
 		this.#cleanupContainer?.()
 		this.refs.container = el
@@ -71,7 +71,7 @@ export class BlockStore {
 
 	attachGrip(el: HTMLButtonElement | null, blockIndex: number, actions: DragActions) {
 		this.#blockIndex = blockIndex
-		this.#dragAction = actions.drag
+		this.#dragAction = actions.action
 		this.#cleanupGrip?.()
 		if (!el) return
 

--- a/packages/core/src/store/README.md
+++ b/packages/core/src/store/README.md
@@ -7,7 +7,7 @@ The central orchestrator of the markput system. Aggregates reactive state, compu
 - **Store**: Main state container that manages:
     - **Internal state** (`store.state`) — signals owned by features: tokens, previous value, inner value, recovery, selection mode, overlay match
     - **Props** (`store.props`) — readonly signals written only via `store.props.set()` (value, options, readOnly, drag, slots, etc.)
-    - **Computed** (`store.computed`) — derived values: `hasMark`, `parser`, `currentValue`, `containerComponent`, `containerProps`, slot resolvers
+    - **Computed** (`store.computed`) — derived values: `hasMark`, `parser`, `current`, `containerComponent`, `containerProps`, slot resolvers
     - **Events** (`store.emit`) — typed events: change, parse, delete, select, overlay, sync, focus, drag, lifecycle, and more
     - **DOM refs** (`store.state.container`, `store.state.overlay`) — reactive signals holding container and overlay HTMLElement references
     - **Node proxies** (`store.nodes`) — `focus` and `input` NodeProxy instances
@@ -26,7 +26,7 @@ store.props.set({value: 'Hello @[world](test)', readOnly: false})
 
 batch(() => {
     store.state.tokens(newTokens)
-    store.state.previousValue(serialized)
+    store.state.last(serialized)
 })
 ```
 

--- a/packages/core/src/store/README.md
+++ b/packages/core/src/store/README.md
@@ -7,7 +7,7 @@ The central orchestrator of the markput system. Aggregates reactive state, compu
 - **Store**: Main state container that manages:
     - **Internal state** (`store.state`) — signals owned by features: tokens, previous value, inner value, recovery, selection mode, overlay match
     - **Props** (`store.props`) — readonly signals written only via `store.props.set()` (value, options, readOnly, drag, slots, etc.)
-    - **Computed** (`store.computed`) — derived values: `hasMark`, `parser`, `current`, `containerComponent`, `containerProps`, slot resolvers
+    - **Computed** (`store.computed`) — derived values: `enabled`, `parser`, `current`, `containerComponent`, `containerProps`, slot resolvers
     - **Events** (`store.emit`) — typed events: change, parse, delete, select, overlay, sync, focus, drag, lifecycle, and more
     - **DOM refs** (`store.state.container`, `store.state.overlay`) — reactive signals holding container and overlay HTMLElement references
     - **Node proxies** (`store.nodes`) — `focus` and `input` NodeProxy instances

--- a/packages/core/src/store/Store.spec.ts
+++ b/packages/core/src/store/Store.spec.ts
@@ -68,8 +68,8 @@ describe('Store', () => {
 	describe('internal state signals', () => {
 		it('update when written directly', () => {
 			const store = new Store()
-			store.value.previousValue('hello')
-			expect(store.value.previousValue()).toBe('hello')
+			store.value.last('hello')
+			expect(store.value.last()).toBe('hello')
 		})
 
 		it('leave other keys unchanged when one signal is updated', () => {
@@ -135,23 +135,23 @@ describe('Store', () => {
 		})
 	})
 
-	describe('innerValue', () => {
-		it('update tokens and previousValue when innerValue is set', () => {
+	describe('next', () => {
+		it('update tokens and last when next is set', () => {
 			const store = new Store()
 			const dispose = effectScope(() => {
-				watch(store.value.innerValue, newValue => {
+				watch(store.value.next, newValue => {
 					if (newValue === undefined) return
 					const newTokens = parseWithParser(store, newValue)
 					batch(() => {
 						store.parsing.tokens(newTokens)
-						store.value.previousValue(newValue)
+						store.value.last(newValue)
 					})
 					store.props.onChange()?.(newValue)
 				})
 			})
-			store.value.innerValue('hello')
+			store.value.next('hello')
 			expect(store.parsing.tokens()).toEqual([{type: 'text', content: 'hello', position: {start: 0, end: 5}}])
-			expect(store.value.previousValue()).toBe('hello')
+			expect(store.value.last()).toBe('hello')
 			dispose()
 		})
 
@@ -160,17 +160,17 @@ describe('Store', () => {
 			const onChange = vi.fn()
 			store.props.set({onChange})
 			const dispose = effectScope(() => {
-				watch(store.value.innerValue, newValue => {
+				watch(store.value.next, newValue => {
 					if (newValue === undefined) return
 					const newTokens = parseWithParser(store, newValue)
 					batch(() => {
 						store.parsing.tokens(newTokens)
-						store.value.previousValue(newValue)
+						store.value.last(newValue)
 					})
 					store.props.onChange()?.(newValue)
 				})
 			})
-			store.value.innerValue('world')
+			store.value.next('world')
 			expect(onChange).toHaveBeenCalledOnce()
 			expect(onChange).toHaveBeenCalledWith('world')
 			dispose()
@@ -179,17 +179,17 @@ describe('Store', () => {
 		it('not throw when onChange is not set', () => {
 			const store = new Store()
 			const dispose = effectScope(() => {
-				watch(store.value.innerValue, newValue => {
+				watch(store.value.next, newValue => {
 					if (newValue === undefined) return
 					const newTokens = parseWithParser(store, newValue)
 					batch(() => {
 						store.parsing.tokens(newTokens)
-						store.value.previousValue(newValue)
+						store.value.last(newValue)
 					})
 					store.props.onChange()?.(newValue)
 				})
 			})
-			expect(() => store.value.innerValue('test')).not.toThrow()
+			expect(() => store.value.next('test')).not.toThrow()
 			dispose()
 		})
 	})
@@ -461,44 +461,44 @@ describe('Store', () => {
 		})
 	})
 
-	describe('currentValue (computed)', () => {
-		it('return empty string when both previousValue and value are undefined', () => {
+	describe('current (computed)', () => {
+		it('return empty string when both last and value are undefined', () => {
 			const store = new Store()
-			expect(store.value.currentValue()).toBe('')
+			expect(store.value.current()).toBe('')
 		})
 
-		it('return previousValue when set', () => {
+		it('return last when set', () => {
 			const store = new Store()
-			store.value.previousValue('cached')
-			expect(store.value.currentValue()).toBe('cached')
+			store.value.last('cached')
+			expect(store.value.current()).toBe('cached')
 		})
 
-		it('fall back to props.value when previousValue is undefined', () => {
+		it('fall back to props.value when last is undefined', () => {
 			const store = new Store()
 			store.props.set({value: 'prop-value'})
-			expect(store.value.currentValue()).toBe('prop-value')
+			expect(store.value.current()).toBe('prop-value')
 		})
 
-		it('prefer previousValue over props.value', () => {
+		it('prefer last over props.value', () => {
 			const store = new Store()
-			store.value.previousValue('cached')
+			store.value.last('cached')
 			store.props.set({value: 'prop-value'})
-			expect(store.value.currentValue()).toBe('cached')
+			expect(store.value.current()).toBe('cached')
 		})
 
-		it('react to previousValue changes', () => {
+		it('react to last changes', () => {
 			const store = new Store()
-			expect(store.value.currentValue()).toBe('')
-			store.value.previousValue('updated')
-			expect(store.value.currentValue()).toBe('updated')
+			expect(store.value.current()).toBe('')
+			store.value.last('updated')
+			expect(store.value.current()).toBe('updated')
 		})
 
-		it('react to props.value changes when previousValue is undefined', () => {
+		it('react to props.value changes when last is undefined', () => {
 			const store = new Store()
 			store.props.set({value: 'initial'})
-			expect(store.value.currentValue()).toBe('initial')
+			expect(store.value.current()).toBe('initial')
 			store.props.set({value: 'changed'})
-			expect(store.value.currentValue()).toBe('changed')
+			expect(store.value.current()).toBe('changed')
 		})
 	})
 })

--- a/packages/core/src/store/Store.spec.ts
+++ b/packages/core/src/store/Store.spec.ts
@@ -26,7 +26,7 @@ describe('Store', () => {
 		const store = new Store()
 		expect(typeof store.parsing.reparse).toBe('function')
 		expect(typeof store.value.change).toBe('function')
-		expect(typeof store.mark.markRemove).toBe('function')
+		expect(typeof store.mark.remove).toBe('function')
 	})
 
 	describe('handler', () => {
@@ -379,43 +379,43 @@ describe('Store', () => {
 		})
 	})
 
-	describe('hasMark (computed)', () => {
+	describe('enabled (computed)', () => {
 		it('return false when no Mark override and no per-option Mark', () => {
 			const store = new Store()
-			expect(store.mark.hasMark()).toBe(false)
+			expect(store.mark.enabled()).toBe(false)
 		})
 
 		it('return true when Mark override is set', () => {
 			const store = new Store()
 			store.props.set({Mark: () => null})
-			expect(store.mark.hasMark()).toBe(true)
+			expect(store.mark.enabled()).toBe(true)
 		})
 
 		it('return true when option has per-option Mark', () => {
 			const store = new Store()
 			store.props.set({options: [{markup: '@[__value__]', Mark: () => null} as Record<string, unknown>]})
-			expect(store.mark.hasMark()).toBe(true)
+			expect(store.mark.enabled()).toBe(true)
 		})
 
 		it('return true when Mark override is set even without per-option Mark', () => {
 			const store = new Store()
 			store.props.set({Mark: () => null, options: [{markup: '@[__value__]'}]})
-			expect(store.mark.hasMark()).toBe(true)
+			expect(store.mark.enabled()).toBe(true)
 		})
 
 		it('return false when option has Mark set to null', () => {
 			const store = new Store()
 			store.props.set({options: [{markup: '@[__value__]', Mark: null} as Record<string, unknown>]})
-			expect(store.mark.hasMark()).toBe(false)
+			expect(store.mark.enabled()).toBe(false)
 		})
 
 		it('react to Mark override changes', () => {
 			const store = new Store()
-			expect(store.mark.hasMark()).toBe(false)
+			expect(store.mark.enabled()).toBe(false)
 			store.props.set({Mark: () => null})
-			expect(store.mark.hasMark()).toBe(true)
+			expect(store.mark.enabled()).toBe(true)
 			store.props.set({Mark: undefined})
-			expect(store.mark.hasMark()).toBe(false)
+			expect(store.mark.enabled()).toBe(false)
 		})
 	})
 
@@ -423,7 +423,7 @@ describe('Store', () => {
 		it('resolve mark slot for text token using span fallback', () => {
 			const store = new Store()
 			const token = {type: 'text', content: 'hello', position: {start: 0, end: 5}} as const
-			const [component, props] = store.mark.mark()(token)
+			const [component, props] = store.mark.slot()(token)
 			expect(component).toBe('span')
 			expect(props).toEqual({})
 		})
@@ -433,7 +433,7 @@ describe('Store', () => {
 			const store = new Store()
 			store.props.set({Span: CustomSpan})
 			const token = {type: 'text', content: 'hello', position: {start: 0, end: 5}} as const
-			const [component, props] = store.mark.mark()(token)
+			const [component, props] = store.mark.slot()(token)
 			expect(component).toBe(CustomSpan)
 			expect(props).toEqual({value: 'hello'})
 		})
@@ -448,7 +448,7 @@ describe('Store', () => {
 				descriptor: {index: 0},
 				position: {start: 0, end: 5},
 			} as any
-			expect(() => store.mark.mark()(token)).toThrow('No mark component found')
+			expect(() => store.mark.slot()(token)).toThrow('No mark component found')
 		})
 
 		it('resolve overlay from global Overlay component', () => {

--- a/packages/core/src/store/Store.spec.ts
+++ b/packages/core/src/store/Store.spec.ts
@@ -54,7 +54,7 @@ describe('Store', () => {
 			expect(handler.overlay).toBe(null)
 			// oxlint-disable-next-line no-unsafe-type-assertion -- minimal stub for reference identity check only, no DOM methods used
 			const stub = {} as HTMLElement
-			store.overlay.overlay(stub)
+			store.overlay.element(stub)
 			expect(handler.overlay).toBe(stub)
 		})
 
@@ -455,7 +455,7 @@ describe('Store', () => {
 			const CustomOverlay = () => null
 			const store = new Store()
 			store.props.set({Overlay: CustomOverlay})
-			const [Component, props] = store.overlay.overlaySlot()()
+			const [Component, props] = store.overlay.slot()()
 			expect(Component).toBe(CustomOverlay)
 			expect(props).toEqual({})
 		})

--- a/packages/core/src/store/Store.ts
+++ b/packages/core/src/store/Store.ts
@@ -41,10 +41,8 @@ export class Store {
 	readonly clipboard = new ClipboardFeature(this)
 	readonly parsing = new ParsingFeature(this)
 
-	readonly #features: Feature[] = []
-
 	constructor() {
-		this.#features = [
+		const features: Feature[] = [
 			this.lifecycle,
 			this.value,
 			this.mark,
@@ -57,7 +55,7 @@ export class Store {
 			this.clipboard,
 			this.parsing,
 		]
-		watch(this.lifecycle.mounted, () => this.#features.forEach(f => f.enable()))
-		watch(this.lifecycle.unmounted, () => this.#features.forEach(f => f.disable()))
+		watch(this.lifecycle.mounted, () => features.forEach(f => f.enable()))
+		watch(this.lifecycle.unmounted, () => features.forEach(f => f.disable()))
 	}
 }

--- a/packages/react/markput/src/components/Block.tsx
+++ b/packages/react/markput/src/components/Block.tsx
@@ -16,9 +16,9 @@ interface BlockProps {
 }
 
 export const Block = memo(({token}: BlockProps) => {
-	const {blockStore, drag, Component, slotProps, isDragging, tokens} = useMarkput(s => ({
+	const {blockStore, action, Component, slotProps, isDragging, tokens} = useMarkput(s => ({
 		blockStore: s.blocks.get(token),
-		drag: s.drag.drag,
+		action: s.drag.action,
 		Component: s.slots.blockComponent,
 		slotProps: s.slots.blockProps,
 		isDragging: s.blocks.get(token).state.isDragging,
@@ -28,7 +28,7 @@ export const Block = memo(({token}: BlockProps) => {
 
 	return (
 		<Component
-			ref={(el: HTMLElement | null) => blockStore.attachContainer(el, blockIndex, {drag})}
+			ref={(el: HTMLElement | null) => blockStore.attachContainer(el, blockIndex, {action})}
 			data-testid="block"
 			{...slotProps}
 			// oxlint-disable-next-line no-unsafe-type-assertion -- slotProps.className is raw and needs casting to string

--- a/packages/react/markput/src/components/DragHandle.tsx
+++ b/packages/react/markput/src/components/DragHandle.tsx
@@ -9,9 +9,9 @@ import styles from '@markput/core/styles.module.css'
 const iconGrip = `${styles.Icon} ${styles.IconGrip}`
 
 export const DragHandle = memo(({token, blockIndex}: {token: TokenType; blockIndex: number}) => {
-	const {blockStore, drag, readOnly, draggable, isDragging, isHovered} = useMarkput(s => ({
+	const {blockStore, action, readOnly, draggable, isDragging, isHovered} = useMarkput(s => ({
 		blockStore: s.blocks.get(token),
-		drag: s.drag.drag,
+		action: s.drag.action,
 		readOnly: s.props.readOnly,
 		draggable: s.props.draggable,
 		isDragging: s.blocks.get(token).state.isDragging,
@@ -29,7 +29,7 @@ export const DragHandle = memo(({token, blockIndex}: {token: TokenType; blockInd
 			)}
 		>
 			<button
-				ref={(el: HTMLButtonElement | null) => blockStore.attachGrip(el, blockIndex, {drag})}
+				ref={(el: HTMLButtonElement | null) => blockStore.attachGrip(el, blockIndex, {action})}
 				type="button"
 				draggable
 				className={cx(styles.GripButton, isDragging && styles.GripButtonDragging)}

--- a/packages/react/markput/src/components/OverlayRenderer.tsx
+++ b/packages/react/markput/src/components/OverlayRenderer.tsx
@@ -5,17 +5,17 @@ import {Suggestions} from './Suggestions'
 
 export const OverlayRenderer = memo(() => {
 	const {
-		overlayMatch,
+		match,
 		key: keyGen,
 		resolveOverlay,
 	} = useMarkput(s => ({
-		overlayMatch: s.overlay.overlayMatch,
+		match: s.overlay.match,
 		key: s.key,
-		resolveOverlay: s.overlay.overlaySlot,
+		resolveOverlay: s.overlay.slot,
 	}))
-	const key = useMemo(() => (overlayMatch ? keyGen.get(overlayMatch.option) : undefined), [overlayMatch])
+	const key = useMemo(() => (match ? keyGen.get(match.option) : undefined), [match])
 
-	const [Overlay, props] = resolveOverlay(overlayMatch?.option, Suggestions)
+	const [Overlay, props] = resolveOverlay(match?.option, Suggestions)
 
 	if (!key) return
 

--- a/packages/react/markput/src/components/Token.tsx
+++ b/packages/react/markput/src/components/Token.tsx
@@ -6,7 +6,7 @@ import {TokenContext} from '../lib/providers/TokenContext'
 
 export const Token = memo(({mark}: {mark: TokenType}) => {
 	const {resolveMarkSlot, key} = useMarkput(s => ({
-		resolveMarkSlot: s.mark.mark,
+		resolveMarkSlot: s.mark.slot,
 		key: s.key,
 	}))
 	const [Component, props] = resolveMarkSlot(mark)

--- a/packages/react/markput/src/lib/hooks/useOverlay.tsx
+++ b/packages/react/markput/src/lib/hooks/useOverlay.tsx
@@ -19,7 +19,7 @@ export interface OverlayHandler {
 }
 
 export function useOverlay(): OverlayHandler {
-	const match = useMarkput(s => s.overlay.overlayMatch)
+	const match = useMarkput(s => s.overlay.match)
 	const storeRef = useRef<Store | null>(null)
 	if (storeRef.current === null) {
 		const ctx = useContext(StoreContext)
@@ -33,13 +33,13 @@ export function useOverlay(): OverlayHandler {
 		return Caret.getAbsolutePosition()
 	}, [match])
 
-	const close = useCallback(() => store.overlay.overlayClose(), [store])
+	const close = useCallback(() => store.overlay.close(), [store])
 	const select = useCallback(
 		(value: {value: string; meta?: string}) => {
 			if (!match) return
 			const mark = createMarkFromOverlay(match, value.value, value.meta)
-			store.overlay.overlaySelect({mark, match})
-			store.overlay.overlayClose()
+			store.overlay.select({mark, match})
+			store.overlay.close()
 		},
 		[match, store]
 	)
@@ -47,10 +47,10 @@ export function useOverlay(): OverlayHandler {
 	const ref = useMemo(
 		(): RefObject<HTMLElement | null> => ({
 			get current() {
-				return store.overlay.overlay()
+				return store.overlay.element()
 			},
 			set current(v: HTMLElement | null) {
-				store.overlay.overlay(v)
+				store.overlay.element(v)
 			},
 		}),
 		[store]

--- a/packages/vue/markput/src/components/Block.vue
+++ b/packages/vue/markput/src/components/Block.vue
@@ -36,7 +36,7 @@ const otherSlotProps = computed(() => {
 <template>
 	<component
 		:is="blockComponent"
-		:ref="(el: any) => blockStore.attachContainer(el?.$el ?? el, props.blockIndex, {drag: store.drag.drag})"
+		:ref="(el: any) => blockStore.attachContainer(el?.$el ?? el, props.blockIndex, {action: store.drag.action})"
 		data-testid="block"
 		v-bind="otherSlotProps"
 		:class="[styles.Block, slotProps?.className as string | undefined]"

--- a/packages/vue/markput/src/components/DragHandle.vue
+++ b/packages/vue/markput/src/components/DragHandle.vue
@@ -31,7 +31,7 @@ const alwaysShowHandle = computed(() => getAlwaysShowHandle(draggable.value))
 			:ref="
 				el =>
 					blockStore.attachGrip(el as HTMLButtonElement | null, props.blockIndex, {
-						drag: store.drag.drag,
+						action: store.drag.action,
 					})
 			"
 			type="button"

--- a/packages/vue/markput/src/components/OverlayRenderer.vue
+++ b/packages/vue/markput/src/components/OverlayRenderer.vue
@@ -9,12 +9,12 @@ import Suggestions from './Suggestions/Suggestions.vue'
 
 const store = useStore()
 // oxlint-disable-next-line no-unsafe-type-assertion -- narrows generic OverlayMatch<CoreOption> → OverlayMatch<Option>; unrelated to Slot typing
-const overlayMatchRef = useMarkput(s => s.overlay.overlayMatch) as Ref<OverlayMatch<Option> | undefined>
-const overlayKey = computed(() => (overlayMatchRef.value ? store.key.get(overlayMatchRef.value.option) : undefined))
-const resolveOverlay = useMarkput(s => s.overlay.overlaySlot)
+const matchRef = useMarkput(s => s.overlay.match) as Ref<OverlayMatch<Option> | undefined>
+const overlayKey = computed(() => (matchRef.value ? store.key.get(matchRef.value.option) : undefined))
+const resolveOverlay = useMarkput(s => s.overlay.slot)
 
 const resolved = computed(() => {
-	const match = overlayMatchRef.value
+	const match = matchRef.value
 	if (!match) return null
 	return resolveOverlay.value(match.option, Suggestions)
 })

--- a/packages/vue/markput/src/components/Token.vue
+++ b/packages/vue/markput/src/components/Token.vue
@@ -19,7 +19,7 @@ const Token = defineComponent({
 
 		const store = useStore()
 		const key = store.key
-		const resolveMarkSlot = useMarkput(s => s.mark.mark)
+		const resolveMarkSlot = useMarkput(s => s.mark.slot)
 
 		return () => {
 			const [Comp, compProps] = resolveMarkSlot.value(props.mark)

--- a/packages/vue/markput/src/lib/hooks/useOverlay.ts
+++ b/packages/vue/markput/src/lib/hooks/useOverlay.ts
@@ -22,7 +22,7 @@ export interface OverlayHandler {
 
 export function useOverlay(): OverlayHandler {
 	const store = useStore()
-	const matchRef = useMarkput(s => s.overlay.overlayMatch) as Ref<OverlayMatch<Option> | undefined>
+	const matchRef = useMarkput(s => s.overlay.match) as Ref<OverlayMatch<Option> | undefined>
 
 	const style = computed(() => {
 		// Depend on matchRef so position recalculates as user types/moves caret
@@ -32,21 +32,21 @@ export function useOverlay(): OverlayHandler {
 		return Caret.getAbsolutePosition()
 	})
 
-	const close = () => store.overlay.overlayClose()
+	const close = () => store.overlay.close()
 	const select = (value: {value: string; meta?: string}) => {
 		const match = matchRef.value
 		if (!match) return
 		const mark = createMarkFromOverlay(match, value.value, value.meta)
-		store.overlay.overlaySelect({mark, match})
-		store.overlay.overlayClose()
+		store.overlay.select({mark, match})
+		store.overlay.close()
 	}
 
 	const ref = {
 		get current() {
-			return store.overlay.overlay()
+			return store.overlay.element()
 		},
 		set current(v: HTMLElement | null) {
-			store.overlay.overlay(v)
+			store.overlay.element(v)
 		},
 	}
 

--- a/packages/website/src/content/docs/development/architecture.md
+++ b/packages/website/src/content/docs/development/architecture.md
@@ -108,7 +108,7 @@ There are **two parse paths**: `getTokensByUI` (user editing — re-parses only 
 2. OverlayFeature runs a trigger probe (on `store.value.change()`, or on `selectionchange` when `showOverlayOn` includes `selectionChange`)
         ↓
 3. If found:
-   - store.overlay.overlayMatch set
+   - store.overlay.match set
         ↓
 4. Overlay component receives match via useOverlay()
         ↓
@@ -117,11 +117,11 @@ There are **two parse paths**: `getTokensByUI` (user editing — re-parses only 
 6. User selects item:
    - Overlay calls select({ value, meta })
         ↓
-7. store.overlay.overlaySelect() emitted
+7. store.overlay.select() emitted
         ↓
 8. Markup inserted, onChange called with new text
         ↓
-9. store.overlay.overlayClose() closes overlay
+9. store.overlay.close() closes overlay
 ```
 
 ## Parsing Pipeline
@@ -219,8 +219,8 @@ Events use `event<T>()` to create typed emitters backed by reactive signals:
 | --------------- | -------------- | --------------------------- | -------------------------------- |
 | `change`        | value          | Text content changes        | `void`                           |
 | `reparse`       | parsing        | Re-parse triggered          | `void`                           |
-| `overlayClose`  | overlay        | Close overlay               | `void`                           |
-| `overlaySelect` | overlay        | Overlay item selected       | `{ mark: Token, match: OverlayMatch }` |
+| `close`         | overlay        | Close overlay               | `void`                           |
+| `select`        | overlay        | Overlay item selected       | `{ mark: Token, match: OverlayMatch }` |
 | `remove`        | mark           | Mark removed                | `{ token: Token }`               |
 | `reconcile`     | dom            | Post-render DOM alignment   | `void`                           |
 | `rendered`      | lifecycle      | After tokens render         | `void`                           |
@@ -310,7 +310,7 @@ class Store {
         value: ValueFeature            // last, next, current, change event
         parsing: ParsingFeature        // tokens, parser, reparse event
         mark: MarkFeature              // enabled, slot, remove event
-        overlay: OverlayFeature        // overlayMatch, overlay, overlaySelect, overlayClose
+        overlay: OverlayFeature        // match, element, slot, select, close
         slots: SlotsFeature            // container ref, isBlock, isDraggable, slot computeds
         caret: CaretFeature            // recovery, selecting (merged Focus + TextSelection)
         keyboard: KeyboardFeature      // input, block edit, arrow nav (merged Input + BlockEdit + ArrowNav)

--- a/packages/website/src/content/docs/development/architecture.md
+++ b/packages/website/src/content/docs/development/architecture.md
@@ -221,7 +221,7 @@ Events use `event<T>()` to create typed emitters backed by reactive signals:
 | `reparse`       | parsing        | Re-parse triggered          | `void`                           |
 | `overlayClose`  | overlay        | Close overlay               | `void`                           |
 | `overlaySelect` | overlay        | Overlay item selected       | `{ mark: Token, match: OverlayMatch }` |
-| `markRemove`    | mark           | Mark removed                | `{ token: Token }`               |
+| `remove`        | mark           | Mark removed                | `{ token: Token }`               |
 | `reconcile`     | dom            | Post-render DOM alignment   | `void`                           |
 | `rendered`      | lifecycle      | After tokens render         | `void`                           |
 | `mounted`       | lifecycle      | Framework initial mount      | `void`                           |
@@ -235,7 +235,7 @@ Events use `event<T>()` to create typed emitters backed by reactive signals:
 store.value.change()
 
 // Emit a payload event
-store.mark.markRemove({ token })
+store.mark.remove({ token })
 
 // Subscribe to an event
 import {watch, effectScope} from '@markput/core'
@@ -309,7 +309,7 @@ class Store {
         lifecycle: LifecycleFeature    // mounted, unmounted, rendered events
         value: ValueFeature            // last, next, current, change event
         parsing: ParsingFeature        // tokens, parser, reparse event
-        mark: MarkFeature              // hasMark, mark, markRemove event
+        mark: MarkFeature              // enabled, slot, remove event
         overlay: OverlayFeature        // overlayMatch, overlay, overlaySelect, overlayClose
         slots: SlotsFeature            // container ref, isBlock, isDraggable, slot computeds
         caret: CaretFeature            // recovery, selecting (merged Focus + TextSelection)
@@ -355,7 +355,7 @@ const tokens = store.parsing.tokens.use()
 | **LifecycleFeature**          | Mount/unmount/render lifecycle events                     |
 | **ValueFeature**              | Previous/inner/current value tracking, change event       |
 | **ParsingFeature**            | Token parsing, parser selection, reparse event            |
-| **MarkFeature**               | Mark detection, mark slot resolution, markRemove event    |
+| **MarkFeature**               | Mark detection, mark slot resolution, remove event        |
 | **OverlayFeature**            | Overlay trigger detection, position, open/close           |
 | **SlotsFeature**              | Container ref, slot component/props resolution            |
 | **CaretFeature**              | Caret tracking, focus recovery, text selection state      |

--- a/packages/website/src/content/docs/development/architecture.md
+++ b/packages/website/src/content/docs/development/architecture.md
@@ -307,7 +307,7 @@ class Store {
 
     readonly feature: {
         lifecycle: LifecycleFeature    // mounted, unmounted, rendered events
-        value: ValueFeature            // previousValue, innerValue, currentValue, change event
+        value: ValueFeature            // last, next, current, change event
         parsing: ParsingFeature        // tokens, parser, reparse event
         mark: MarkFeature              // hasMark, mark, markRemove event
         overlay: OverlayFeature        // overlayMatch, overlay, overlaySelect, overlayClose
@@ -336,7 +336,7 @@ store.parsing.tokens(newTokens)
 import {batch} from '@markput/core'
 batch(() => {
 	store.parsing.tokens(newTokens)
-	store.value.previousValue(serialized)
+	store.value.last(serialized)
 })
 
 // Framework-provided props (MarkedInput calls store.props.set on each render)


### PR DESCRIPTION
## Summary

- Rename 12 reactive symbols across ValueFeature, MarkFeature, OverlayFeature, and DragFeature so each name reads clearly within its feature namespace
- Pure renaming refactor — no behavioral changes
- Also includes prior flattening refactor (drop `state`/`computed`/`emit` containers, promote to store.*)

## Renames

| Feature | Old | New |
|---------|-----|-----|
| value | `previousValue` | `last` |
| value | `innerValue` | `next` |
| value | `currentValue` | `current` |
| mark | `hasMark` | `enabled` |
| mark | `mark` | `slot` |
| mark | `markRemove` | `remove` |
| overlay | `overlayMatch` | `match` |
| overlay | `overlay` | `element` |
| overlay | `overlaySlot` | `slot` |
| overlay | `overlaySelect` | `select` |
| overlay | `overlayClose` | `close` |
| drag | `drag` | `action` |

## Verification

All checks pass: 893 tests, typecheck, lint, format, build.