### PR TITLE
test(storybook): format html snapshots

### DIFF
--- a/packages/storybook/src/pages/__snapshots__/stories.react.spec.tsx.snap
+++ b/packages/storybook/src/pages/__snapshots__/stories.react.spec.tsx.snap
@@ -1,273 +1,1620 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Component: stories > Ant stories > Story Tagged 1`] = `"<div><span contenteditable="true">We preset five different colors. You can set color property such as </span><span tabindex="0">success</span><span contenteditable="true">, </span><span tabindex="0">processing</span><span contenteditable="true">, </span><span tabindex="0">error</span><span contenteditable="true">, </span><span tabindex="0">default</span><span contenteditable="true"> and </span><span tabindex="0">warning</span><span contenteditable="true"> to show specific status.</span></div>"`;
+exports[`Component: stories > Ant stories > Story Tagged 1`] = `
+"<div>
+  <span contenteditable="true">We preset five different colors. You can set color property such as </span>
+  <span tabindex="0">success</span>
+  <span contenteditable="true">, </span>
+  <span tabindex="0">processing</span>
+  <span contenteditable="true">, </span>
+  <span tabindex="0">error</span>
+  <span contenteditable="true">, </span>
+  <span tabindex="0">default</span>
+  <span contenteditable="true"> and </span>
+  <span tabindex="0">warning</span>
+  <span contenteditable="true"> to show specific status.</span>
+</div>"
+`;
 
-exports[`Component: stories > Base stories > Story Autocomplete 1`] = `"<div><span contenteditable="true">Hello, clickable marked @world!</span></div>"`;
+exports[`Component: stories > Base stories > Story Autocomplete 1`] = `
+"<div>
+  <span contenteditable="true">Hello, clickable marked @world!</span>
+</div>"
+`;
 
 exports[`Component: stories > Base stories > Story Configured 1`] = `
-"<div><div><span contenteditable="true">Enter the '@' for calling </span><button type="button" tabindex="0">primary</button><span contenteditable="true"> suggestions and '/' for </span><button type="button" tabindex="0">default</button><span contenteditable="true">!
-Mark is can be a any component with any logic. In this example it is the </span><button type="button" tabindex="0">Button</button><span contenteditable="true">: clickable primary or secondary.
-For found mark used </span><button type="button" tabindex="0">annotations</button><span contenteditable="true">.</span></div><div></div><div><button>Copy</button><div><pre data-value="Enter the '@' for calling @[primary](primary:4) suggestions and '/' for @[default](default:7)!
-Mark is can be a any component with any logic. In this example it is the @[Button](primary:54): clickable primary or secondary.
-For found mark used @[annotations](default:123).">Enter the '@' for calling @[primary](primary:4) suggestions and '/' for @[default](default:7)!
-Mark is can be a any component with any logic. In this example it is the @[Button](primary:54): clickable primary or secondary.
-For found mark used @[annotations](default:123).</pre></div><div><span>Plain text</span><span>37 words · 271 chars · 3 lines</span></div></div></div>"
+"<div>
+  <div>
+    <span contenteditable="true">Enter the '@' for calling </span>
+    <button type="button" tabindex="0">primary</button>
+    <span contenteditable="true"> suggestions and '/' for </span>
+    <button type="button" tabindex="0">default</button>
+    <span contenteditable="true">!&#10;Mark is can be a any component with any logic. In this example it is the </span>
+    <button type="button" tabindex="0">Button</button>
+    <span contenteditable="true">: clickable primary or secondary.&#10;For found mark used </span>
+    <button type="button" tabindex="0">annotations</button>
+    <span contenteditable="true">.</span>
+  </div>
+  <div></div>
+  <div>
+    <button>Copy</button>
+    <div>
+      <pre data-value="Enter the '@' for calling @[primary](primary:4) suggestions and '/' for @[default](default:7)!&#10;Mark is can be a any component with any logic. In this example it is the @[Button](primary:54): clickable primary or secondary.&#10;For found mark used @[annotations](default:123).">Enter the '@' for calling @[primary](primary:4) suggestions and '/' for @[default](default:7)!&#10;Mark is can be a any component with any logic. In this example it is the @[Button](primary:54): clickable primary or secondary.&#10;For found mark used @[annotations](default:123).</pre>
+    </div>
+    <div>
+      <span>Plain text</span>
+      <span>37 words · 271 chars · 3 lines</span>
+    </div>
+  </div>
+</div>"
 `;
 
-exports[`Component: stories > Base stories > Story Default 1`] = `"<div><span contenteditable="true">Hello, clickable marked </span><mark tabindex="0">world</mark><span contenteditable="true">!</span></div>"`;
+exports[`Component: stories > Base stories > Story Default 1`] = `
+"<div>
+  <span contenteditable="true">Hello, clickable marked </span>
+  <mark tabindex="0">world</mark>
+  <span contenteditable="true">!</span>
+</div>"
+`;
 
 exports[`Component: stories > Clipboard stories > Story Drag 1`] = `
-"<div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span contenteditable="true">hello
-</span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><mark data-testid="mark" tabindex="0">world</mark></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span contenteditable="true">
-foo</span></div></div>"
+"<div>
+  <div data-testid="block">
+    <div>
+      <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+        <span></span>
+      </button>
+    </div>
+    <span contenteditable="true">hello&#10;</span>
+  </div>
+  <div data-testid="block">
+    <div>
+      <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+        <span></span>
+      </button>
+    </div>
+    <mark data-testid="mark" tabindex="0">world</mark>
+  </div>
+  <div data-testid="block">
+    <div>
+      <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+        <span></span>
+      </button>
+    </div>
+    <span contenteditable="true">&#10;foo</span>
+  </div>
+</div>"
 `;
 
-exports[`Component: stories > Clipboard stories > Story Inline 1`] = `"<div><span contenteditable="true">hello </span><mark data-testid="mark" tabindex="0">world</mark><span contenteditable="true"> foo</span></div>"`;
+exports[`Component: stories > Clipboard stories > Story Inline 1`] = `
+"<div>
+  <span contenteditable="true">hello </span>
+  <mark data-testid="mark" tabindex="0">world</mark>
+  <span contenteditable="true"> foo</span>
+</div>"
+`;
 
-exports[`Component: stories > Clipboard stories > Story NestedMarkStory 1`] = `"<div><span contenteditable="true">hello </span><mark data-testid="mark" tabindex="0"><strong>wor</strong><em>ld</em></mark><span contenteditable="true"> foo</span></div>"`;
+exports[`Component: stories > Clipboard stories > Story NestedMarkStory 1`] = `
+"<div>
+  <span contenteditable="true">hello </span>
+  <mark data-testid="mark" tabindex="0">
+    <strong>wor</strong>
+    <em>ld</em>
+  </mark>
+  <span contenteditable="true"> foo</span>
+</div>"
+`;
 
-exports[`Component: stories > Clipboard stories > Story PlainText 1`] = `"<div><span contenteditable="true">abc</span></div>"`;
+exports[`Component: stories > Clipboard stories > Story PlainText 1`] = `
+"<div>
+  <span contenteditable="true">abc</span>
+</div>"
+`;
 
 exports[`Component: stories > Drag stories > Story Markdown 1`] = `
-"<div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true">Welcome to </span><span tabindex="0"><span><span contenteditable="true">Marked Input</span></span></span><span contenteditable="true"></span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span contenteditable="true">A powerful library for parsing rich text with markdown formatting.
-
-</span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true">Features</span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true"></span><span tabindex="0"><span><span contenteditable="true">Bold</span></span></span><span contenteditable="true"> and </span><span tabindex="0"><span><span contenteditable="true">italic</span></span></span><span contenteditable="true"> text support</span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true"></span><span tabindex="0">Code snippets</span><span contenteditable="true"> and </span><span tabindex="0">code blocks</span><span contenteditable="true"></span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true"></span><span tabindex="0">Strikethrough</span><span contenteditable="true"> for deleted content</span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true">Links like </span><span tabindex="0">GitHub</span><span contenteditable="true"></span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true">Example</span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0">const parser = new ParserV2(['**__value__**', '*__value__*'])
-const result = parser.parse('Hello **world**!')
-</span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span contenteditable="true">
-
-Visit our docs for more details.</span></div></div>"
+"<div>
+  <div data-testid="block">
+    <div>
+      <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+        <span></span>
+      </button>
+    </div>
+    <span tabindex="0">
+      <span>
+        <span contenteditable="true">Welcome to </span>
+        <span tabindex="0">
+          <span>
+            <span contenteditable="true">Marked Input</span>
+          </span>
+        </span>
+        <span contenteditable="true"></span>
+      </span>
+    </span>
+  </div>
+  <div data-testid="block">
+    <div>
+      <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+        <span></span>
+      </button>
+    </div>
+    <span contenteditable="true">A powerful library for parsing rich text with markdown formatting.&#10;&#10;</span>
+  </div>
+  <div data-testid="block">
+    <div>
+      <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+        <span></span>
+      </button>
+    </div>
+    <span tabindex="0">
+      <span>
+        <span contenteditable="true">Features</span>
+      </span>
+    </span>
+  </div>
+  <div data-testid="block">
+    <div>
+      <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+        <span></span>
+      </button>
+    </div>
+    <span tabindex="0">
+      <span>
+        <span contenteditable="true"></span>
+        <span tabindex="0">
+          <span>
+            <span contenteditable="true">Bold</span>
+          </span>
+        </span>
+        <span contenteditable="true"> and </span>
+        <span tabindex="0">
+          <span>
+            <span contenteditable="true">italic</span>
+          </span>
+        </span>
+        <span contenteditable="true"> text support</span>
+      </span>
+    </span>
+  </div>
+  <div data-testid="block">
+    <div>
+      <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+        <span></span>
+      </button>
+    </div>
+    <span tabindex="0">
+      <span>
+        <span contenteditable="true"></span>
+        <span tabindex="0">Code snippets</span>
+        <span contenteditable="true"> and </span>
+        <span tabindex="0">code blocks</span>
+        <span contenteditable="true"></span>
+      </span>
+    </span>
+  </div>
+  <div data-testid="block">
+    <div>
+      <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+        <span></span>
+      </button>
+    </div>
+    <span tabindex="0">
+      <span>
+        <span contenteditable="true"></span>
+        <span tabindex="0">Strikethrough</span>
+        <span contenteditable="true"> for deleted content</span>
+      </span>
+    </span>
+  </div>
+  <div data-testid="block">
+    <div>
+      <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+        <span></span>
+      </button>
+    </div>
+    <span tabindex="0">
+      <span>
+        <span contenteditable="true">Links like </span>
+        <span tabindex="0">GitHub</span>
+        <span contenteditable="true"></span>
+      </span>
+    </span>
+  </div>
+  <div data-testid="block">
+    <div>
+      <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+        <span></span>
+      </button>
+    </div>
+    <span tabindex="0">
+      <span>
+        <span contenteditable="true">Example</span>
+      </span>
+    </span>
+  </div>
+  <div data-testid="block">
+    <div>
+      <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+        <span></span>
+      </button>
+    </div>
+    <span tabindex="0">const parser = new ParserV2(['**__value__**', '*__value__*'])&#10;const result = parser.parse('Hello **world**!')&#10;</span>
+  </div>
+  <div data-testid="block">
+    <div>
+      <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+        <span></span>
+      </button>
+    </div>
+    <span contenteditable="true">&#10;&#10;Visit our docs for more details.</span>
+  </div>
+</div>"
 `;
 
 exports[`Component: stories > Drag stories > Story MarkdownDrag 1`] = `
-"<div><div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true">Welcome to Draggable Blocks</span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span contenteditable="true">This is the first paragraph.
-
-This is the second paragraph.
-
-</span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true">Features</span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true">Drag handles appear on hover</span></span></span></div></div><div></div><div><button>Copy</button><div><pre data-value="# Welcome to Draggable Blocks
-
-This is the first paragraph.
-
-This is the second paragraph.
-
-## Features
-
-- Drag handles appear on hover
-
-"># Welcome to Draggable Blocks
-
-This is the first paragraph.
-
-This is the second paragraph.
-
-## Features
-
-- Drag handles appear on hover
-
-</pre></div><div><span>Plain text</span><span>23 words · 137 chars · 11 lines</span></div></div></div>"
+"<div>
+  <div>
+    <div data-testid="block">
+      <div>
+        <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+          <span></span>
+        </button>
+      </div>
+      <span tabindex="0">
+        <span>
+          <span contenteditable="true">Welcome to Draggable Blocks</span>
+        </span>
+      </span>
+    </div>
+    <div data-testid="block">
+      <div>
+        <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+          <span></span>
+        </button>
+      </div>
+      <span contenteditable="true">This is the first paragraph.&#10;&#10;This is the second paragraph.&#10;&#10;</span>
+    </div>
+    <div data-testid="block">
+      <div>
+        <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+          <span></span>
+        </button>
+      </div>
+      <span tabindex="0">
+        <span>
+          <span contenteditable="true">Features</span>
+        </span>
+      </span>
+    </div>
+    <div data-testid="block">
+      <div>
+        <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+          <span></span>
+        </button>
+      </div>
+      <span tabindex="0">
+        <span>
+          <span contenteditable="true">Drag handles appear on hover</span>
+        </span>
+      </span>
+    </div>
+  </div>
+  <div></div>
+  <div>
+    <button>Copy</button>
+    <div>
+      <pre data-value="# Welcome to Draggable Blocks&#10;&#10;This is the first paragraph.&#10;&#10;This is the second paragraph.&#10;&#10;## Features&#10;&#10;- Drag handles appear on hover&#10;&#10;"># Welcome to Draggable Blocks&#10;&#10;This is the first paragraph.&#10;&#10;This is the second paragraph.&#10;&#10;## Features&#10;&#10;- Drag handles appear on hover&#10;&#10;</pre>
+    </div>
+    <div>
+      <span>Plain text</span>
+      <span>23 words · 137 chars · 11 lines</span>
+    </div>
+  </div>
+</div>"
 `;
 
 exports[`Component: stories > Drag stories > Story PlainTextDrag 1`] = `
