### PR TITLE
fix(ci): use PAT for release-please to trigger CI on release PRs

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -18,7 +18,7 @@ jobs:
             - uses: googleapis/release-please-action@v4
               id: release
               with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
+                  token: ${{ secrets.PAT }}
                   target-branch: next
                   config-file: release-please-config.json
 


### PR DESCRIPTION
## Summary
- Replace `GITHUB_TOKEN` with `secrets.PAT` in the Release Please action
- `GITHUB_TOKEN` commits don't trigger other workflows (GitHub security restriction); a PAT does

## Test plan
- [ ] Merge this into `next`
- [ ] Verify the next release PR (#217 or future) has CI checks running

🤖 Generated with [Claude Code](https://claude.com/claude-code)