-"<div><div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true">First block of plain text</span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true">Second block of plain text</span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true">Third block of plain text</span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true">Fourth block of plain text</span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true">Fifth block of plain text</span></span></span></div></div><div></div><div><button>Copy</button><div><pre data-value="First block of plain text
-
-Second block of plain text
-
-Third block of plain text
-
-Fourth block of plain text
-
-Fifth block of plain text
-
-">First block of plain text
-
-Second block of plain text
-
-Third block of plain text
-
-Fourth block of plain text
-
-Fifth block of plain text
-
-</pre></div><div><span>Plain text</span><span>25 words · 137 chars · 11 lines</span></div></div></div>"
+"<div>
+  <div>
+    <div data-testid="block">
+      <div>
+        <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+          <span></span>
+        </button>
+      </div>
+      <span tabindex="0">
+        <span>
+          <span contenteditable="true">First block of plain text</span>
+        </span>
+      </span>
+    </div>
+    <div data-testid="block">
+      <div>
+        <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+          <span></span>
+        </button>
+      </div>
+      <span tabindex="0">
+        <span>
+          <span contenteditable="true">Second block of plain text</span>
+        </span>
+      </span>
+    </div>
+    <div data-testid="block">
+      <div>
+        <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+          <span></span>
+        </button>
+      </div>
+      <span tabindex="0">
+        <span>
+          <span contenteditable="true">Third block of plain text</span>
+        </span>
+      </span>
+    </div>
+    <div data-testid="block">
+      <div>
+        <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+          <span></span>
+        </button>
+      </div>
+      <span tabindex="0">
+        <span>
+          <span contenteditable="true">Fourth block of plain text</span>
+        </span>
+      </span>
+    </div>
+    <div data-testid="block">
+      <div>
+        <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+          <span></span>
+        </button>
+      </div>
+      <span tabindex="0">
+        <span>
+          <span contenteditable="true">Fifth block of plain text</span>
+        </span>
+      </span>
+    </div>
+  </div>
+  <div></div>
+  <div>
+    <button>Copy</button>
+    <div>
+      <pre data-value="First block of plain text&#10;&#10;Second block of plain text&#10;&#10;Third block of plain text&#10;&#10;Fourth block of plain text&#10;&#10;Fifth block of plain text&#10;&#10;">First block of plain text&#10;&#10;Second block of plain text&#10;&#10;Third block of plain text&#10;&#10;Fourth block of plain text&#10;&#10;Fifth block of plain text&#10;&#10;</pre>
+    </div>
+    <div>
+      <span>Plain text</span>
+      <span>25 words · 137 chars · 11 lines</span>
+    </div>
+  </div>
+</div>"
 `;
 
-exports[`Component: stories > Drag stories > Story ReadOnlyDrag 1`] = `"<div><div data-testid="block"><span><span><span contenteditable="false">Read-Only Content</span></span></span></div><div data-testid="block"><span><span><span contenteditable="false">Section A</span></span></span></div><div data-testid="block"><span><span><span contenteditable="false">Section B</span></span></span></div></div>"`;
+exports[`Component: stories > Drag stories > Story ReadOnlyDrag 1`] = `
+"<div>
+  <div data-testid="block">
+    <span>
+      <span>
+        <span contenteditable="false">Read-Only Content</span>
+      </span>
+    </span>
+  </div>
+  <div data-testid="block">
+    <span>
+      <span>
+        <span contenteditable="false">Section A</span>
+      </span>
+    </span>
+  </div>
+  <div data-testid="block">
+    <span>
+      <span>
+        <span contenteditable="false">Section B</span>
+      </span>
+    </span>
+  </div>
+</div>"
+`;
 
 exports[`Component: stories > Drag stories > Story TodoList 1`] = `
-"<div><div><div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span contenteditable="true">
-</span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><div tabindex="0"><input type="checkbox"><span><span contenteditable="true">Design Phase</span></span></div></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><input type="checkbox"><span><span contenteditable="true">Create wireframes</span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><input type="checkbox" checked=""><span><span contenteditable="true">Define color palette</span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><input type="checkbox"><span><span contenteditable="true">Design component library</span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><div tabindex="0"><input type="checkbox" checked=""><span><span contenteditable="true">Research</span></span></div></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><input type="checkbox" checked=""><span><span contenteditable="true">Analyze competitors</span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><input type="checkbox" checked=""><span><span contenteditable="true">User interviews</span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><input type="checkbox" checked=""><span><span contenteditable="true">Draft interview questions</span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><input type="checkbox" checked=""><span><span contenteditable="true">Schedule 5 sessions</span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><div tabindex="0"><input type="checkbox"><span><span contenteditable="true">Development</span></span></div></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><input type="checkbox"><span><span contenteditable="true">Set up CI/CD pipeline</span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><input type="checkbox" checked=""><span><span contenteditable="true">Write unit tests</span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><input type="checkbox"><span><span contenteditable="true">API integration</span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><input type="checkbox"><span><span contenteditable="true">Auth endpoints</span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><input type="checkbox"><span><span contenteditable="true">Data sync</span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><div tabindex="0"><input type="checkbox"><span><span contenteditable="true">Launch</span></span></div></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><input type="checkbox"><span><span contenteditable="true">Final QA pass</span></span></span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><input type="checkbox"><span><span contenteditable="true">Deploy to production</span></span></span></div></div></div><div><button>Copy</button><div><pre data-value="
-- [ ] Design Phase
-	- [ ] Create wireframes
-	- [x] Define color palette
-	- [ ] Design component library
-- [x] Research
-	- [x] Analyze competitors
-	- [x] User interviews
-	- [x] Draft interview questions
-	- [x] Schedule 5 sessions
-- [ ] Development
-	- [ ] Set up CI/CD pipeline
-	- [x] Write unit tests
-	- [ ] API integration
-	- [ ] Auth endpoints
-	- [ ] Data sync
-- [ ] Launch
-	- [ ] Final QA pass
-	- [ ] Deploy to production
-">
-- [ ] Design Phase
-	- [ ] Create wireframes
-	- [x] Define color palette
-	- [ ] Design component library
-- [x] Research
-	- [x] Analyze competitors
-	- [x] User interviews
-	- [x] Draft interview questions
-	- [x] Schedule 5 sessions
-- [ ] Development
-	- [ ] Set up CI/CD pipeline
-	- [x] Write unit tests
-	- [ ] API integration
-	- [ ] Auth endpoints
-	- [ ] Data sync
-- [ ] Launch
-	- [ ] Final QA pass
-	- [ ] Deploy to production
-</pre></div><div><span>Plain text</span><span>89 words · 425 chars · 20 lines</span></div></div></div>"
+"<div>
+  <div>
+    <div>
+      <div data-testid="block">
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span contenteditable="true">&#10;</span>
+      </div>
+      <div data-testid="block">
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <div tabindex="0">
+          <input type="checkbox">
+          <span>
+            <span contenteditable="true">Design Phase</span>
+          </span>
+        </div>
+      </div>
+      <div data-testid="block">
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <input type="checkbox">
+          <span>
+            <span contenteditable="true">Create wireframes</span>
+          </span>
+        </span>
+      </div>
+      <div data-testid="block">
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <input type="checkbox" checked="">
+          <span>
+            <span contenteditable="true">Define color palette</span>
+          </span>
+        </span>
+      </div>
+      <div data-testid="block">
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <input type="checkbox">
+          <span>
+            <span contenteditable="true">Design component library</span>
+          </span>
+        </span>
+      </div>
+      <div data-testid="block">
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <div tabindex="0">
+          <input type="checkbox" checked="">
+          <span>
+            <span contenteditable="true">Research</span>
+          </span>
+        </div>
+      </div>
+      <div data-testid="block">
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <input type="checkbox" checked="">
+          <span>
+            <span contenteditable="true">Analyze competitors</span>
+          </span>
+        </span>
+      </div>
+      <div data-testid="block">
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <input type="checkbox" checked="">
+          <span>
+            <span contenteditable="true">User interviews</span>
+          </span>
+        </span>
+      </div>
+      <div data-testid="block">
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <input type="checkbox" checked="">
+          <span>
+            <span contenteditable="true">Draft interview questions</span>
+          </span>
+        </span>
+      </div>
+      <div data-testid="block">
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <input type="checkbox" checked="">
+          <span>
+            <span contenteditable="true">Schedule 5 sessions</span>
+          </span>
+        </span>
+      </div>
+      <div data-testid="block">
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <div tabindex="0">
+          <input type="checkbox">
+          <span>
+            <span contenteditable="true">Development</span>
+          </span>
+        </div>
+      </div>
+      <div data-testid="block">
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <input type="checkbox">
+          <span>
+            <span contenteditable="true">Set up CI/CD pipeline</span>
+          </span>
+        </span>
+      </div>
+      <div data-testid="block">
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <input type="checkbox" checked="">
+          <span>
+            <span contenteditable="true">Write unit tests</span>
+          </span>
+        </span>
+      </div>
+      <div data-testid="block">
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <input type="checkbox">
+          <span>
+            <span contenteditable="true">API integration</span>
+          </span>
+        </span>
+      </div>
+      <div data-testid="block">
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <input type="checkbox">
+          <span>
+            <span contenteditable="true">Auth endpoints</span>
+          </span>
+        </span>
+      </div>
+      <div data-testid="block">
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <input type="checkbox">
+          <span>
+            <span contenteditable="true">Data sync</span>
+          </span>
+        </span>
+      </div>
+      <div data-testid="block">
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <div tabindex="0">
+          <input type="checkbox">
+          <span>
+            <span contenteditable="true">Launch</span>
+          </span>
+        </div>
+      </div>
+      <div data-testid="block">
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <input type="checkbox">
+          <span>
+            <span contenteditable="true">Final QA pass</span>
+          </span>
+        </span>
+      </div>
+      <div data-testid="block">
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <input type="checkbox">
+          <span>
+            <span contenteditable="true">Deploy to production</span>
+          </span>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div>
+    <button>Copy</button>
+    <div>
+      <pre data-value="&#10;- [ ] Design Phase&#10;	- [ ] Create wireframes&#10;	- [x] Define color palette&#10;	- [ ] Design component library&#10;- [x] Research&#10;	- [x] Analyze competitors&#10;	- [x] User interviews&#10;	- [x] Draft interview questions&#10;	- [x] Schedule 5 sessions&#10;- [ ] Development&#10;	- [ ] Set up CI/CD pipeline&#10;	- [x] Write unit tests&#10;	- [ ] API integration&#10;	- [ ] Auth endpoints&#10;	- [ ] Data sync&#10;- [ ] Launch&#10;	- [ ] Final QA pass&#10;	- [ ] Deploy to production&#10;">- [ ] Design Phase&#10;	- [ ] Create wireframes&#10;	- [x] Define color palette&#10;	- [ ] Design component library&#10;- [x] Research&#10;	- [x] Analyze competitors&#10;	- [x] User interviews&#10;	- [x] Draft interview questions&#10;	- [x] Schedule 5 sessions&#10;- [ ] Development&#10;	- [ ] Set up CI/CD pipeline&#10;	- [x] Write unit tests&#10;	- [ ] API integration&#10;	- [ ] Auth endpoints&#10;	- [ ] Data sync&#10;- [ ] Launch&#10;	- [ ] Final QA pass&#10;	- [ ] Deploy to production&#10;</pre>
+    </div>
+    <div>
+      <span>Plain text</span>
+      <span>89 words · 425 chars · 20 lines</span>
+    </div>
+  </div>
+</div>"
 `;
 
-exports[`Component: stories > Dynamic stories > Story Dynamic 1`] = `"<div><span contenteditable="true">Hello, dynamical mark </span><mark tabindex="0">world</mark><span contenteditable="true">!</span></div>"`;
+exports[`Component: stories > Dynamic stories > Story Dynamic 1`] = `
+"<div>
+  <span contenteditable="true">Hello, dynamical mark </span>
+  <mark tabindex="0">world</mark>
+  <span contenteditable="true">!</span>
+</div>"
+`;
 
-exports[`Component: stories > Dynamic stories > Story Focusable 1`] = `"<div><div><div><span contenteditable="true">Hello, </span><abbr title="By key operations" tabindex="0">focusable</abbr><span contenteditable="true"> abbreviation </span><abbr title="Hello! Hello!" tabindex="0">world</abbr><span contenteditable="true">!</span></div></div><div><button>Copy</button><div><pre data-value="Hello, @[focusable](By key operations) abbreviation @[world](Hello! Hello!)!">Hello, @[focusable](By key operations) abbreviation @[world](Hello! Hello!)!</pre></div><div><span>Plain text</span><span>7 words · 76 chars · 1 lines</span></div></div></div>"`;
+exports[`Component: stories > Dynamic stories > Story Focusable 1`] = `
+"<div>
+  <div>
+    <div>
+      <span contenteditable="true">Hello, </span>
+      <abbr title="By key operations" tabindex="0">focusable</abbr>
+      <span contenteditable="true"> abbreviation </span>
+      <abbr title="Hello! Hello!" tabindex="0">world</abbr>
+      <span contenteditable="true">!</span>
+    </div>
+  </div>
+  <div>
+    <button>Copy</button>
+    <div>
+      <pre data-value="Hello, @[focusable](By key operations) abbreviation @[world](Hello! Hello!)!">Hello, @[focusable](By key operations) abbreviation @[world](Hello! Hello!)!</pre>
+    </div>
+    <div>
+      <span>Plain text</span>
+      <span>7 words · 76 chars · 1 lines</span>
+    </div>
+  </div>
+</div>"
+`;
 
-exports[`Component: stories > Dynamic stories > Story Removable 1`] = `"<div><span contenteditable="true">I </span><mark tabindex="0">contain</mark><span contenteditable="true"> </span><mark tabindex="0">removable</mark><span contenteditable="true"> by click </span><mark tabindex="0">marks</mark><span contenteditable="true">!</span></div>"`;
+exports[`Component: stories > Dynamic stories > Story Removable 1`] = `
+"<div>
+  <span contenteditable="true">I </span>
+  <mark tabindex="0">contain</mark>
+  <span contenteditable="true"> </span>
+  <mark tabindex="0">removable</mark>
+  <span contenteditable="true"> by click </span>
+  <mark tabindex="0">marks</mark>
+  <span contenteditable="true">!</span>
+</div>"
+`;
 
-exports[`Component: stories > Experimental stories > Story Controlled 1`] = `"<div contenteditable="true"><span></span><mark data-value="John" data-meta="id:123">John</mark><span></span><mark data-value="World" data-meta="greeting">World</mark><span></span></div>"`;
+exports[`Component: stories > Experimental stories > Story Controlled 1`] = `
+"<div contenteditable="true">
+  <span></span>
+  <mark data-value="John" data-meta="id:123">John</mark>
+  <span></span>
+  <mark data-value="World" data-meta="greeting">World</mark>
+  <span></span>
+</div>"
+`;
 
-exports[`Component: stories > Experimental stories > Story Markdown 1`] = `"<div contenteditable="true"><span></span><strong data-type="heading">Welcome to Markdown Editor</strong><span></span><strong data-type="bold"><span><span></span></span></strong><span></span><em data-type="italic"><span><span></span></span></em><span></span><code data-type="code"><span><span></span></span></code><span></span><a href="links" data-type="link" data-url="links">links</a><span></span><span data-type="blockquote">&gt; </span><span></span><span data-type="blockquote">&gt; </span><span></span></div>"`;
+exports[`Component: stories > Experimental stories > Story Markdown 1`] = `
+"<div contenteditable="true">
+  <span></span>
+  <strong data-type="heading">Welcome to Markdown Editor</strong>
+  <span></span>
+  <strong data-type="bold">
+    <span>
+      <span></span>
+    </span>
+  </strong>
+  <span></span>
+  <em data-type="italic">
+    <span>
+      <span></span>
+    </span>
+  </em>
+  <span></span>
+  <code data-type="code">
+    <span>
+      <span></span>
+    </span>
+  </code>
+  <span></span>
+  <a href="links" data-type="link" data-url="links">links</a>
+  <span></span>
+  <span data-type="blockquote">&gt; </span>
+  <span></span>
+  <span data-type="blockquote">&gt; </span>
+  <span></span>
+</div>"
+`;
 
-exports[`Component: stories > Experimental stories > Story Uncontrolled 1`] = `"<div contenteditable="true"><span></span><mark data-value="John" data-meta="id:123">John</mark><span></span><mark data-value="World" data-meta="greeting">World</mark><span></span></div>"`;
+exports[`Component: stories > Experimental stories > Story Uncontrolled 1`] = `
+"<div contenteditable="true">
+  <span></span>
+  <mark data-value="John" data-meta="id:123">John</mark>
+  <span></span>
+  <mark data-value="World" data-meta="greeting">World</mark>
+  <span></span>
+</div>"
+`;
 
-exports[`Component: stories > Material stories > Story Chipped 1`] = `"<div><span contenteditable="true">Hello beautiful the </span><div tabindex="0"><span>first</span></div><span contenteditable="true"> world from the </span><div tabindex="0"><span>second</span></div><span contenteditable="true"> </span></div>"`;
+exports[`Component: stories > Material stories > Story Chipped 1`] = `
+"<div>
+  <span contenteditable="true">Hello beautiful the </span>
+  <div tabindex="0">
+    <span>first</span>
+  </div>
+  <span contenteditable="true"> world from the </span>
+  <div tabindex="0">
+    <span>second</span>
+  </div>
+  <span contenteditable="true"> </span>
+</div>"
+`;
 
 exports[`Component: stories > Material stories > Story Mentions 1`] = `
-"<div><span contenteditable="true">Enter the '@' for calling mention list:
-- Hello @Agustina and </span><div tabindex="0"><div>R</div><span>Ruslan</span></div><span contenteditable="true">!</span></div>"
+"<div>
+  <span contenteditable="true">Enter the '@' for calling mention list:&#10;- Hello @Agustina and </span>
+  <div tabindex="0">
+    <div>R</div>
+    <span>Ruslan</span>
+  </div>
+  <span contenteditable="true">!</span>
+</div>"
 `;
 
-exports[`Component: stories > Material stories > Story Overridden 1`] = `"<div><div><span contenteditable="true">Hello beautiful the </span><div tabindex="0"><span>first</span></div><span contenteditable="true"> world from the </span><div tabindex="0"><span>second</span></div><span contenteditable="true"> </span></div></div>"`;
+exports[`Component: stories > Material stories > Story Overridden 1`] = `
+"<div>
+  <div>
+    <span contenteditable="true">Hello beautiful the </span>
+    <div tabindex="0">
+      <span>first</span>
+    </div>
+    <span contenteditable="true"> world from the </span>
+    <div tabindex="0">
+      <span>second</span>
+    </div>
+    <span contenteditable="true"> </span>
+  </div>
+</div>"
+`;
 
 exports[`Component: stories > Nested stories > Story ComplexHtmlDocument 1`] = `
-"<div><button>Preview</button><button>Write</button></div><div><span contenteditable="false"></span><article><span><span contenteditable="false">
-</span><header><span><span contenteditable="false">
-</span><h1><span><span contenteditable="false">Understanding </span><strong><span><span contenteditable="false">Nested HTML</span></span></strong><span contenteditable="false"> Structures</span></span></h1><span contenteditable="false">
-</span><p><span><span contenteditable="false"></span><small><span><span contenteditable="false">Published on </span><time><span><span contenteditable="false">November 13, 2025</span></span></time><span contenteditable="false"></span></span></small><span contenteditable="false"></span></span></p><span contenteditable="false">
-</span></span></header><span contenteditable="false">
-
-</span><section><span><span contenteditable="false">
-</span><h2><span><span contenteditable="false">Introduction</span></span></h2><span contenteditable="false">
-</span><p><span><span contenteditable="false">This is a </span><em><span><span contenteditable="false">comprehensive example</span></span></em><span contenteditable="false"> of </span><strong><span><span contenteditable="false">nested HTML tags</span></span></strong><span contenteditable="false"> working together. The </span><code><span><span contenteditable="false">MarkedInput</span></span></code><span contenteditable="false"> library can parse and render </span><mark><span><span contenteditable="false">complex HTML structures</span></span></mark><span contenteditable="false"> with multiple levels of nesting.</span></span></p><span contenteditable="false">
-
-</span><blockquote><span><span contenteditable="false">
-</span><p><span><span contenteditable="false">HTML nesting allows us to create </span><strong><span><span contenteditable="false">rich, semantic documents</span></span></strong><span contenteditable="false"> that are both </span><em><span><span contenteditable="false">readable</span></span></em><span contenteditable="false"> and </span><u><span><span contenteditable="false">well-structured</span></span></u><span contenteditable="false">.</span></span></p><span contenteditable="false">
-</span></span></blockquote><span contenteditable="false">
-</span></span></section><span contenteditable="false">
-
-</span><section><span><span contenteditable="false">
-</span><h2><span><span contenteditable="false">Key Features</span></span></h2><span contenteditable="false">
-</span><ul><span><span contenteditable="false">
-</span><li><span><span contenteditable="false"></span><strong><span><span contenteditable="false">Bold text</span></span></strong><span contenteditable="false"> using </span><code><span><span contenteditable="false">&amp;lt;strong&amp;gt;</span></span></code><span contenteditable="false"> or </span><code><span><span contenteditable="false">&amp;lt;b&amp;gt;</span></span></code><span contenteditable="false"> tags</span></span></li><span contenteditable="false">
-</span><li><span><span contenteditable="false"></span><em><span><span contenteditable="false">Italic text</span></span></em><span contenteditable="false"> with </span><code><span><span contenteditable="false">&amp;lt;em&amp;gt;</span></span></code><span contenteditable="false"> or </span><code><span><span contenteditable="false">&amp;lt;i&amp;gt;</span></span></code><span contenteditable="false"> tags</span></span></li><span contenteditable="false">
-</span><li><span><span contenteditable="false"></span><u><span><span contenteditable="false">Underlined content</span></span></u><span contenteditable="false"> for emphasis</span></span></li><span contenteditable="false">
-</span><li><span><span contenteditable="false"></span><mark><span><span contenteditable="false">Highlighted text</span></span></mark><span contenteditable="false"> to draw attention</span></span></li><span contenteditable="false">
-</span><li><span><span contenteditable="false"></span><del><span><span contenteditable="false">Strikethrough</span></span></del><span contenteditable="false"> for deleted content</span></span></li><span contenteditable="false">
-</span><li><span><span contenteditable="false"></span><code><span><span contenteditable="false">Inline code</span></span></code><span contenteditable="false"> snippets</span></span></li><span contenteditable="false">
-</span></span></ul><span contenteditable="false">
-</span></span></section><span contenteditable="false">
-
-</span><section><span><span contenteditable="false">
-</span><h2><span><span contenteditable="false">Advanced Examples</span></span></h2><span contenteditable="false">
-</span><h3><span><span contenteditable="false">Mathematical Notation</span></span></h3><span contenteditable="false">
-</span><p><span><span contenteditable="false">The formula for water is H</span><sub><span><span contenteditable="false">2</span></span></sub><span contenteditable="false">O, and Einstein's famous equation is E=mc</span><sup><span><span contenteditable="false">2</span></span></sup><span contenteditable="false">.</span></span></p><span contenteditable="false">
-
-</span><h3><span><span contenteditable="false">Code Blocks</span></span></h3><span contenteditable="false">
-</span><pre><span><span contenteditable="false"></span><code><span><span contenteditable="false">function parseHTML(input) {
-  return parser.parse(input);
-}</span></span></code><span contenteditable="false"></span></span></pre><span contenteditable="false">
-
-</span><h3><span><span contenteditable="false">Nested Lists</span></span></h3><span contenteditable="false">
-</span><ol><span><span contenteditable="false">
-</span><li><span><span contenteditable="false">First level item
-</span><ul><span><span contenteditable="false">
-</span><li><span><span contenteditable="false">Second level </span><strong><span><span contenteditable="false">nested</span></span></strong><span contenteditable="false"> item</span></span></li><span contenteditable="false">
-</span><li><span><span contenteditable="false">Another nested item with </span><em><span><span contenteditable="false">emphasis</span></span></em><span contenteditable="false"></span></span></li><span contenteditable="false">
-</span></span></ul><span contenteditable="false">
-</span></span></li><span contenteditable="false">
-</span><li><span><span contenteditable="false">Another first level item</span></span></li><span contenteditable="false">
-</span></span></ol><span contenteditable="false">
-</span></span></section><span contenteditable="false">
-
-</span><section><span><span contenteditable="false">
-</span><h2><span><span contenteditable="false">Complex Nesting</span></span></h2><span contenteditable="false">
-</span><div><span><span contenteditable="false">
-</span><p><span><span contenteditable="false">Here's a </span><strong><span><span contenteditable="false">complex example</span></span></strong><span contenteditable="false"> with </span><em><span><span contenteditable="false">multiple </span><u><span><span contenteditable="false">nested </span><mark><span><span contenteditable="false">tags</span></span></mark><span contenteditable="false"></span></span></u><span contenteditable="false"> inside</span></span></em><span contenteditable="false"> each other.</span></span></p><span contenteditable="false">
-</span><p><span><span contenteditable="false">You can even have </span><code><span><span contenteditable="false">code with </span><strong><span><span contenteditable="false">bold</span></span></strong><span contenteditable="false"> inside</span></span></code><span contenteditable="false"> or </span><mark><span><span contenteditable="false">highlighted </span><em><span><span contenteditable="false">italic </span><u><span><span contenteditable="false">underlined</span></span></u><span contenteditable="false"></span></span></em><span contenteditable="false"> text</span></span></mark><span contenteditable="false">.</span></span></p><span contenteditable="false">
-</span></span></div><span contenteditable="false">
-</span></span></section><span contenteditable="false">
-
-</span><footer><span><span contenteditable="false">
-</span><p><span><span contenteditable="false"></span><small><span><span contenteditable="false">© 2025 MarkedInput Library. Built with </span><strong><span><span contenteditable="false">React</span></span></strong><span contenteditable="false"> and </span><em><span><span contenteditable="false">TypeScript</span></span></em><span contenteditable="false">.</span></span></small><span contenteditable="false"></span></span></p><span contenteditable="false">
-</span></span></footer><span contenteditable="false">
-</span></span></article><span contenteditable="false"></span></div>"
+"<div>
+  <button>Preview</button>
+  <button>Write</button>
+</div>
+<div>
+  <span contenteditable="false"></span>
+  <article>
+    <span>
+      <span contenteditable="false">&#10;</span>
+      <header>
+        <span>
+          <span contenteditable="false">&#10;</span>
+          <h1>
+            <span>
+              <span contenteditable="false">Understanding </span>
+              <strong>
+                <span>
+                  <span contenteditable="false">Nested HTML</span>
+                </span>
+              </strong>
+              <span contenteditable="false"> Structures</span>
+            </span>
+          </h1>
+          <span contenteditable="false">&#10;</span>
+          <p>
+            <span>
+              <span contenteditable="false"></span>
+              <small>
+                <span>
+                  <span contenteditable="false">Published on </span>
+                  <time>
+                    <span>
+                      <span contenteditable="false">November 13, 2025</span>
+                    </span>
+                  </time>
+                  <span contenteditable="false"></span>
+                </span>
+              </small>
+              <span contenteditable="false"></span>
+            </span>
+          </p>
+          <span contenteditable="false">&#10;</span>
+        </span>
+      </header>
+      <span contenteditable="false">&#10;&#10;</span>
+      <section>
+        <span>
+          <span contenteditable="false">&#10;</span>
+          <h2>
+            <span>
+              <span contenteditable="false">Introduction</span>
+            </span>
+          </h2>
+          <span contenteditable="false">&#10;</span>
+          <p>
+            <span>
+              <span contenteditable="false">This is a </span>
+              <em>
+                <span>
+                  <span contenteditable="false">comprehensive example</span>
+                </span>
+              </em>
+              <span contenteditable="false"> of </span>
+              <strong>
+                <span>
+                  <span contenteditable="false">nested HTML tags</span>
+                </span>
+              </strong>
+              <span contenteditable="false"> working together. The </span>
+              <code>
+                <span>
+                  <span contenteditable="false">MarkedInput</span>
+                </span>
+              </code>
+              <span contenteditable="false"> library can parse and render </span>
+              <mark>
+                <span>
+                  <span contenteditable="false">complex HTML structures</span>
+                </span>
+              </mark>
+              <span contenteditable="false"> with multiple levels of nesting.</span>
+            </span>
+          </p>
+          <span contenteditable="false">&#10;&#10;</span>
+          <blockquote>
+            <span>
+              <span contenteditable="false">&#10;</span>
+              <p>
+                <span>
+                  <span contenteditable="false">HTML nesting allows us to create </span>
+                  <strong>
+                    <span>
+                      <span contenteditable="false">rich, semantic documents</span>
+                    </span>
+                  </strong>
+                  <span contenteditable="false"> that are both </span>
+                  <em>
+                    <span>
+                      <span contenteditable="false">readable</span>
+                    </span>
+                  </em>
+                  <span contenteditable="false"> and </span>
+                  <u>
+                    <span>
+                      <span contenteditable="false">well-structured</span>
+                    </span>
+                  </u>
+                  <span contenteditable="false">.</span>
+                </span>
+              </p>
+              <span contenteditable="false">&#10;</span>
+            </span>
+          </blockquote>
+          <span contenteditable="false">&#10;</span>
+        </span>
+      </section>
+      <span contenteditable="false">&#10;&#10;</span>
+      <section>
+        <span>
+          <span contenteditable="false">&#10;</span>
+          <h2>
+            <span>
+              <span contenteditable="false">Key Features</span>
+            </span>
+          </h2>
+          <span contenteditable="false">&#10;</span>
+          <ul>
+            <span>
+              <span contenteditable="false">&#10;</span>
+              <li>
+                <span>
+                  <span contenteditable="false"></span>
+                  <strong>
+                    <span>
+                      <span contenteditable="false">Bold text</span>
+                    </span>
+                  </strong>
+                  <span contenteditable="false"> using </span>
+                  <code>
+                    <span>
+                      <span contenteditable="false">&amp;lt;strong&amp;gt;</span>
+                    </span>
+                  </code>
+                  <span contenteditable="false"> or </span>
+                  <code>
+                    <span>
+                      <span contenteditable="false">&amp;lt;b&amp;gt;</span>
+                    </span>
+                  </code>
+                  <span contenteditable="false"> tags</span>
+                </span>
+              </li>
+              <span contenteditable="false">&#10;</span>
+              <li>
+                <span>
+                  <span contenteditable="false"></span>
+                  <em>
+                    <span>
+                      <span contenteditable="false">Italic text</span>
+                    </span>
+                  </em>
+                  <span contenteditable="false"> with </span>
+                  <code>
+                    <span>
+                      <span contenteditable="false">&amp;lt;em&amp;gt;</span>
+                    </span>
+                  </code>
+                  <span contenteditable="false"> or </span>
+                  <code>
+                    <span>
+                      <span contenteditable="false">&amp;lt;i&amp;gt;</span>
+                    </span>
+                  </code>
+                  <span contenteditable="false"> tags</span>
+                </span>
+              </li>
+              <span contenteditable="false">&#10;</span>
+              <li>
+                <span>
+                  <span contenteditable="false"></span>
+                  <u>
+                    <span>
+                      <span contenteditable="false">Underlined content</span>
+                    </span>
+                  </u>
+                  <span contenteditable="false"> for emphasis</span>
+                </span>
+              </li>
+              <span contenteditable="false">&#10;</span>
+              <li>
+                <span>
+                  <span contenteditable="false"></span>
+                  <mark>
+                    <span>
+                      <span contenteditable="false">Highlighted text</span>
+                    </span>
+                  </mark>
+                  <span contenteditable="false"> to draw attention</span>
+                </span>
+              </li>
+              <span contenteditable="false">&#10;</span>
+              <li>
+                <span>
+                  <span contenteditable="false"></span>
+                  <del>
+                    <span>
+                      <span contenteditable="false">Strikethrough</span>
+                    </span>
+                  </del>
+                  <span contenteditable="false"> for deleted content</span>
+                </span>
+              </li>
+              <span contenteditable="false">&#10;</span>
+              <li>
+                <span>
+                  <span contenteditable="false"></span>
+                  <code>
+                    <span>
+                      <span contenteditable="false">Inline code</span>
+                    </span>
+                  </code>
+                  <span contenteditable="false"> snippets</span>
+                </span>
+              </li>
+              <span contenteditable="false">&#10;</span>
+            </span>
+          </ul>
+          <span contenteditable="false">&#10;</span>
+        </span>
+      </section>
+      <span contenteditable="false">&#10;&#10;</span>
+      <section>
+        <span>
+          <span contenteditable="false">&#10;</span>
+          <h2>
+            <span>
+              <span contenteditable="false">Advanced Examples</span>
+            </span>
+          </h2>
+          <span contenteditable="false">&#10;</span>
+          <h3>
+            <span>
+              <span contenteditable="false">Mathematical Notation</span>
+            </span>
+          </h3>
+          <span contenteditable="false">&#10;</span>
+          <p>
+            <span>
+              <span contenteditable="false">The formula for water is H</span>
+              <sub>
+                <span>
+                  <span contenteditable="false">2</span>
+                </span>
+              </sub>
+              <span contenteditable="false">O, and Einstein's famous equation is E=mc</span>
+              <sup>
+                <span>
+                  <span contenteditable="false">2</span>
+                </span>
+              </sup>
+              <span contenteditable="false">.</span>
+            </span>
+          </p>
+          <span contenteditable="false">&#10;&#10;</span>
+          <h3>
+            <span>
+              <span contenteditable="false">Code Blocks</span>
+            </span>
+          </h3>
+          <span contenteditable="false">&#10;</span>
+          <pre>
+            <span>
+              <span contenteditable="false"></span>
+              <code>
+                <span>
+                  <span contenteditable="false">function parseHTML(input) {&#10;  return parser.parse(input);&#10;}</span>
+                </span>
+              </code>
+              <span contenteditable="false"></span>
+            </span>
+          </pre>
+          <span contenteditable="false">&#10;&#10;</span>
+          <h3>
+            <span>
+              <span contenteditable="false">Nested Lists</span>
+            </span>
+          </h3>
+          <span contenteditable="false">&#10;</span>
+          <ol>
+            <span>
+              <span contenteditable="false">&#10;</span>
+              <li>
+                <span>
+                  <span contenteditable="false">First level item&#10;</span>
+                  <ul>
+                    <span>
+                      <span contenteditable="false">&#10;</span>
+                      <li>
+                        <span>
+                          <span contenteditable="false">Second level </span>
+                          <strong>
+                            <span>
+                              <span contenteditable="false">nested</span>
+                            </span>
+                          </strong>
+                          <span contenteditable="false"> item</span>
+                        </span>
+                      </li>
+                      <span contenteditable="false">&#10;</span>
+                      <li>
+                        <span>
+                          <span contenteditable="false">Another nested item with </span>
+                          <em>
+                            <span>
+                              <span contenteditable="false">emphasis</span>
+                            </span>
+                          </em>
+                          <span contenteditable="false"></span>
+                        </span>
+                      </li>
+                      <span contenteditable="false">&#10;</span>
+                    </span>
+                  </ul>
+                  <span contenteditable="false">&#10;</span>
+                </span>
+              </li>
+              <span contenteditable="false">&#10;</span>
+              <li>
+                <span>
+                  <span contenteditable="false">Another first level item</span>
+                </span>
+              </li>
+              <span contenteditable="false">&#10;</span>
+            </span>
+          </ol>
+          <span contenteditable="false">&#10;</span>
+        </span>
+      </section>
+      <span contenteditable="false">&#10;&#10;</span>
+      <section>
+        <span>
+          <span contenteditable="false">&#10;</span>
+          <h2>
+            <span>
+              <span contenteditable="false">Complex Nesting</span>
+            </span>
+          </h2>
+          <span contenteditable="false">&#10;</span>
+          <div>
+            <span>
+              <span contenteditable="false">&#10;</span>
+              <p>
+                <span>
+                  <span contenteditable="false">Here's a </span>
+                  <strong>
+                    <span>
+                      <span contenteditable="false">complex example</span>
+                    </span>
+                  </strong>
+                  <span contenteditable="false"> with </span>
+                  <em>
+                    <span>
+                      <span contenteditable="false">multiple </span>
+                      <u>
+                        <span>
+                          <span contenteditable="false">nested </span>
+                          <mark>
+                            <span>
+                              <span contenteditable="false">tags</span>
+                            </span>
+                          </mark>
+                          <span contenteditable="false"></span>
+                        </span>
+                      </u>
+                      <span contenteditable="false"> inside</span>
+                    </span>
+                  </em>
+                  <span contenteditable="false"> each other.</span>
+                </span>
+              </p>
+              <span contenteditable="false">&#10;</span>
+              <p>
+                <span>
+                  <span contenteditable="false">You can even have </span>
+                  <code>
+                    <span>
+                      <span contenteditable="false">code with </span>
+                      <strong>
+                        <span>
+                          <span contenteditable="false">bold</span>
+                        </span>
+                      </strong>
+                      <span contenteditable="false"> inside</span>
+                    </span>
+                  </code>
+                  <span contenteditable="false"> or </span>
+                  <mark>
+                    <span>
+                      <span contenteditable="false">highlighted </span>
+                      <em>
+                        <span>
+                          <span contenteditable="false">italic </span>
+                          <u>
+                            <span>
+                              <span contenteditable="false">underlined</span>
+                            </span>
+                          </u>
+                          <span contenteditable="false"></span>
+                        </span>
+                      </em>
+                      <span contenteditable="false"> text</span>
+                    </span>
+                  </mark>
+                  <span contenteditable="false">.</span>
+                </span>
+              </p>
+              <span contenteditable="false">&#10;</span>
+            </span>
+          </div>
+          <span contenteditable="false">&#10;</span>
+        </span>
+      </section>
+      <span contenteditable="false">&#10;&#10;</span>
+      <footer>
+        <span>
+          <span contenteditable="false">&#10;</span>
+          <p>
+            <span>
+              <span contenteditable="false"></span>
+              <small>
+                <span>
+                  <span contenteditable="false">© 2025 MarkedInput Library. Built with </span>
+                  <strong>
+                    <span>
+                      <span contenteditable="false">React</span>
+                    </span>
+                  </strong>
+                  <span contenteditable="false"> and </span>
+                  <em>
+                    <span>
+                      <span contenteditable="false">TypeScript</span>
+                    </span>
+                  </em>
+                  <span contenteditable="false">.</span>
+                </span>
+              </small>
+              <span contenteditable="false"></span>
+            </span>
+          </p>
+          <span contenteditable="false">&#10;</span>
+        </span>
+      </footer>
+      <span contenteditable="false">&#10;</span>
+    </span>
+  </article>
+  <span contenteditable="false"></span>
+</div>"
 `;
 
 exports[`Component: stories > Nested stories > Story ComplexMarkdown 1`] = `
-"<div><button>Preview</button><button>Write</button></div><div><span contenteditable="false"></span><span><span><span contenteditable="false">Welcome to </span><span><span><span contenteditable="false">Marked Input</span></span></span><span contenteditable="false"></span></span></span><span contenteditable="false">This is a </span><span><span><span contenteditable="false">powerful</span></span></span><span contenteditable="false"> library for parsing </span><span><span><span contenteditable="false">rich text</span></span></span><span contenteditable="false"> with </span><span><span><span contenteditable="false">markdown</span></span></span><span contenteditable="false"> formatting.
-You can use </span><span>inline code</span><span contenteditable="false"> snippets like </span><span>const parser = new ParserV2()</span><span contenteditable="false"> in your text.
-
-</span><span><span><span contenteditable="false">Features</span></span></span><span contenteditable="false">- </span><span><span><span contenteditable="false">Bold text</span></span></span><span contenteditable="false"> with </span><span><span><span contenteditable="false">strong emphasis</span></span></span><span contenteditable="false">
-- </span><span><span><span contenteditable="false">Italic text</span></span></span><span contenteditable="false"> and </span><span><span><span contenteditable="false">emphasis</span></span></span><span contenteditable="false"> support
-</span><span><span><span contenteditable="false"></span><span>Code snippets</span><span contenteditable="false"> and </span><span>code blocks</span><span contenteditable="false">
-</span><span><span><span contenteditable="false"></span><span>Strikethrough</span><span contenteditable="false"> for deleted content
-</span><span><span><span contenteditable="false">Links like </span><span>GitHub</span><span contenteditable="false"></span></span></span><span contenteditable="false"></span><span><span><span contenteditable="false">Example</span></span></span><span contenteditable="false">Here's how to use it:</span></span></span><span contenteditable="false"></span><span>const parser = new ParserV2(['**__value__**', '*__value__*'])
-const result = parser.parse('Hello **world**!')
-</span><span contenteditable="false"></span></span></span><span contenteditable="false">Visit our </span><span>documentation</span><span contenteditable="false"> for more details.
-</span><span>This feature is deprecated</span><span contenteditable="false"> and will be removed in v3.0.</span></div>"
+"<div>
+  <button>Preview</button>
+  <button>Write</button>
+</div>
+<div>
+  <span contenteditable="false"></span>
+  <span>
+    <span>
+      <span contenteditable="false">Welcome to </span>
+      <span>
+        <span>
+          <span contenteditable="false">Marked Input</span>
+        </span>
+      </span>
+      <span contenteditable="false"></span>
+    </span>
+  </span>
+  <span contenteditable="false">This is a </span>
+  <span>
+    <span>
+      <span contenteditable="false">powerful</span>
+    </span>
+  </span>
+  <span contenteditable="false"> library for parsing </span>
+  <span>
+    <span>
+      <span contenteditable="false">rich text</span>
+    </span>
+  </span>
+  <span contenteditable="false"> with </span>
+  <span>
+    <span>
+      <span contenteditable="false">markdown</span>
+    </span>
+  </span>
+  <span contenteditable="false"> formatting.&#10;You can use </span>
+  <span>inline code</span>
+  <span contenteditable="false"> snippets like </span>
+  <span>const parser = new ParserV2()</span>
+  <span contenteditable="false"> in your text.&#10;&#10;</span>
+  <span>
+    <span>
+      <span contenteditable="false">Features</span>
+    </span>
+  </span>
+  <span contenteditable="false">- </span>
+  <span>
+    <span>
+      <span contenteditable="false">Bold text</span>
+    </span>
+  </span>
+  <span contenteditable="false"> with </span>
+  <span>
+    <span>
+      <span contenteditable="false">strong emphasis</span>
+    </span>
+  </span>
+  <span contenteditable="false">&#10;- </span>
+  <span>
+    <span>
+      <span contenteditable="false">Italic text</span>
+    </span>
+  </span>
+  <span contenteditable="false"> and </span>
+  <span>
+    <span>
+      <span contenteditable="false">emphasis</span>
+    </span>
+  </span>
+  <span contenteditable="false"> support&#10;</span>
+  <span>
+    <span>
+      <span contenteditable="false"></span>
+      <span>Code snippets</span>
+      <span contenteditable="false"> and </span>
+      <span>code blocks</span>
+      <span contenteditable="false">&#10;</span>
+      <span>
+        <span>
+          <span contenteditable="false"></span>
+          <span>Strikethrough</span>
+          <span contenteditable="false"> for deleted content&#10;</span>
+          <span>
+            <span>
+              <span contenteditable="false">Links like </span>
+              <span>GitHub</span>
+              <span contenteditable="false"></span>
+            </span>
+          </span>
+          <span contenteditable="false"></span>
+          <span>
+            <span>
+              <span contenteditable="false">Example</span>
+            </span>
+          </span>
+          <span contenteditable="false">Here's how to use it:</span>
+        </span>
+      </span>
+      <span contenteditable="false"></span>
+      <span>const parser = new ParserV2(['**__value__**', '*__value__*'])&#10;const result = parser.parse('Hello **world**!')&#10;</span>
+      <span contenteditable="false"></span>
+    </span>
+  </span>
+  <span contenteditable="false">Visit our </span>
+  <span>documentation</span>
+  <span contenteditable="false"> for more details.&#10;</span>
+  <span>This feature is deprecated</span>
+  <span contenteditable="false"> and will be removed in v3.0.</span>
+</div>"
 `;
 
-exports[`Component: stories > Nested stories > Story HtmlLikeTags 1`] = `"<div><span contenteditable="true"></span><div tabindex="0"><span><span contenteditable="true">This is a div with </span><mark tabindex="0"><span><span contenteditable="true">a mark inside</span></span></mark><span contenteditable="true"> and </span><b tabindex="0"><span><span contenteditable="true">bold text with </span><del tabindex="0"><span><span contenteditable="true">nested del</span></span></del><span contenteditable="true"></span></span></b><span contenteditable="true"></span></span></div><span contenteditable="true"></span></div>"`;
+exports[`Component: stories > Nested stories > Story HtmlLikeTags 1`] = `
+"<div>
+  <span contenteditable="true"></span>
+  <div tabindex="0">
+    <span>
+      <span contenteditable="true">This is a div with </span>
+      <mark tabindex="0">
+        <span>
+          <span contenteditable="true">a mark inside</span>
+        </span>
+      </mark>
+      <span contenteditable="true"> and </span>
+      <b tabindex="0">
+        <span>
+          <span contenteditable="true">bold text with </span>
+          <del tabindex="0">
+            <span>
+              <span contenteditable="true">nested del</span>
+            </span>
+          </del>
+          <span contenteditable="true"></span>
+        </span>
+      </b>
+      <span contenteditable="true"></span>
+    </span>
+  </div>
+  <span contenteditable="true"></span>
+</div>"
+`;
 
-exports[`Component: stories > Nested stories > Story InteractiveNested 1`] = `"<div><span contenteditable="true"></span><span role="button" tabindex="0" title="Depth: 0, Nested: true"><span><span contenteditable="true">Click me </span><span role="button" tabindex="0" title="Depth: 1, Nested: true"><span><span contenteditable="true">or me </span><span role="button" tabindex="0" title="Depth: 2, Nested: false"><span><span contenteditable="true">or even me</span></span></span><span contenteditable="true"></span></span></span><span contenteditable="true"></span></span></span><span contenteditable="true"></span></div>"`;
+exports[`Component: stories > Nested stories > Story InteractiveNested 1`] = `
+"<div>
+  <span contenteditable="true"></span>
+  <span role="button" tabindex="0" title="Depth: 0, Nested: true">
+    <span>
+      <span contenteditable="true">Click me </span>
+      <span role="button" tabindex="0" title="Depth: 1, Nested: true">
+        <span>
+          <span contenteditable="true">or me </span>
+          <span role="button" tabindex="0" title="Depth: 2, Nested: false">
+            <span>
+              <span contenteditable="true">or even me</span>
+            </span>
+          </span>
+          <span contenteditable="true"></span>
+        </span>
+      </span>
+      <span contenteditable="true"></span>
+    </span>
+  </span>
+  <span contenteditable="true"></span>
+</div>"
+`;
 
-exports[`Component: stories > Nested stories > Story MultipleLevels 1`] = `"<div><span contenteditable="true">Check </span><span tabindex="0"><span><span contenteditable="true">this tag with </span><span tabindex="0"><span><span contenteditable="true">nested mention with </span><span tabindex="0"><span><span contenteditable="true">code</span></span></span><span contenteditable="true"></span></span></span><span contenteditable="true"></span></span></span><span contenteditable="true"> and </span><span tabindex="0"><span><span contenteditable="true">another </span><span tabindex="0"><span><span contenteditable="true">deeply nested</span></span></span><span contenteditable="true"> tag</span></span></span><span contenteditable="true"></span></div>"`;
+exports[`Component: stories > Nested stories > Story MultipleLevels 1`] = `
+"<div>
+  <span contenteditable="true">Check </span>
+  <span tabindex="0">
+    <span>
+      <span contenteditable="true">this tag with </span>
+      <span tabindex="0">
+        <span>
+          <span contenteditable="true">nested mention with </span>
+          <span tabindex="0">
+            <span>
+              <span contenteditable="true">code</span>
+            </span>
+          </span>
+          <span contenteditable="true"></span>
+        </span>
+      </span>
+      <span contenteditable="true"></span>
+    </span>
+  </span>
+  <span contenteditable="true"> and </span>
+  <span tabindex="0">
+    <span>
+      <span contenteditable="true">another </span>
+      <span tabindex="0">
+        <span>
+          <span contenteditable="true">deeply nested</span>
+        </span>
+      </span>
+      <span contenteditable="true"> tag</span>
+    </span>
+  </span>
+  <span contenteditable="true"></span>
+</div>"
+`;
 
-exports[`Component: stories > Nested stories > Story SimpleNesting 1`] = `"<div><span contenteditable="true">This is </span><span tabindex="0"><span><span contenteditable="true">italic text with </span><span tabindex="0"><span><span contenteditable="true">bold</span></span></span><span contenteditable="true"> inside</span></span></span><span contenteditable="true"> and more text.</span></div>"`;
+exports[`Component: stories > Nested stories > Story SimpleNesting 1`] = `
+"<div>
+  <span contenteditable="true">This is </span>
+  <span tabindex="0">
+    <span>
+      <span contenteditable="true">italic text with </span>
+      <span tabindex="0">
+        <span>
+          <span contenteditable="true">bold</span>
+        </span>
+      </span>
+      <span contenteditable="true"> inside</span>
+    </span>
+  </span>
+  <span contenteditable="true"> and more text.</span>
+</div>"
+`;
 
-exports[`Component: stories > Overlay stories > Story CustomOverlay 1`] = `"<div><span contenteditable="true">Hello, custom overlay by trigger @!</span></div>"`;
+exports[`Component: stories > Overlay stories > Story CustomOverlay 1`] = `
+"<div>
+  <span contenteditable="true">Hello, custom overlay by trigger @!</span>
+</div>"
+`;
 
-exports[`Component: stories > Overlay stories > Story CustomTrigger 1`] = `"<div><span contenteditable="true">Hello, custom overlay by trigger /!</span></div>"`;
+exports[`Component: stories > Overlay stories > Story CustomTrigger 1`] = `
+"<div>
+  <span contenteditable="true">Hello, custom overlay by trigger /!</span>
+</div>"
+`;
 
-exports[`Component: stories > Overlay stories > Story DefaultOverlay 1`] = `"<div><span contenteditable="true">Hello, default - suggestion overlay by trigger @!</span></div>"`;
+exports[`Component: stories > Overlay stories > Story DefaultOverlay 1`] = `
+"<div>
+  <span contenteditable="true">Hello, default - suggestion overlay by trigger @!</span>
+</div>"
+`;
 
-exports[`Component: stories > Overlay stories > Story PositionedOverlay 1`] = `"<div><span contenteditable="true">Hello, positioned overlay by trigger @!</span></div>"`;
+exports[`Component: stories > Overlay stories > Story PositionedOverlay 1`] = `
+"<div>
+  <span contenteditable="true">Hello, positioned overlay by trigger @!</span>
+</div>"
+`;
 
-exports[`Component: stories > Overlay stories > Story SelectableOverlay 1`] = `"<div><span contenteditable="true">Hello, suggest overlay by trigger @!</span></div>"`;
+exports[`Component: stories > Overlay stories > Story SelectableOverlay 1`] = `
+"<div>
+  <span contenteditable="true">Hello, suggest overlay by trigger @!</span>
+</div>"
+`;
 
-exports[`Component: stories > Rsuite stories > Story Overridden 1`] = `"<div><span contenteditable="true">Type the '@' to begin creating a </span><div data-size="md" tabindex="0"><span>tag</span></div><span contenteditable="true">. Then press the </span><div data-size="md" tabindex="0"><span>Enter</span></div><span contenteditable="true"> to finish. For example: @hello</span></div>"`;
+exports[`Component: stories > Rsuite stories > Story Overridden 1`] = `
+"<div>
+  <span contenteditable="true">Type the '@' to begin creating a </span>
+  <div data-size="md" tabindex="0">
+    <span>tag</span>
+  </div>
+  <span contenteditable="true">. Then press the </span>
+  <div data-size="md" tabindex="0">
+    <span>Enter</span>
+  </div>
+  <span contenteditable="true"> to finish. For example: @hello</span>
+</div>"
+`;
 
-exports[`Component: stories > Rsuite stories > Story TaggedInput 1`] = `"<div><span contenteditable="true">Type the '@' to begin creating a </span><div data-size="md" tabindex="0"><span>tag</span></div><span contenteditable="true">. Then press the </span><div data-size="md" tabindex="0"><span>Enter</span></div><span contenteditable="true"> to finish. For example: @hello</span></div>"`;
+exports[`Component: stories > Rsuite stories > Story TaggedInput 1`] = `
+"<div>
+  <span contenteditable="true">Type the '@' to begin creating a </span>
+  <div data-size="md" tabindex="0">
+    <span>tag</span>
+  </div>
+  <span contenteditable="true">. Then press the </span>
+  <div data-size="md" tabindex="0">
+    <span>Enter</span>
+  </div>
+  <span contenteditable="true"> to finish. For example: @hello</span>
+</div>"
+`;
 
 exports[`Component: stories > Selection stories > Story Drag 1`] = `
-"<div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span contenteditable="true">hello
-</span></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><mark data-testid="mark" tabindex="0">world</mark></div><div data-testid="block"><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span contenteditable="true">
-foo</span></div></div>"
+"<div>
+  <div data-testid="block">
+    <div>
+      <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+        <span></span>
+      </button>
+    </div>
+    <span contenteditable="true">hello&#10;</span>
+  </div>
+  <div data-testid="block">
+    <div>
+      <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+        <span></span>
+      </button>
+    </div>
+    <mark data-testid="mark" tabindex="0">world</mark>
+  </div>
+  <div data-testid="block">
+    <div>
+      <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+        <span></span>
+      </button>
+    </div>
+    <span contenteditable="true">&#10;foo</span>
+  </div>
+</div>"
 `;
 
-exports[`Component: stories > Selection stories > Story Inline 1`] = `"<div><span contenteditable="true">hello </span><mark data-testid="mark" tabindex="0">world</mark><span contenteditable="true"> foo</span></div>"`;
+exports[`Component: stories > Selection stories > Story Inline 1`] = `
+"<div>
+  <span contenteditable="true">hello </span>
+  <mark data-testid="mark" tabindex="0">world</mark>
+  <span contenteditable="true"> foo</span>
+</div>"
+`;
 
-exports[`Component: stories > Slots stories > Story CustomComponents 1`] = `"<div><span contenteditable="true">Both @[container] and @[span] are @[customized]</span></div>"`;
+exports[`Component: stories > Slots stories > Story CustomComponents 1`] = `
+"<div>
+  <span contenteditable="true">Both @[container] and @[span] are @[customized]</span>
+</div>"
+`;
 
-exports[`Component: stories > Slots stories > Story DataAttributes 1`] = `"<div data-test-id="marked-input-demo" data-module="slots-api" data-user-id="user-123"><span contenteditable="true">Use @[data] attributes for testing and tracking</span></div>"`;
+exports[`Component: stories > Slots stories > Story DataAttributes 1`] = `
+"<div data-test-id="marked-input-demo" data-module="slots-api" data-user-id="user-123">
+  <span contenteditable="true">Use @[data] attributes for testing and tracking</span>
+</div>"
+`;
 
-exports[`Component: stories > Slots stories > Story StyleMerging 1`] = `"<div><span contenteditable="true">Container has @[merged] styles from multiple sources</span></div>"`;
+exports[`Component: stories > Slots stories > Story StyleMerging 1`] = `
+"<div>
+  <span contenteditable="true">Container has @[merged] styles from multiple sources</span>
+</div>"
+`;
 
-exports[`Component: stories > Slots stories > Story WithSlotProps 1`] = `"<h3>Styling &amp; Events via slotProps</h3><p>Customize styling and add custom event handlers without replacing components:</p><div><span contenteditable="true">Try pressing @[Enter] or clicking</span></div><div><strong>Recent events:</strong><p>No events yet</p></div>"`;
+exports[`Component: stories > Slots stories > Story WithSlotProps 1`] = `
+"<h3>Styling &amp; Events via slotProps</h3>
+<p>Customize styling and add custom event handlers without replacing components:</p>
+<div>
+  <span contenteditable="true">Try pressing @[Enter] or clicking</span>
+</div>
+<div>
+  <strong>Recent events:</strong>
+  <p>No events yet</p>
+</div>"
+`;

--- a/packages/storybook/src/pages/__snapshots__/stories.vue.spec.ts.snap
+++ b/packages/storybook/src/pages/__snapshots__/stories.vue.spec.ts.snap
@@ -1,152 +1,1085 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Component: stories > Base stories > Story Autocomplete 1`] = `"<div><span contenteditable="true">Hello, clickable marked @world!</span></div><!--v-if-->"`;
+exports[`Component: stories > Base stories > Story Autocomplete 1`] = `
+"<div>
+  <span contenteditable="true">Hello, clickable marked @world!</span>
+</div>
+<!--v-if-->"
+`;
 
 exports[`Component: stories > Base stories > Story Configured 1`] = `
-"<div><div><div><span contenteditable="true">Enter the '@' for calling </span><button type="button" tabindex="0">primary</button><span contenteditable="true"> suggestions and '/' for </span><button type="button" tabindex="0">default</button><span contenteditable="true">!
-Mark is can be a any component with any logic. In this example it is the </span><button type="button" tabindex="0">Button</button><span contenteditable="true">: clickable primary or secondary.
-For found mark used </span><button type="button" tabindex="0">annotations</button><span contenteditable="true">.</span></div><!--v-if--></div><div><div>Plain Value</div><pre>Enter the '@' for calling @[primary](primary:4) suggestions and '/' for @[default](default:7)!
-Mark is can be a any component with any logic. In this example it is the @[Button](primary:54): clickable primary or secondary.
-For found mark used @[annotations](default:123).</pre></div></div>"
+"<div>
+  <div>
+    <div>
+      <span contenteditable="true">Enter the '@' for calling </span>
+      <button type="button" tabindex="0">primary</button>
+      <span contenteditable="true"> suggestions and '/' for </span>
+      <button type="button" tabindex="0">default</button>
+      <span contenteditable="true">!&#10;Mark is can be a any component with any logic. In this example it is the </span>
+      <button type="button" tabindex="0">Button</button>
+      <span contenteditable="true">: clickable primary or secondary.&#10;For found mark used </span>
+      <button type="button" tabindex="0">annotations</button>
+      <span contenteditable="true">.</span>
+    </div>
+    <!--v-if-->
+  </div>
+  <div>
+    <div>Plain Value</div>
+    <pre>Enter the '@' for calling @[primary](primary:4) suggestions and '/' for @[default](default:7)!&#10;Mark is can be a any component with any logic. In this example it is the @[Button](primary:54): clickable primary or secondary.&#10;For found mark used @[annotations](default:123).</pre>
+  </div>
+</div>"
 `;
 
-exports[`Component: stories > Base stories > Story Default 1`] = `"<div><span contenteditable="true">Hello, clickable marked </span><mark tabindex="0">world</mark><span contenteditable="true">!</span></div><!--v-if-->"`;
+exports[`Component: stories > Base stories > Story Default 1`] = `
+"<div>
+  <span contenteditable="true">Hello, clickable marked </span>
+  <mark tabindex="0">world</mark>
+  <span contenteditable="true">!</span>
+</div>
+<!--v-if-->"
+`;
 
 exports[`Component: stories > Clipboard stories > Story Drag 1`] = `
-"<div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span contenteditable="true">hello
-</span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><mark data-testid="mark" tabindex="0">world</mark><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span contenteditable="true">
-foo</span><!--v-if--><!--v-if--></div></div><!--v-if-->"
+"<div>
+  <div data-testid="block">
+    <!--v-if-->
+    <div>
+      <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+        <span></span>
+      </button>
+    </div>
+    <span contenteditable="true">hello&#10;</span>
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+  <div data-testid="block">
+    <!--v-if-->
+    <div>
+      <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+        <span></span>
+      </button>
+    </div>
+    <mark data-testid="mark" tabindex="0">world</mark>
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+  <div data-testid="block">
+    <!--v-if-->
+    <div>
+      <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+        <span></span>
+      </button>
+    </div>
+    <span contenteditable="true">&#10;foo</span>
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+</div>
+<!--v-if-->"
 `;
 
-exports[`Component: stories > Clipboard stories > Story Inline 1`] = `"<div><span contenteditable="true">hello </span><mark data-testid="mark" tabindex="0">world</mark><span contenteditable="true"> foo</span></div><!--v-if-->"`;
+exports[`Component: stories > Clipboard stories > Story Inline 1`] = `
+"<div>
+  <span contenteditable="true">hello </span>
+  <mark data-testid="mark" tabindex="0">world</mark>
+  <span contenteditable="true"> foo</span>
+</div>
+<!--v-if-->"
+`;
 
-exports[`Component: stories > Clipboard stories > Story NestedMarkStory 1`] = `"<div><span contenteditable="true">hello </span><mark data-testid="mark" tabindex="0"><strong>wor</strong><em>ld</em></mark><span contenteditable="true"> foo</span></div><!--v-if-->"`;
+exports[`Component: stories > Clipboard stories > Story NestedMarkStory 1`] = `
+"<div>
+  <span contenteditable="true">hello </span>
+  <mark data-testid="mark" tabindex="0">
+    <strong>wor</strong>
+    <em>ld</em>
+  </mark>
+  <span contenteditable="true"> foo</span>
+</div>
+<!--v-if-->"
+`;
 
-exports[`Component: stories > Clipboard stories > Story PlainText 1`] = `"<div><span contenteditable="true">abc</span></div><!--v-if-->"`;
+exports[`Component: stories > Clipboard stories > Story PlainText 1`] = `
+"<div>
+  <span contenteditable="true">abc</span>
+</div>
+<!--v-if-->"
+`;
 
 exports[`Component: stories > Drag stories > Story Markdown 1`] = `
-"<div><div><div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true">Welcome to </span><span tabindex="0"><span><span contenteditable="true">Marked Input</span></span></span><span contenteditable="true"></span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span contenteditable="true">A powerful library for parsing rich text with markdown formatting.
-
-</span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true">Features</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true"></span><span tabindex="0"><span><span contenteditable="true">Bold</span></span></span><span contenteditable="true"> and </span><span tabindex="0"><span><span contenteditable="true">italic</span></span></span><span contenteditable="true"> text support</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true"></span><span tabindex="0">Code snippets</span><span contenteditable="true"> and </span><span tabindex="0">code blocks</span><span contenteditable="true"></span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true"></span><span tabindex="0">Strikethrough</span><span contenteditable="true"> for deleted content</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true">Links like </span><span tabindex="0">GitHub</span><span contenteditable="true"></span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true">Example</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0">const parser = new ParserV2(['**__value__**', '*__value__*'])
-const result = parser.parse('Hello **world**!')
-</span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span contenteditable="true">
-
-Visit our docs for more details.</span><!--v-if--><!--v-if--></div></div><!--v-if--></div><div><div>Plain Value</div><pre># Welcome to **Marked Input**
-
-A powerful library for parsing rich text with markdown formatting.
-
-## Features
-
-- **Bold** and *italic* text support
-
-- \`Code snippets\` and \`code blocks\`
-
-- ~~Strikethrough~~ for deleted content
-
-- Links like [GitHub](https://github.com)
-
-## Example
-
-\`\`\`javascript
-const parser = new ParserV2(['**__value__**', '*__value__*'])
-const result = parser.parse('Hello **world**!')
-\`\`\`
-
-Visit our docs for more details.</pre></div></div>"
+"<div>
+  <div>
+    <div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <span>
+            <span contenteditable="true">Welcome to </span>
+            <span tabindex="0">
+              <span>
+                <span contenteditable="true">Marked Input</span>
+              </span>
+            </span>
+            <span contenteditable="true"></span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span contenteditable="true">A powerful library for parsing rich text with markdown formatting.&#10;&#10;</span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <span>
+            <span contenteditable="true">Features</span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <span>
+            <span contenteditable="true"></span>
+            <span tabindex="0">
+              <span>
+                <span contenteditable="true">Bold</span>
+              </span>
+            </span>
+            <span contenteditable="true"> and </span>
+            <span tabindex="0">
+              <span>
+                <span contenteditable="true">italic</span>
+              </span>
+            </span>
+            <span contenteditable="true"> text support</span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <span>
+            <span contenteditable="true"></span>
+            <span tabindex="0">Code snippets</span>
+            <span contenteditable="true"> and </span>
+            <span tabindex="0">code blocks</span>
+            <span contenteditable="true"></span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <span>
+            <span contenteditable="true"></span>
+            <span tabindex="0">Strikethrough</span>
+            <span contenteditable="true"> for deleted content</span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <span>
+            <span contenteditable="true">Links like </span>
+            <span tabindex="0">GitHub</span>
+            <span contenteditable="true"></span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <span>
+            <span contenteditable="true">Example</span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">const parser = new ParserV2(['**__value__**', '*__value__*'])&#10;const result = parser.parse('Hello **world**!')&#10;</span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span contenteditable="true">&#10;&#10;Visit our docs for more details.</span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+    </div>
+    <!--v-if-->
+  </div>
+  <div>
+    <div>Plain Value</div>
+    <pre># Welcome to **Marked Input**&#10;&#10;A powerful library for parsing rich text with markdown formatting.&#10;&#10;## Features&#10;&#10;- **Bold** and *italic* text support&#10;&#10;- \`Code snippets\` and \`code blocks\`&#10;&#10;- ~~Strikethrough~~ for deleted content&#10;&#10;- Links like [GitHub](https://github.com)&#10;&#10;## Example&#10;&#10;\`\`\`javascript&#10;const parser = new ParserV2(['**__value__**', '*__value__*'])&#10;const result = parser.parse('Hello **world**!')&#10;\`\`\`&#10;&#10;Visit our docs for more details.</pre>
+  </div>
+</div>"
 `;
 
 exports[`Component: stories > Drag stories > Story MarkdownDrag 1`] = `
-"<div><div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true">Welcome to Draggable Blocks</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span contenteditable="true">This is the first paragraph.
-
-This is the second paragraph.
-
-</span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true">Features</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true">Drag handles appear on hover</span></span></span><!--v-if--><!--v-if--></div></div><!--v-if--><pre># Welcome to Draggable Blocks
-
-This is the first paragraph.
-
-This is the second paragraph.
-
-## Features
-
-- Drag handles appear on hover
-
-</pre></div>"
+"<div>
+  <div>
+    <div data-testid="block">
+      <!--v-if-->
+      <div>
+        <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+          <span></span>
+        </button>
+      </div>
+      <span tabindex="0">
+        <span>
+          <span contenteditable="true">Welcome to Draggable Blocks</span>
+        </span>
+      </span>
+      <!--v-if-->
+      <!--v-if-->
+    </div>
+    <div data-testid="block">
+      <!--v-if-->
+      <div>
+        <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+          <span></span>
+        </button>
+      </div>
+      <span contenteditable="true">This is the first paragraph.&#10;&#10;This is the second paragraph.&#10;&#10;</span>
+      <!--v-if-->
+      <!--v-if-->
+    </div>
+    <div data-testid="block">
+      <!--v-if-->
+      <div>
+        <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+          <span></span>
+        </button>
+      </div>
+      <span tabindex="0">
+        <span>
+          <span contenteditable="true">Features</span>
+        </span>
+      </span>
+      <!--v-if-->
+      <!--v-if-->
+    </div>
+    <div data-testid="block">
+      <!--v-if-->
+      <div>
+        <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+          <span></span>
+        </button>
+      </div>
+      <span tabindex="0">
+        <span>
+          <span contenteditable="true">Drag handles appear on hover</span>
+        </span>
+      </span>
+      <!--v-if-->
+      <!--v-if-->
+    </div>
+  </div>
+  <!--v-if-->
+  <pre># Welcome to Draggable Blocks&#10;&#10;This is the first paragraph.&#10;&#10;This is the second paragraph.&#10;&#10;## Features&#10;&#10;- Drag handles appear on hover&#10;&#10;</pre>
+</div>"
 `;
 
 exports[`Component: stories > Drag stories > Story PlainTextDrag 1`] = `
-"<div><div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true">First block of plain text</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true">Second block of plain text</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true">Third block of plain text</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true">Fourth block of plain text</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span><span contenteditable="true">Fifth block of plain text</span></span></span><!--v-if--><!--v-if--></div></div><!--v-if--><pre>First block of plain text
-
-Second block of plain text
-
-Third block of plain text
-
-Fourth block of plain text
-
-Fifth block of plain text
-
-</pre></div>"
+"<div>
+  <div>
+    <div data-testid="block">
+      <!--v-if-->
+      <div>
+        <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+          <span></span>
+        </button>
+      </div>
+      <span tabindex="0">
+        <span>
+          <span contenteditable="true">First block of plain text</span>
+        </span>
+      </span>
+      <!--v-if-->
+      <!--v-if-->
+    </div>
+    <div data-testid="block">
+      <!--v-if-->
+      <div>
+        <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+          <span></span>
+        </button>
+      </div>
+      <span tabindex="0">
+        <span>
+          <span contenteditable="true">Second block of plain text</span>
+        </span>
+      </span>
+      <!--v-if-->
+      <!--v-if-->
+    </div>
+    <div data-testid="block">
+      <!--v-if-->
+      <div>
+        <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+          <span></span>
+        </button>
+      </div>
+      <span tabindex="0">
+        <span>
+          <span contenteditable="true">Third block of plain text</span>
+        </span>
+      </span>
+      <!--v-if-->
+      <!--v-if-->
+    </div>
+    <div data-testid="block">
+      <!--v-if-->
+      <div>
+        <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+          <span></span>
+        </button>
+      </div>
+      <span tabindex="0">
+        <span>
+          <span contenteditable="true">Fourth block of plain text</span>
+        </span>
+      </span>
+      <!--v-if-->
+      <!--v-if-->
+    </div>
+    <div data-testid="block">
+      <!--v-if-->
+      <div>
+        <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+          <span></span>
+        </button>
+      </div>
+      <span tabindex="0">
+        <span>
+          <span contenteditable="true">Fifth block of plain text</span>
+        </span>
+      </span>
+      <!--v-if-->
+      <!--v-if-->
+    </div>
+  </div>
+  <!--v-if-->
+  <pre>First block of plain text&#10;&#10;Second block of plain text&#10;&#10;Third block of plain text&#10;&#10;Fourth block of plain text&#10;&#10;Fifth block of plain text&#10;&#10;</pre>
+</div>"
 `;
 
-exports[`Component: stories > Drag stories > Story ReadOnlyDrag 1`] = `"<div><div data-testid="block"><!--v-if--><!--v-if--><span><span><span contenteditable="false">Read-Only Content</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><!--v-if--><span><span><span contenteditable="false">Section A</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><!--v-if--><span><span><span contenteditable="false">Section B</span></span></span><!--v-if--><!--v-if--></div></div><!--v-if-->"`;
+exports[`Component: stories > Drag stories > Story ReadOnlyDrag 1`] = `
+"<div>
+  <div data-testid="block">
+    <!--v-if-->
+    <!--v-if-->
+    <span>
+      <span>
+        <span contenteditable="false">Read-Only Content</span>
+      </span>
+    </span>
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+  <div data-testid="block">
+    <!--v-if-->
+    <!--v-if-->
+    <span>
+      <span>
+        <span contenteditable="false">Section A</span>
+      </span>
+    </span>
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+  <div data-testid="block">
+    <!--v-if-->
+    <!--v-if-->
+    <span>
+      <span>
+        <span contenteditable="false">Section B</span>
+      </span>
+    </span>
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+</div>
+<!--v-if-->"
+`;
 
 exports[`Component: stories > Drag stories > Story TodoListDrag 1`] = `
-"<div><div><div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><!----><span><span contenteditable="true">📋 Project Launch Checklist</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span>☐</span><span><span contenteditable="true">Design Phase</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span>☐</span><span><span contenteditable="true">Create wireframes</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span>☑</span><span><span contenteditable="true">Define color palette</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span>☐</span><span><span contenteditable="true">Design component library</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span>☑</span><span><span contenteditable="true">Research</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span>☑</span><span><span contenteditable="true">Analyze competitors</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span>☑</span><span><span contenteditable="true">User interviews</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span>☑</span><span><span contenteditable="true">Draft interview questions</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span>☑</span><span><span contenteditable="true">Schedule 5 sessions</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span>☐</span><span><span contenteditable="true">Development</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span>☐</span><span><span contenteditable="true">Set up CI/CD pipeline</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span>☑</span><span><span contenteditable="true">Write unit tests</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span>☐</span><span><span contenteditable="true">API integration</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span>☐</span><span><span contenteditable="true">Auth endpoints</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span>☐</span><span><span contenteditable="true">Data sync</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span>☐</span><span><span contenteditable="true">Launch</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span>☐</span><span><span contenteditable="true">Final QA pass</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><span>☐</span><span><span contenteditable="true">Deploy to production</span></span></span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span tabindex="0"><!----><span><span contenteditable="true">☐ = pending  ☑ = done</span></span></span><!--v-if--><!--v-if--></div></div><!--v-if--></div><div><div>Plain Value</div><pre># 📋 Project Launch Checklist
-
-- [ ] Design Phase
-	- [ ] Create wireframes
-	- [x] Define color palette
-	- [ ] Design component library
-- [x] Research
-	- [x] Analyze competitors
-	- [x] User interviews
-		- [x] Draft interview questions
-		- [x] Schedule 5 sessions
-- [ ] Development
-	- [ ] Set up CI/CD pipeline
-	- [x] Write unit tests
-	- [ ] API integration
-		- [ ] Auth endpoints
-		- [ ] Data sync
-- [ ] Launch
-	- [ ] Final QA pass
-	- [ ] Deploy to production
-&gt; ☐ = pending  ☑ = done
-
-</pre></div></div>"
+"<div>
+  <div>
+    <div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <!---->
+          <span>
+            <span contenteditable="true">📋 Project Launch Checklist</span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <span>☐</span>
+          <span>
+            <span contenteditable="true">Design Phase</span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <span>☐</span>
+          <span>
+            <span contenteditable="true">Create wireframes</span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <span>☑</span>
+          <span>
+            <span contenteditable="true">Define color palette</span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <span>☐</span>
+          <span>
+            <span contenteditable="true">Design component library</span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <span>☑</span>
+          <span>
+            <span contenteditable="true">Research</span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <span>☑</span>
+          <span>
+            <span contenteditable="true">Analyze competitors</span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <span>☑</span>
+          <span>
+            <span contenteditable="true">User interviews</span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <span>☑</span>
+          <span>
+            <span contenteditable="true">Draft interview questions</span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <span>☑</span>
+          <span>
+            <span contenteditable="true">Schedule 5 sessions</span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <span>☐</span>
+          <span>
+            <span contenteditable="true">Development</span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <span>☐</span>
+          <span>
+            <span contenteditable="true">Set up CI/CD pipeline</span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <span>☑</span>
+          <span>
+            <span contenteditable="true">Write unit tests</span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <span>☐</span>
+          <span>
+            <span contenteditable="true">API integration</span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <span>☐</span>
+          <span>
+            <span contenteditable="true">Auth endpoints</span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <span>☐</span>
+          <span>
+            <span contenteditable="true">Data sync</span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <span>☐</span>
+          <span>
+            <span contenteditable="true">Launch</span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <span>☐</span>
+          <span>
+            <span contenteditable="true">Final QA pass</span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <span>☐</span>
+          <span>
+            <span contenteditable="true">Deploy to production</span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+      <div data-testid="block">
+        <!--v-if-->
+        <div>
+          <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+            <span></span>
+          </button>
+        </div>
+        <span tabindex="0">
+          <!---->
+          <span>
+            <span contenteditable="true">☐ = pending  ☑ = done</span>
+          </span>
+        </span>
+        <!--v-if-->
+        <!--v-if-->
+      </div>
+    </div>
+    <!--v-if-->
+  </div>
+  <div>
+    <div>Plain Value</div>
+    <pre># 📋 Project Launch Checklist&#10;&#10;- [ ] Design Phase&#10;	- [ ] Create wireframes&#10;	- [x] Define color palette&#10;	- [ ] Design component library&#10;- [x] Research&#10;	- [x] Analyze competitors&#10;	- [x] User interviews&#10;		- [x] Draft interview questions&#10;		- [x] Schedule 5 sessions&#10;- [ ] Development&#10;	- [ ] Set up CI/CD pipeline&#10;	- [x] Write unit tests&#10;	- [ ] API integration&#10;		- [ ] Auth endpoints&#10;		- [ ] Data sync&#10;- [ ] Launch&#10;	- [ ] Final QA pass&#10;	- [ ] Deploy to production&#10;&gt; ☐ = pending  ☑ = done&#10;&#10;</pre>
+  </div>
+</div>"
 `;
 
-exports[`Component: stories > Dynamic stories > Story Dynamic 1`] = `"<div><span contenteditable="true">Hello, dynamical mark </span><mark meta=" " value="world" tabindex="0">world</mark><span contenteditable="true">!</span></div><!--v-if-->"`;
+exports[`Component: stories > Dynamic stories > Story Dynamic 1`] = `
+"<div>
+  <span contenteditable="true">Hello, dynamical mark </span>
+  <mark meta=" " value="world" tabindex="0">world</mark>
+  <span contenteditable="true">!</span>
+</div>
+<!--v-if-->"
+`;
 
-exports[`Component: stories > Dynamic stories > Story Focusable 1`] = `"<div><div><div><span contenteditable="true">Hello, </span><abbr title="By key operations" meta="By key operations" value="focusable" tabindex="0">focusable</abbr><span contenteditable="true"> abbreviation </span><abbr title="Hello! Hello!" meta="Hello! Hello!" value="world" tabindex="0">world</abbr><span contenteditable="true">!</span></div><!--v-if--></div><div><div>Plain Value</div><pre>Hello, @[focusable](By key operations) abbreviation @[world](Hello! Hello!)!</pre></div></div>"`;
+exports[`Component: stories > Dynamic stories > Story Focusable 1`] = `
+"<div>
+  <div>
+    <div>
+      <span contenteditable="true">Hello, </span>
+      <abbr title="By key operations" meta="By key operations" value="focusable" tabindex="0">focusable</abbr>
+      <span contenteditable="true"> abbreviation </span>
+      <abbr title="Hello! Hello!" meta="Hello! Hello!" value="world" tabindex="0">world</abbr>
+      <span contenteditable="true">!</span>
+    </div>
+    <!--v-if-->
+  </div>
+  <div>
+    <div>Plain Value</div>
+    <pre>Hello, @[focusable](By key operations) abbreviation @[world](Hello! Hello!)!</pre>
+  </div>
+</div>"
+`;
 
-exports[`Component: stories > Dynamic stories > Story Removable 1`] = `"<div><span contenteditable="true">I </span><mark meta=" " value="contain" tabindex="0">contain</mark><span contenteditable="true"> </span><mark meta=" " value="removable" tabindex="0">removable</mark><span contenteditable="true"> by click </span><mark meta=" " value="marks" tabindex="0">marks</mark><span contenteditable="true">!</span></div><!--v-if-->"`;
+exports[`Component: stories > Dynamic stories > Story Removable 1`] = `
+"<div>
+  <span contenteditable="true">I </span>
+  <mark meta=" " value="contain" tabindex="0">contain</mark>
+  <span contenteditable="true"> </span>
+  <mark meta=" " value="removable" tabindex="0">removable</mark>
+  <span contenteditable="true"> by click </span>
+  <mark meta=" " value="marks" tabindex="0">marks</mark>
+  <span contenteditable="true">!</span>
+</div>
+<!--v-if-->"
+`;
 
-exports[`Component: stories > Nested stories > Story HtmlLikeTags 1`] = `"<div><div><div><span contenteditable="true"></span><div tabindex="0"><span><span contenteditable="true">This is a div with </span><mark tabindex="0"><span><span contenteditable="true">a mark inside</span></span></mark><span contenteditable="true"> and </span><b tabindex="0"><span><span contenteditable="true">bold text with </span><del tabindex="0"><span><span contenteditable="true">nested del</span></span></del><span contenteditable="true"></span></span></b><span contenteditable="true"></span></span></div><span contenteditable="true"></span></div><!--v-if--></div><div><div>Plain Value</div><pre>&lt;div&gt;This is a div with &lt;mark&gt;a mark inside&lt;/mark&gt; and &lt;b&gt;bold text with &lt;del&gt;nested del&lt;/del&gt;&lt;/b&gt;&lt;/div&gt;</pre></div></div>"`;
+exports[`Component: stories > Nested stories > Story HtmlLikeTags 1`] = `
+"<div>
+  <div>
+    <div>
+      <span contenteditable="true"></span>
+      <div tabindex="0">
+        <span>
+          <span contenteditable="true">This is a div with </span>
+          <mark tabindex="0">
+            <span>
+              <span contenteditable="true">a mark inside</span>
+            </span>
+          </mark>
+          <span contenteditable="true"> and </span>
+          <b tabindex="0">
+            <span>
+              <span contenteditable="true">bold text with </span>
+              <del tabindex="0">
+                <span>
+                  <span contenteditable="true">nested del</span>
+                </span>
+              </del>
+              <span contenteditable="true"></span>
+            </span>
+          </b>
+          <span contenteditable="true"></span>
+        </span>
+      </div>
+      <span contenteditable="true"></span>
+    </div>
+    <!--v-if-->
+  </div>
+  <div>
+    <div>Plain Value</div>
+    <pre>&lt;div&gt;This is a div with &lt;mark&gt;a mark inside&lt;/mark&gt; and &lt;b&gt;bold text with &lt;del&gt;nested del&lt;/del&gt;&lt;/b&gt;&lt;/div&gt;</pre>
+  </div>
+</div>"
+`;
 
-exports[`Component: stories > Nested stories > Story MultipleLevels 1`] = `"<div><div><div><span contenteditable="true">Check </span><span tabindex="0"><span><span contenteditable="true">this tag with </span><span tabindex="0"><span><span contenteditable="true">nested mention with </span><span tabindex="0"><span><span contenteditable="true">code</span></span></span><span contenteditable="true"></span></span></span><span contenteditable="true"></span></span></span><span contenteditable="true"> and </span><span tabindex="0"><span><span contenteditable="true">another </span><span tabindex="0"><span><span contenteditable="true">deeply nested</span></span></span><span contenteditable="true"> tag</span></span></span><span contenteditable="true"></span></div><!--v-if--></div><div><div>Plain Value</div><pre>Check #[this tag with @[nested mention with \`code\`]] and #[another #[deeply nested] tag]</pre></div></div>"`;
+exports[`Component: stories > Nested stories > Story MultipleLevels 1`] = `
+"<div>
+  <div>
+    <div>
+      <span contenteditable="true">Check </span>
+      <span tabindex="0">
+        <span>
+          <span contenteditable="true">this tag with </span>
+          <span tabindex="0">
+            <span>
+              <span contenteditable="true">nested mention with </span>
+              <span tabindex="0">
+                <span>
+                  <span contenteditable="true">code</span>
+                </span>
+              </span>
+              <span contenteditable="true"></span>
+            </span>
+          </span>
+          <span contenteditable="true"></span>
+        </span>
+      </span>
+      <span contenteditable="true"> and </span>
+      <span tabindex="0">
+        <span>
+          <span contenteditable="true">another </span>
+          <span tabindex="0">
+            <span>
+              <span contenteditable="true">deeply nested</span>
+            </span>
+          </span>
+          <span contenteditable="true"> tag</span>
+        </span>
+      </span>
+      <span contenteditable="true"></span>
+    </div>
+    <!--v-if-->
+  </div>
+  <div>
+    <div>Plain Value</div>
+    <pre>Check #[this tag with @[nested mention with \`code\`]] and #[another #[deeply nested] tag]</pre>
+  </div>
+</div>"
+`;
 
-exports[`Component: stories > Nested stories > Story SimpleNesting 1`] = `"<div><div><div><span contenteditable="true">This is </span><span tabindex="0"><span><span contenteditable="true">italic text with </span><span tabindex="0"><span><span contenteditable="true">bold</span></span></span><span contenteditable="true"> inside</span></span></span><span contenteditable="true"> and more text.</span></div><!--v-if--></div><div><div>Plain Value</div><pre>This is *italic text with **bold** inside* and more text.</pre></div></div>"`;
+exports[`Component: stories > Nested stories > Story SimpleNesting 1`] = `
+"<div>
+  <div>
+    <div>
+      <span contenteditable="true">This is </span>
+      <span tabindex="0">
+        <span>
+          <span contenteditable="true">italic text with </span>
+          <span tabindex="0">
+            <span>
+              <span contenteditable="true">bold</span>
+            </span>
+          </span>
+          <span contenteditable="true"> inside</span>
+        </span>
+      </span>
+      <span contenteditable="true"> and more text.</span>
+    </div>
+    <!--v-if-->
+  </div>
+  <div>
+    <div>Plain Value</div>
+    <pre>This is *italic text with **bold** inside* and more text.</pre>
+  </div>
+</div>"
+`;
 
-exports[`Component: stories > Overlay stories > Story CustomOverlay 1`] = `"<div><span contenteditable="true">Hello, custom overlay by trigger @!</span></div><!--v-if-->"`;
+exports[`Component: stories > Overlay stories > Story CustomOverlay 1`] = `
+"<div>
+  <span contenteditable="true">Hello, custom overlay by trigger @!</span>
+</div>
+<!--v-if-->"
+`;
 
-exports[`Component: stories > Overlay stories > Story CustomTrigger 1`] = `"<div><span contenteditable="true">Hello, custom overlay by trigger /!</span></div><!--v-if-->"`;
+exports[`Component: stories > Overlay stories > Story CustomTrigger 1`] = `
+"<div>
+  <span contenteditable="true">Hello, custom overlay by trigger /!</span>
+</div>
+<!--v-if-->"
+`;
 
-exports[`Component: stories > Overlay stories > Story DefaultOverlay 1`] = `"<div><span contenteditable="true">Hello, default - suggestion overlay by trigger @!</span></div><!--v-if-->"`;
+exports[`Component: stories > Overlay stories > Story DefaultOverlay 1`] = `
+"<div>
+  <span contenteditable="true">Hello, default - suggestion overlay by trigger @!</span>
+</div>
+<!--v-if-->"
+`;
 
-exports[`Component: stories > Overlay stories > Story PositionedOverlay 1`] = `"<div><span contenteditable="true">Hello, positioned overlay by trigger @!</span></div><!--v-if-->"`;
+exports[`Component: stories > Overlay stories > Story PositionedOverlay 1`] = `
+"<div>
+  <span contenteditable="true">Hello, positioned overlay by trigger @!</span>
+</div>
+<!--v-if-->"
+`;
 
-exports[`Component: stories > Overlay stories > Story SelectableOverlay 1`] = `"<div><span contenteditable="true">Hello, suggest overlay by trigger @!</span></div><!--v-if-->"`;
+exports[`Component: stories > Overlay stories > Story SelectableOverlay 1`] = `
+"<div>
+  <span contenteditable="true">Hello, suggest overlay by trigger @!</span>
+</div>
+<!--v-if-->"
+`;
 
 exports[`Component: stories > Selection stories > Story Drag 1`] = `
-"<div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span contenteditable="true">hello
-</span><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><mark data-testid="mark" tabindex="0">world</mark><!--v-if--><!--v-if--></div><div data-testid="block"><!--v-if--><div><button type="button" draggable="true" aria-label="Drag to reorder or click for options"><span></span></button></div><span contenteditable="true">
-foo</span><!--v-if--><!--v-if--></div></div><!--v-if-->"
+"<div>
+  <div data-testid="block">
+    <!--v-if-->
+    <div>
+      <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+        <span></span>
+      </button>
+    </div>
+    <span contenteditable="true">hello&#10;</span>
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+  <div data-testid="block">
+    <!--v-if-->
+    <div>
+      <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+        <span></span>
+      </button>
+    </div>
+    <mark data-testid="mark" tabindex="0">world</mark>
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+  <div data-testid="block">
+    <!--v-if-->
+    <div>
+      <button type="button" draggable="true" aria-label="Drag to reorder or click for options">
+        <span></span>
+      </button>
+    </div>
+    <span contenteditable="true">&#10;foo</span>
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+</div>
+<!--v-if-->"
 `;
 
-exports[`Component: stories > Selection stories > Story Inline 1`] = `"<div><span contenteditable="true">hello </span><mark data-testid="mark" tabindex="0">world</mark><span contenteditable="true"> foo</span></div><!--v-if-->"`;
+exports[`Component: stories > Selection stories > Story Inline 1`] = `
+"<div>
+  <span contenteditable="true">hello </span>
+  <mark data-testid="mark" tabindex="0">world</mark>
+  <span contenteditable="true"> foo</span>
+</div>
+<!--v-if-->"
+`;
 
-exports[`Component: stories > Slots stories > Story DataAttributes 1`] = `"<div><div><div data-test-id="marked-input-demo" data-module="slots-api" data-user-id="user-123"><span contenteditable="true">Use @[data] attributes for testing and tracking</span></div><!--v-if--></div><div><div>Plain Value</div><pre>Use @[data] attributes for testing and tracking</pre></div></div>"`;
+exports[`Component: stories > Slots stories > Story DataAttributes 1`] = `
+"<div>
+  <div>
+    <div data-test-id="marked-input-demo" data-module="slots-api" data-user-id="user-123">
+      <span contenteditable="true">Use @[data] attributes for testing and tracking</span>
+    </div>
+    <!--v-if-->
+  </div>
+  <div>
+    <div>Plain Value</div>
+    <pre>Use @[data] attributes for testing and tracking</pre>
+  </div>
+</div>"
+`;
 
-exports[`Component: stories > Slots stories > Story StyleMerging 1`] = `"<div><div><div><span contenteditable="true">Container has @[merged] styles from multiple sources</span></div><!--v-if--></div><div><div>Plain Value</div><pre>Container has @[merged] styles from multiple sources</pre></div></div>"`;
+exports[`Component: stories > Slots stories > Story StyleMerging 1`] = `
+"<div>
+  <div>
+    <div>
+      <span contenteditable="true">Container has @[merged] styles from multiple sources</span>
+    </div>
+    <!--v-if-->
+  </div>
+  <div>
+    <div>Plain Value</div>
+    <pre>Container has @[merged] styles from multiple sources</pre>
+  </div>
+</div>"
+`;
 
-exports[`Component: stories > Slots stories > Story WithSlotProps 1`] = `"<h3>Styling &amp; Events via slotProps</h3><p>Customize styling and add custom event handlers without replacing components:</p><div><span contenteditable="true"></span></div><!--v-if--><div><strong>Recent events:</strong><p>No events yet</p></div>"`;
+exports[`Component: stories > Slots stories > Story WithSlotProps 1`] = `
+"<h3>Styling &amp; Events via slotProps</h3>
+<p>Customize styling and add custom event handlers without replacing components:</p>
+<div>
+  <span contenteditable="true"></span>
+</div>
+<!--v-if-->
+<div>
+  <strong>Recent events:</strong>
+  <p>No events yet</p>
+</div>"
+`;

--- a/packages/storybook/src/pages/htmlSnapshot.react.spec.tsx
+++ b/packages/storybook/src/pages/htmlSnapshot.react.spec.tsx
@@ -1,0 +1,49 @@
+import {describe, expect, it} from 'vitest'
+
+import {snapshotHtml} from '../shared/lib/htmlSnapshot'
+
+describe('snapshotHtml', () => {
+	it('formats nested html and strips unstable attributes', () => {
+		const html =
+			'<div class="wrapper" style="color: red"><span contenteditable="true">Hello</span><mark tabindex="0"><strong>wor</strong><em>ld</em></mark><!--v-if--></div>'
+
+		expect(snapshotHtml(html)).toMatchInlineSnapshot(`
+			"<div>
+			  <span contenteditable="true">Hello</span>
+			  <mark tabindex="0">
+			    <strong>wor</strong>
+			    <em>ld</em>
+			  </mark>
+			  <!--v-if-->
+			</div>"
+		`)
+	})
+
+	it('represents multiline text and attribute values without raw snapshot line breaks', () => {
+		const html = '<div><span contenteditable="true">hello\n</span><pre data-value="a\nb">a\nb</pre></div>'
+
+		expect(snapshotHtml(html)).toMatchInlineSnapshot(`
+			"<div>
+			  <span contenteditable="true">hello&#10;</span>
+			  <pre data-value="a&#10;b">a&#10;b</pre>
+			</div>"
+		`)
+	})
+
+	it('keeps browser serialization for void elements', () => {
+		const html = '<div><input class="checkbox" style="color: red" type="checkbox"><span>Done</span></div>'
+
+		expect(snapshotHtml(html)).toMatchInlineSnapshot(`
+			"<div>
+			  <input type="checkbox">
+			  <span>Done</span>
+			</div>"
+		`)
+	})
+
+	it('escapes serialized text and attribute content', () => {
+		const html = '<div data-value="a &amp; b &quot;c&quot;">Tom &amp; Jerry &lt;3</div>'
+
+		expect(snapshotHtml(html)).toBe('<div data-value="a &amp; b &quot;c&quot;">Tom &amp; Jerry &lt;3</div>')
+	})
+})

--- a/packages/storybook/src/pages/stories.react.spec.tsx
+++ b/packages/storybook/src/pages/stories.react.spec.tsx
@@ -2,6 +2,8 @@ import {composeStories} from '@storybook/react-vite'
 import {describe, expect, it} from 'vitest'
 import {render} from 'vitest-browser-react'
 
+import {snapshotHtml} from '../shared/lib/htmlSnapshot'
+
 // Automatically import all stories files
 const storiesModules = import.meta.glob('./**/*.react.stories.tsx', {eager: true})
 
@@ -31,7 +33,7 @@ const getTests =
 	([name, Story]: [string, any]) =>
 		it(`Story ${name}`, async () => {
 			const {container} = await render(<Story />)
-			expect(container.innerHTML.replace(/ class="[^"]*"/g, '').replace(/ style="[^"]*"/g, '')).toMatchSnapshot()
+			expect(snapshotHtml(container.innerHTML)).toMatchSnapshot()
 		})
 
 describe('Component: stories', () => {

--- a/packages/storybook/src/pages/stories.vue.spec.ts
+++ b/packages/storybook/src/pages/stories.vue.spec.ts
@@ -3,6 +3,8 @@ import {composeStories} from '@storybook/vue3-vite'
 import {describe, expect, it} from 'vitest'
 import {render} from 'vitest-browser-vue'
 
+import {snapshotHtml} from '../shared/lib/htmlSnapshot'
+
 const storiesModules = import.meta.glob('./**/*.vue.stories.ts', {eager: true})
 
 const storiesByCategory = new Map<string, Record<string, any>>()
@@ -28,7 +30,7 @@ const getTests =
 	([name, Story]: [string, any]) =>
 		it(`Story ${name}`, async () => {
 			const {container} = await render(Story)
-			expect(container.innerHTML.replace(/ class="[^"]*"/g, '').replace(/ style="[^"]*"/g, '')).toMatchSnapshot()
+			expect(snapshotHtml(container.innerHTML)).toMatchSnapshot()
 		})
 
 describe('Component: stories', () => {

--- a/packages/storybook/src/shared/lib/htmlSnapshot.ts
+++ b/packages/storybook/src/shared/lib/htmlSnapshot.ts
@@ -1,0 +1,76 @@
+const INLINE_ELEMENT = 'span'
+
+export function snapshotHtml(html: string): string {
+	const template = document.createElement('template')
+	template.innerHTML = html
+	stripUnstableAttributes(template.content)
+
+	return formatChildren(template.content, 0).join('\n')
+}
+
+function stripUnstableAttributes(parent: ParentNode): void {
+	for (const element of parent.querySelectorAll('[class],[style]')) {
+		element.removeAttribute('class')
+		element.removeAttribute('style')
+	}
+}
+
+function formatChildren(parent: Node, depth: number): string[] {
+	return Array.from(parent.childNodes).flatMap(child => formatNode(child, depth))
+}
+
+function formatNode(node: ChildNode, depth: number): string[] {
+	if (node instanceof Text) {
+		if (node.data === '') return []
+		return [`${indent(depth)}${serializeText(node.data)}`]
+	}
+
+	if (node instanceof Comment) {
+		return [`${indent(depth)}<!--${node.data}-->`]
+	}
+
+	if (node instanceof Element) {
+		return formatElement(node, depth)
+	}
+
+	return []
+}
+
+function formatElement(element: Element, depth: number): string[] {
+	if (element.childNodes.length === 0 || hasOnlyTextChildren(element)) {
+		return [`${indent(depth)}${serializeInline(element.outerHTML)}`]
+	}
+
+	const shellElement = element.cloneNode(false)
+	if (!(shellElement instanceof Element)) {
+		return [`${indent(depth)}${serializeInline(element.outerHTML)}`]
+	}
+
+	const shell = shellElement.outerHTML
+	const closeTag = `</${element.localName}>`
+
+	if (!shell.endsWith(closeTag)) {
+		return [`${indent(depth)}${serializeInline(element.outerHTML)}`]
+	}
+
+	const openTag = shell.slice(0, -closeTag.length)
+	return [`${indent(depth)}${openTag}`, ...formatChildren(element, depth + 1), `${indent(depth)}${closeTag}`]
+}
+
+function hasOnlyTextChildren(element: Element): boolean {
+	return Array.from(element.childNodes).every(child => child instanceof Text)
+}
+
+function serializeText(value: string): string {
+	const wrapper = document.createElement(INLINE_ELEMENT)
+	wrapper.textContent = value
+	return serializeInline(wrapper.innerHTML)
+}
+
+function serializeInline(value: string): string {
+	return value.replaceAll('\r\n', '&#10;').replaceAll('\n', '&#10;').replaceAll('\r', '&#13;')
+}
+
+function indent(depth: number): string {
+	return '  '.repeat(depth)
+}


### PR DESCRIPTION
## Summary
- add a shared Storybook HTML snapshot formatter that strips unstable class/style attributes and preserves browser serialization
- update React and Vue story snapshot tests to use formatted HTML
- regenerate story snapshots in readable nested form

## Test Plan
- [x] pnpm test
- [x] pnpm run build
- [x] pnpm run typecheck
- [x] pnpm run lint:check
- [x] pnpm run format:check