### PR TITLE
refactor(caret): consolidate caret model and improve model() primitive

### DIFF
--- a/packages/core/src/features/caret/CaretModel.spec.ts
+++ b/packages/core/src/features/caret/CaretModel.spec.ts
@@ -86,23 +86,7 @@ describe('CaretModel', () => {
 	})
 
 	describe('selectAll', () => {
-		it('extends DOM selection across container', () => {
-			const store = new Store()
-			const container = document.createElement('div')
-			container.appendChild(document.createTextNode('hi'))
-			document.body.appendChild(container)
-			store.dom.container(container)
-
-			const mockSel = {setBaseAndExtent: vi.fn(), rangeCount: 0}
-			// oxlint-disable-next-line no-unsafe-type-assertion -- minimal stub of Selection for spy
-			vi.spyOn(window, 'getSelection').mockReturnValue(mockSel as unknown as Selection)
-
-			store.caret.selectAll()
-			expect(mockSel.setBaseAndExtent).toHaveBeenCalledWith(container.firstChild, 0, container.lastChild, 1)
-			container.remove()
-			vi.restoreAllMocks()
-		})
-		it('writes caret.selection from the resulting raw selection', () => {
+		it('sets selection to full value range and applies it to DOM', () => {
 			const store = new Store()
 			store.props.set({defaultValue: 'hello'})
 			store.lifecycle.mounted()
@@ -114,20 +98,27 @@ describe('CaretModel', () => {
 			store.dom.container(container)
 			store.lifecycle.rendered()
 
-			vi.spyOn(store.dom, 'readRawSelection').mockReturnValue({
+			const placeRangeSpy = vi.spyOn(store.dom, 'placeRange').mockReturnValue({
 				ok: true,
-				value: {range: {start: 0, end: 5}},
+				value: {applied: {start: 0, end: 5}},
 			})
 
 			store.caret.selectAll()
+			expect(placeRangeSpy).toHaveBeenCalledWith({start: 0, end: 5})
 			expect(store.caret.selection()).toEqual({start: 0, end: 5})
 			container.remove()
 			vi.restoreAllMocks()
 		})
-		it('is no-op when container is missing', () => {
+		it('clears selection when placeRange fails', () => {
 			const store = new Store()
-			expect(() => store.caret.selectAll()).not.toThrow()
-			expect(store.caret.isUserSelecting()).toBe(false)
+			store.props.set({defaultValue: 'hello'})
+			store.lifecycle.mounted()
+
+			vi.spyOn(store.dom, 'placeRange').mockReturnValue({ok: false, reason: 'notIndexed'})
+
+			store.caret.selectAll()
+			expect(store.caret.selection()).toBeUndefined()
+			vi.restoreAllMocks()
 		})
 	})
 

--- a/packages/core/src/features/caret/CaretModel.spec.ts
+++ b/packages/core/src/features/caret/CaretModel.spec.ts
@@ -4,10 +4,10 @@ import {watch} from '../../shared/signals'
 import {Store} from '../../store/Store'
 
 describe('CaretModel', () => {
-	it('exposes range and isSelecting', () => {
+	it('exposes range and isUserSelecting', () => {
 		const store = new Store()
 		expect(typeof store.caret.range).toBe('function')
-		expect(typeof store.caret.isSelecting).toBe('function')
+		expect(typeof store.caret.isUserSelecting).toBe('function')
 	})
 
 	it('range starts undefined', () => {
@@ -47,11 +47,11 @@ describe('CaretModel', () => {
 			store.caret.position(5)
 			expect(store.caret.range()).toEqual({start: 5, end: 5})
 		})
-		it('write does not change isSelecting', () => {
+		it('write does not change isUserSelecting', () => {
 			const store = new Store()
-			store.caret.isSelecting(true)
+			store.caret.isUserSelecting(true)
 			store.caret.position(5)
-			expect(store.caret.isSelecting()).toBe(true)
+			expect(store.caret.isUserSelecting()).toBe(true)
 		})
 		it('write collapses an extended range', () => {
 			const store = new Store()
@@ -117,7 +117,7 @@ describe('CaretModel', () => {
 		it('is no-op when container is missing', () => {
 			const store = new Store()
 			expect(() => store.caret.selectAll()).not.toThrow()
-			expect(store.caret.isSelecting()).toBe(false)
+			expect(store.caret.isUserSelecting()).toBe(false)
 		})
 	})
 
@@ -131,7 +131,7 @@ describe('CaretModel', () => {
 			return {store, container}
 		}
 
-		it('flips isSelecting when mouse drags across nodes inside the editor', () => {
+		it('flips isUserSelecting when mouse drags across nodes inside the editor', () => {
 			const {store, container} = mountWithContainer()
 			const a = document.createElement('span')
 			const b = document.createElement('span')
@@ -145,13 +145,13 @@ describe('CaretModel', () => {
 
 			a.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}))
 			b.dispatchEvent(new MouseEvent('mousemove', {bubbles: true}))
-			expect(store.caret.isSelecting()).toBe(true)
+			expect(store.caret.isUserSelecting()).toBe(true)
 
 			container.remove()
 			vi.restoreAllMocks()
 		})
 
-		it('does not flip isSelecting when drag stays on the same element', () => {
+		it('does not flip isUserSelecting when drag stays on the same element', () => {
 			const {store, container} = mountWithContainer()
 			const a = document.createElement('span')
 			a.textContent = 'a'
@@ -163,22 +163,22 @@ describe('CaretModel', () => {
 
 			a.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}))
 			a.dispatchEvent(new MouseEvent('mousemove', {bubbles: true}))
-			expect(store.caret.isSelecting()).toBe(false)
+			expect(store.caret.isUserSelecting()).toBe(false)
 
 			container.remove()
 			vi.restoreAllMocks()
 		})
 
-		it('clears isSelecting on mouseup when the resulting selection is collapsed', () => {
+		it('clears isUserSelecting on mouseup when the resulting selection is collapsed', () => {
 			const {store, container} = mountWithContainer()
-			store.caret.isSelecting(true)
+			store.caret.isUserSelecting(true)
 
 			const mockSel = {isCollapsed: true, focusNode: null, rangeCount: 0}
 			// oxlint-disable-next-line no-unsafe-type-assertion -- minimal stub of Selection for tracking logic
 			vi.spyOn(window, 'getSelection').mockReturnValue(mockSel as unknown as Selection)
 
 			document.dispatchEvent(new MouseEvent('mouseup', {bubbles: true}))
-			expect(store.caret.isSelecting()).toBe(false)
+			expect(store.caret.isUserSelecting()).toBe(false)
 
 			container.remove()
 			vi.restoreAllMocks()
@@ -213,12 +213,12 @@ describe('CaretModel', () => {
 			placeAtSpy.mockRestore()
 		})
 
-		it('skips restoration when isSelecting', () => {
+		it('skips restoration when isUserSelecting', () => {
 			const store = new Store()
 			const placeAtSpy = vi.spyOn(store.dom, 'placeAt')
 			store.lifecycle.mounted()
 			store.caret.position(3)
-			store.caret.isSelecting(true)
+			store.caret.isUserSelecting(true)
 			store.lifecycle.rendered()
 			expect(placeAtSpy).not.toHaveBeenCalled()
 			placeAtSpy.mockRestore()
@@ -240,13 +240,13 @@ describe('CaretModel', () => {
 	})
 
 	describe('single reconcile driver', () => {
-		it('calls dom.reconcile when isSelecting changes', () => {
+		it('calls dom.reconcile when isUserSelecting changes', () => {
 			const store = new Store()
 			const reconcileSpy = vi.spyOn(store.dom, 'reconcile')
 			store.lifecycle.mounted()
 			reconcileSpy.mockClear()
-			store.caret.isSelecting(true)
-			expect(reconcileSpy).toHaveBeenCalledWith({isSelecting: true})
+			store.caret.isUserSelecting(true)
+			expect(reconcileSpy).toHaveBeenCalledWith({isUserSelecting: true})
 			reconcileSpy.mockRestore()
 		})
 	})

--- a/packages/core/src/features/caret/CaretModel.spec.ts
+++ b/packages/core/src/features/caret/CaretModel.spec.ts
@@ -4,48 +4,48 @@ import {watch} from '../../shared/signals'
 import {Store} from '../../store/Store'
 
 describe('CaretModel', () => {
-	it('exposes range and isUserSelecting', () => {
+	it('exposes selection and isUserSelecting', () => {
 		const store = new Store()
-		expect(typeof store.caret.range).toBe('function')
+		expect(typeof store.caret.selection).toBe('function')
 		expect(typeof store.caret.isUserSelecting).toBe('function')
 	})
 
-	it('range starts undefined', () => {
-		expect(new Store().caret.range()).toBeUndefined()
+	it('selection starts undefined', () => {
+		expect(new Store().caret.selection()).toBeUndefined()
 	})
 
-	it('range write is structural-equality deduped', () => {
+	it('selection write is structural-equality deduped', () => {
 		const store = new Store()
 		const notify = vi.fn()
-		const stop = watch(store.caret.range, notify)
-		store.caret.range({start: 5, end: 5})
-		store.caret.range({start: 5, end: 5})
+		const stop = watch(store.caret.selection, notify)
+		store.caret.selection({start: 5, end: 5})
+		store.caret.selection({start: 5, end: 5})
 		expect(notify).toHaveBeenCalledTimes(1)
 		stop()
 	})
 
-	it('range undefined write is no-op when already undefined', () => {
+	it('selection undefined write is no-op when already undefined', () => {
 		const store = new Store()
 		const notify = vi.fn()
-		const stop = watch(store.caret.range, notify)
-		store.caret.range(undefined)
+		const stop = watch(store.caret.selection, notify)
+		store.caret.selection(undefined)
 		expect(notify).not.toHaveBeenCalled()
 		stop()
 	})
 
 	describe('position', () => {
-		it('is undefined when range is undefined', () => {
+		it('is undefined when selection is undefined', () => {
 			expect(new Store().caret.position()).toBeUndefined()
 		})
 		it('returns start when collapsed', () => {
 			const store = new Store()
-			store.caret.range({start: 5, end: 5})
+			store.caret.selection({start: 5, end: 5})
 			expect(store.caret.position()).toBe(5)
 		})
-		it('write collapses range to {pos, pos}', () => {
+		it('write collapses selection to {pos, pos}', () => {
 			const store = new Store()
 			store.caret.position(5)
-			expect(store.caret.range()).toEqual({start: 5, end: 5})
+			expect(store.caret.selection()).toEqual({start: 5, end: 5})
 		})
 		it('write does not change isUserSelecting', () => {
 			const store = new Store()
@@ -53,11 +53,11 @@ describe('CaretModel', () => {
 			store.caret.position(5)
 			expect(store.caret.isUserSelecting()).toBe(true)
 		})
-		it('write collapses an extended range', () => {
+		it('write collapses an extended selection', () => {
 			const store = new Store()
-			store.caret.range({start: 2, end: 8})
+			store.caret.selection({start: 2, end: 8})
 			store.caret.position(3)
-			expect(store.caret.range()).toEqual({start: 3, end: 3})
+			expect(store.caret.selection()).toEqual({start: 3, end: 3})
 		})
 	})
 
@@ -92,7 +92,7 @@ describe('CaretModel', () => {
 			container.remove()
 			vi.restoreAllMocks()
 		})
-		it('writes caret.range from the resulting raw selection', () => {
+		it('writes caret.selection from the resulting raw selection', () => {
 			const store = new Store()
 			store.props.set({defaultValue: 'hello'})
 			store.lifecycle.mounted()
@@ -110,7 +110,7 @@ describe('CaretModel', () => {
 			})
 
 			store.caret.selectAll()
-			expect(store.caret.range()).toEqual({start: 0, end: 5})
+			expect(store.caret.selection()).toEqual({start: 0, end: 5})
 			container.remove()
 			vi.restoreAllMocks()
 		})
@@ -196,7 +196,7 @@ describe('CaretModel', () => {
 	})
 
 	describe('restoration via dom.indexed', () => {
-		it('restores range after indexed fires', () => {
+		it('restores selection after indexed fires', () => {
 			const store = new Store()
 			const container = document.createElement('div')
 			document.body.appendChild(container)
@@ -224,7 +224,7 @@ describe('CaretModel', () => {
 			placeAtSpy.mockRestore()
 		})
 
-		it('clears range when placeAt fails', () => {
+		it('clears selection when placeAt fails', () => {
 			const store = new Store()
 			const container = document.createElement('div')
 			document.body.appendChild(container)
@@ -233,7 +233,7 @@ describe('CaretModel', () => {
 			store.lifecycle.mounted()
 			store.caret.position(3)
 			store.lifecycle.rendered()
-			expect(store.caret.range()).toBeUndefined()
+			expect(store.caret.selection()).toBeUndefined()
 			container.remove()
 			vi.restoreAllMocks()
 		})

--- a/packages/core/src/features/caret/CaretModel.spec.ts
+++ b/packages/core/src/features/caret/CaretModel.spec.ts
@@ -61,27 +61,27 @@ describe('CaretModel', () => {
 		})
 	})
 
-	describe('isFullSelection', () => {
+	describe('isAllSelected', () => {
 		it('returns false when value is empty', () => {
-			expect(new Store().caret.isFullSelection()).toBe(false)
+			expect(new Store().caret.isAllSelected()).toBe(false)
 		})
 		it('returns false when selection is collapsed', () => {
 			const store = new Store()
 			store.props.set({defaultValue: 'hello'})
 			store.caret.selection({start: 2, end: 2})
-			expect(store.caret.isFullSelection()).toBe(false)
+			expect(store.caret.isAllSelected()).toBe(false)
 		})
 		it('returns false for a partial selection', () => {
 			const store = new Store()
 			store.props.set({defaultValue: 'hello'})
 			store.caret.selection({start: 1, end: 3})
-			expect(store.caret.isFullSelection()).toBe(false)
+			expect(store.caret.isAllSelected()).toBe(false)
 		})
 		it('returns true when selection spans the entire value', () => {
 			const store = new Store()
 			store.props.set({defaultValue: 'hello'})
 			store.caret.selection({start: 0, end: 5})
-			expect(store.caret.isFullSelection()).toBe(true)
+			expect(store.caret.isAllSelected()).toBe(true)
 		})
 	})
 

--- a/packages/core/src/features/caret/CaretModel.spec.ts
+++ b/packages/core/src/features/caret/CaretModel.spec.ts
@@ -62,16 +62,26 @@ describe('CaretModel', () => {
 	})
 
 	describe('isFullSelection', () => {
-		it('returns false when no container', () => {
+		it('returns false when value is empty', () => {
 			expect(new Store().caret.isFullSelection()).toBe(false)
 		})
 		it('returns false when selection is collapsed', () => {
 			const store = new Store()
-			const container = document.createElement('div')
-			document.body.appendChild(container)
-			store.dom.container(container)
+			store.props.set({defaultValue: 'hello'})
+			store.caret.selection({start: 2, end: 2})
 			expect(store.caret.isFullSelection()).toBe(false)
-			container.remove()
+		})
+		it('returns false for a partial selection', () => {
+			const store = new Store()
+			store.props.set({defaultValue: 'hello'})
+			store.caret.selection({start: 1, end: 3})
+			expect(store.caret.isFullSelection()).toBe(false)
+		})
+		it('returns true when selection spans the entire value', () => {
+			const store = new Store()
+			store.props.set({defaultValue: 'hello'})
+			store.caret.selection({start: 0, end: 5})
+			expect(store.caret.isFullSelection()).toBe(true)
 		})
 	})
 

--- a/packages/core/src/features/caret/CaretModel.ts
+++ b/packages/core/src/features/caret/CaretModel.ts
@@ -6,10 +6,10 @@ import type {DomController} from '../dom/DomController'
 import type {Lifecycle} from '../lifecycle/Lifecycle'
 
 export class CaretModel {
-	readonly range = signal<Range>(undefined, {equals: shallow})
+	readonly selection = signal<Range>(undefined, {equals: shallow})
 	readonly position = computed({
-		get: () => this.range()?.start,
-		set: value => this.range(value !== undefined ? {start: value, end: value} : undefined),
+		get: () => this.selection()?.start,
+		set: value => this.selection(value !== undefined ? {start: value, end: value} : undefined),
 	})
 
 	/**
@@ -53,7 +53,7 @@ export class CaretModel {
 		if (!container?.firstChild || !container.lastChild) return
 		window.getSelection()?.setBaseAndExtent(container.firstChild, 0, container.lastChild, 1)
 		const rawSel = this.dom.readRawSelection()
-		if (rawSel.ok) this.range(rawSel.value.range)
+		if (rawSel.ok) this.selection(rawSel.value.range)
 	}
 
 	#enableFocusTracking(): void {
@@ -63,23 +63,23 @@ export class CaretModel {
 		listen(container, 'focusin', e => {
 			const target = e.target instanceof HTMLElement ? e.target : undefined
 			if (!target) {
-				this.range(undefined)
+				this.selection(undefined)
 				return
 			}
 			const result = this.dom.locateNode(target)
 			if (!result.ok) {
 				if (result.reason === 'control') return
-				this.range(undefined)
+				this.selection(undefined)
 				return
 			}
 			const rawSel = this.dom.readRawSelection()
-			if (rawSel.ok) this.range(rawSel.value.range)
+			if (rawSel.ok) this.selection(rawSel.value.range)
 		})
 
 		listen(container, 'focusout', () => {
 			queueMicrotask(() => {
 				if (!container.contains(document.activeElement)) {
-					this.range(undefined)
+					this.selection(undefined)
 				}
 			})
 		})
@@ -126,36 +126,36 @@ export class CaretModel {
 			const result = this.dom.locateNode(sel.focusNode)
 			if (!result.ok) {
 				if (result.reason === 'control') return
-				this.range(undefined)
+				this.selection(undefined)
 				return
 			}
 			const rawSel = this.dom.readRawSelection()
-			if (rawSel.ok) this.range(rawSel.value.range)
-			else this.range(undefined)
+			if (rawSel.ok) this.selection(rawSel.value.range)
+			else this.selection(undefined)
 		})
 	}
 
 	#applyRangeToDOM(): void {
 		if (this.isUserSelecting()) return
-		const range = this.range()
-		if (range === undefined) return
+		const sel = this.selection()
+		if (sel === undefined) return
 
-		if (range.start === range.end) {
-			const result = this.dom.placeAt(range.start)
+		if (sel.start === sel.end) {
+			const result = this.dom.placeAt(sel.start)
 			if (!result.ok) {
-				this.range(undefined)
+				this.selection(undefined)
 				return
 			}
 			const applied = result.value.applied
-			if (applied !== range.start) this.range({start: applied, end: applied})
+			if (applied !== sel.start) this.selection({start: applied, end: applied})
 			return
 		}
 
-		const result = this.dom.placeRange(range)
+		const result = this.dom.placeRange(sel)
 		if (!result.ok) {
-			this.range(undefined)
+			this.selection(undefined)
 			return
 		}
-		this.range(result.value.applied)
+		this.selection(result.value.applied)
 	}
 }

--- a/packages/core/src/features/caret/CaretModel.ts
+++ b/packages/core/src/features/caret/CaretModel.ts
@@ -24,7 +24,7 @@ export class CaretModel {
 	 * Whether the current selection spans the entire raw value
 	 * ({@link selection} is `{start: 0, end: value.length}`).
 	 */
-	readonly isFullSelection = computed(() => {
+	readonly isAllSelected = computed(() => {
 		const s = this.selection()
 		const v = this.value.current()
 		return s?.start === 0 && s.end === v.length && v.length > 0

--- a/packages/core/src/features/caret/CaretModel.ts
+++ b/packages/core/src/features/caret/CaretModel.ts
@@ -12,9 +12,11 @@ export class CaretModel {
 		set: value => this.range(value !== undefined ? {start: value, end: value} : undefined),
 	})
 
-	// isUserSelecting flags the period between the user starting and finishing
-	// a selection (mouse drag, keyboard Shift+Arrow, etc.). It is used to freeze
-	// structural text surfaces (contenteditable=false) while selecting.
+	/**
+	 * Whether the user is actively selecting text (mouse drag, keyboard
+	 * Shift+Arrow, etc.). Drives {@link DomController.reconcile} to freeze
+	 * structural text surfaces (contenteditable=false) while selecting.
+	 */
 	readonly isUserSelecting = signal<boolean>(false)
 
 	constructor(

--- a/packages/core/src/features/caret/CaretModel.ts
+++ b/packages/core/src/features/caret/CaretModel.ts
@@ -20,10 +20,6 @@ export class CaretModel {
 	 */
 	readonly isUserSelecting = signal<boolean>(false)
 
-	/**
-	 * Whether the current selection spans the entire raw value
-	 * ({@link selection} is `{start: 0, end: value.length}`).
-	 */
 	readonly isAllSelected = computed(() => {
 		const s = this.selection()
 		const v = this.value.current()

--- a/packages/core/src/features/caret/CaretModel.ts
+++ b/packages/core/src/features/caret/CaretModel.ts
@@ -12,7 +12,10 @@ export class CaretModel {
 		set: value => this.range(value !== undefined ? {start: value, end: value} : undefined),
 	})
 
-	readonly isSelecting = signal<boolean>(false)
+	// isUserSelecting flags the period between the user starting and finishing
+	// a selection (mouse drag, keyboard Shift+Arrow, etc.). It is used to freeze
+	// structural text surfaces (contenteditable=false) while selecting.
+	readonly isUserSelecting = signal<boolean>(false)
 
 	constructor(
 		private readonly lifecycle: Lifecycle,
@@ -22,13 +25,13 @@ export class CaretModel {
 			this.#enableFocusTracking()
 			this.#enableSelectionTracking()
 			watch(dom.indexed, () => {
-				dom.reconcile({isSelecting: this.isSelecting()})
+				dom.reconcile({isUserSelecting: this.isUserSelecting()})
 				this.#applyRangeToDOM()
 			})
 			effect(() => {
-				const isSelecting = this.isSelecting()
+				const isUserSelecting = this.isUserSelecting()
 				dom.readOnly()
-				dom.reconcile({isSelecting})
+				dom.reconcile({isUserSelecting})
 			})
 		})
 	}
@@ -101,21 +104,21 @@ export class CaretModel {
 			const selectionIntersectsEditor = window.getSelection()?.containsNode(container, true) ?? false
 
 			if ((startedOutsideEditor || sweepingAcrossNodes) && selectionIntersectsEditor) {
-				this.isSelecting(true)
+				this.isUserSelecting(true)
 			}
 		})
 
 		listen(document, 'mouseup', () => {
 			pressedAt = null
-			if (!this.isSelecting()) return
+			if (!this.isUserSelecting()) return
 			const sel = window.getSelection()
-			if (!sel || sel.isCollapsed) this.isSelecting(false)
+			if (!sel || sel.isCollapsed) this.isUserSelecting(false)
 		})
 
 		listen(document, 'selectionchange', () => {
 			const sel = window.getSelection()
-			if (this.isSelecting() && (!sel || sel.isCollapsed)) {
-				this.isSelecting(false)
+			if (this.isUserSelecting() && (!sel || sel.isCollapsed)) {
+				this.isUserSelecting(false)
 			}
 			if (!sel?.focusNode) return
 			const result = this.dom.locateNode(sel.focusNode)
@@ -131,7 +134,7 @@ export class CaretModel {
 	}
 
 	#applyRangeToDOM(): void {
-		if (this.isSelecting()) return
+		if (this.isUserSelecting()) return
 		const range = this.range()
 		if (range === undefined) return
 

--- a/packages/core/src/features/caret/CaretModel.ts
+++ b/packages/core/src/features/caret/CaretModel.ts
@@ -47,11 +47,8 @@ export class CaretModel {
 	}
 
 	selectAll(): void {
-		const container = this.dom.container()
-		if (!container?.firstChild || !container.lastChild) return
-		window.getSelection()?.setBaseAndExtent(container.firstChild, 0, container.lastChild, 1)
-		const rawSel = this.dom.readRawSelection()
-		if (rawSel.ok) this.selection(rawSel.value.range)
+		this.selection({start: 0, end: this.value.current().length})
+		this.#applyRangeToDOM()
 	}
 
 	#enableFocusTracking(): void {

--- a/packages/core/src/features/caret/CaretModel.ts
+++ b/packages/core/src/features/caret/CaretModel.ts
@@ -4,6 +4,7 @@ import {computed, effect, listen, signal, watch} from '../../shared/signals'
 import {shallow} from '../../shared/utils/shallow'
 import type {DomController} from '../dom/DomController'
 import type {Lifecycle} from '../lifecycle/Lifecycle'
+import type {ValueModel} from '../value/ValueModel'
 
 export class CaretModel {
 	readonly selection = signal<Range>(undefined, {equals: shallow})
@@ -19,9 +20,20 @@ export class CaretModel {
 	 */
 	readonly isUserSelecting = signal<boolean>(false)
 
+	/**
+	 * Whether the current selection spans the entire raw value
+	 * ({@link selection} is `{start: 0, end: value.length}`).
+	 */
+	readonly isFullSelection = computed(() => {
+		const s = this.selection()
+		const v = this.value.current()
+		return s?.start === 0 && s.end === v.length && v.length > 0
+	})
+
 	constructor(
 		private readonly lifecycle: Lifecycle,
-		private readonly dom: DomController
+		private readonly dom: DomController,
+		private readonly value: ValueModel
 	) {
 		lifecycle.onMounted(() => {
 			this.#enableFocusTracking()
@@ -36,16 +48,6 @@ export class CaretModel {
 				dom.reconcile({isUserSelecting})
 			})
 		})
-	}
-
-	isFullSelection(): boolean {
-		const sel = window.getSelection()
-		const container = this.dom.container()
-		if (!sel?.rangeCount || !container?.firstChild || !container.lastChild) return false
-		const range = sel.getRangeAt(0)
-		if (!container.contains(range.startContainer) || !container.contains(range.endContainer)) return false
-		const selected = range.toString()
-		return selected.length > 0 && selected === container.textContent
 	}
 
 	selectAll(): void {

--- a/packages/core/src/features/caret/README.md
+++ b/packages/core/src/features/caret/README.md
@@ -10,8 +10,8 @@ overlay positioning and block-edit navigation.
       caret/selection position.
     - `position: Signal<number | undefined>` — writable computed bound to
       `range.start`; writing collapses the range to `{start: pos, end: pos}`.
-    - `isSelecting: Signal<boolean>` — flips while the user is actively
-      drag-selecting; drives `dom.reconcile({isSelecting})` so structural text
+    - `isUserSelecting: Signal<boolean>` — flips while the user is actively
+      drag-selecting; drives `dom.reconcile({isUserSelecting})` so structural text
       surfaces become non-editable during drags.
     - `isFullSelection()` / `selectAll()` — imperative helpers for whole-editor
       selection.

--- a/packages/core/src/features/caret/README.md
+++ b/packages/core/src/features/caret/README.md
@@ -13,7 +13,7 @@ overlay positioning and block-edit navigation.
     - `isUserSelecting: Signal<boolean>` — flips while the user is actively
       drag-selecting; drives `dom.reconcile({isUserSelecting})` so structural text
       surfaces become non-editable during drags.
-    - `isFullSelection: Signal<boolean>` — computed from {@link selection} and
+    - `isAllSelected: Signal<boolean>` — computed from {@link selection} and
       `value.current().length`; true when the selection spans the entire raw value.
     - `selectAll()` — imperative helper for whole-editor selection.
 

--- a/packages/core/src/features/caret/README.md
+++ b/packages/core/src/features/caret/README.md
@@ -13,8 +13,9 @@ overlay positioning and block-edit navigation.
     - `isUserSelecting: Signal<boolean>` — flips while the user is actively
       drag-selecting; drives `dom.reconcile({isUserSelecting})` so structural text
       surfaces become non-editable during drags.
-    - `isFullSelection()` / `selectAll()` — imperative helpers for whole-editor
-      selection.
+    - `isFullSelection: Signal<boolean>` — computed from {@link selection} and
+      `value.current().length`; true when the selection spans the entire raw value.
+    - `selectAll()` — imperative helper for whole-editor selection.
 
     Document mouse + selectionchange listeners and focus tracking are wired in
     the constructor and tear down with the lifecycle scope. Range is re-applied

--- a/packages/core/src/features/dom/DomController.spec.ts
+++ b/packages/core/src/features/dom/DomController.spec.ts
@@ -430,10 +430,10 @@ describe('DomController structural indexing', () => {
 		container.remove()
 	})
 
-	it('skips apply when isSelecting', () => {
+	it('skips apply when isUserSelecting', () => {
 		const {store, container} = mountStructuralInline('hello')
 		store.caret.range({start: 2, end: 2})
-		store.caret.isSelecting(true)
+		store.caret.isUserSelecting(true)
 		store.lifecycle.rendered()
 
 		expect(store.caret.range()).toEqual({start: 2, end: 2})
@@ -510,7 +510,7 @@ describe('DomController structural indexing', () => {
 			container.remove()
 		})
 
-		it('reconcile respects isSelecting flag', () => {
+		it('reconcile respects isUserSelecting flag', () => {
 			const store = new Store()
 			const container = document.createElement('div')
 			const span = document.createElement('span')
@@ -521,10 +521,10 @@ describe('DomController structural indexing', () => {
 			store.dom.container(container)
 			store.lifecycle.rendered()
 
-			store.dom.reconcile({isSelecting: true})
+			store.dom.reconcile({isUserSelecting: true})
 			expect(span.contentEditable).toBe('false')
 
-			store.dom.reconcile({isSelecting: false})
+			store.dom.reconcile({isUserSelecting: false})
 			expect(span.contentEditable).toBe('true')
 
 			container.remove()

--- a/packages/core/src/features/dom/DomController.spec.ts
+++ b/packages/core/src/features/dom/DomController.spec.ts
@@ -391,27 +391,27 @@ describe('DomController structural indexing', () => {
 	it('clamps OOB caret range and places at maxPos', () => {
 		const {store, container} = mountStructuralInline('hello')
 
-		store.caret.range({start: 999, end: 999})
+		store.caret.selection({start: 999, end: 999})
 		store.lifecycle.rendered()
 
-		expect(store.caret.range()).toEqual({start: 5, end: 5})
+		expect(store.caret.selection()).toEqual({start: 5, end: 5})
 		container.remove()
 	})
 
 	it('clamps OOB selection range', () => {
 		const {store, container} = mountStructuralInline('hello')
 
-		store.caret.range({start: 999, end: 1000})
+		store.caret.selection({start: 999, end: 1000})
 		store.lifecycle.rendered()
 
-		expect(store.caret.range()).toEqual({start: 5, end: 5})
+		expect(store.caret.selection()).toEqual({start: 5, end: 5})
 		container.remove()
 	})
 
-	it('applies caret.range to DOM after render', () => {
+	it('applies caret.selection to DOM after render', () => {
 		const {store, container, textNode} = mountStructuralInline('hello')
 
-		store.caret.range({start: 3, end: 3})
+		store.caret.selection({start: 3, end: 3})
 		store.lifecycle.rendered()
 
 		const sel = window.getSelection()
@@ -422,21 +422,21 @@ describe('DomController structural indexing', () => {
 
 	it('clamps OOB range and places caret at clamped position', () => {
 		const {store, container} = mountStructuralInline('hello') // length 5
-		store.caret.range({start: 999, end: 999})
+		store.caret.selection({start: 999, end: 999})
 		store.lifecycle.rendered()
 
 		// clamped to maxPos (5); structural equality prevents re-fire
-		expect(store.caret.range()).toEqual({start: 5, end: 5})
+		expect(store.caret.selection()).toEqual({start: 5, end: 5})
 		container.remove()
 	})
 
 	it('skips apply when isUserSelecting', () => {
 		const {store, container} = mountStructuralInline('hello')
-		store.caret.range({start: 2, end: 2})
+		store.caret.selection({start: 2, end: 2})
 		store.caret.isUserSelecting(true)
 		store.lifecycle.rendered()
 
-		expect(store.caret.range()).toEqual({start: 2, end: 2})
+		expect(store.caret.selection()).toEqual({start: 2, end: 2})
 		container.remove()
 	})
 

--- a/packages/core/src/features/dom/DomController.ts
+++ b/packages/core/src/features/dom/DomController.ts
@@ -207,8 +207,8 @@ export class DomController {
 		return callback
 	}
 
-	reconcile(opts?: {isSelecting?: boolean}): void {
-		this.#reconcileStructuralTextSurfaces(opts?.isSelecting)
+	reconcile(opts?: {isUserSelecting?: boolean}): void {
+		this.#reconcileStructuralTextSurfaces(opts?.isUserSelecting)
 	}
 
 	locateNode(node: Node): NodeLocationResult {
@@ -642,9 +642,9 @@ export class DomController {
 		)
 	}
 
-	#reconcileStructuralTextSurfaces(isSelecting?: boolean): void {
+	#reconcileStructuralTextSurfaces(isUserSelecting?: boolean): void {
 		const tokenIndex = this.parsing.index()
-		const editable = this.props.readOnly() || isSelecting ? 'false' : 'true'
+		const editable = this.props.readOnly() || isUserSelecting ? 'false' : 'true'
 
 		for (const record of this.#pathElements.values()) {
 			const resolved = tokenIndex.resolveAddress(record.address)

--- a/packages/core/src/features/dom/README.md
+++ b/packages/core/src/features/dom/README.md
@@ -7,7 +7,7 @@ Owns rendered DOM structure, token-to-element indexing, raw boundary mapping, te
 - **DOM registration**: React/Vue register the root through `store.dom.container` and block controls through `store.dom.controlFor()`.
 - **DOM index**: Built after `lifecycle.rendered()` from direct rendered token roots.
 - **Raw mapping**: Converts DOM boundaries and selections to serialized raw positions for the value pipeline.
-- **Range placement**: Applies `caret.range` to the DOM after every render by placing text carets or selections. Out-of-bounds ranges are clamped; ranges that cannot be placed are cleared and reported through `dom.diagnostics`.
+- **Range placement**: Applies `caret.selection` to the DOM after every render by placing text carets or selections. Out-of-bounds ranges are clamped; ranges that cannot be placed are cleared and reported through `dom.diagnostics`.
 - **Text reconciliation**: Keeps structural text roots in sync with parsed text tokens and `readOnly` state.
 
 Production code must not infer token identity from public data attributes or user refs.

--- a/packages/core/src/features/drag/DragController.spec.ts
+++ b/packages/core/src/features/drag/DragController.spec.ts
@@ -39,7 +39,7 @@ describe('DragController', () => {
 		expect(typeof store.drag.action).toBe('function')
 	})
 
-	it('commits drag edits through current() and writes caret.range', () => {
+	it('commits drag edits through current() and writes caret.selection', () => {
 		store.props.set({layout: 'block', draggable: true})
 		store.lifecycle.mounted()
 		store.value.current('alpha\n\nbeta\n\n')
@@ -49,6 +49,6 @@ describe('DragController', () => {
 		store.drag.action({type: 'delete', index: 0})
 
 		expect(currentSpy).toHaveBeenCalledWith('beta\n\n')
-		expect(store.caret.range()).toEqual({start: 6, end: 6})
+		expect(store.caret.selection()).toEqual({start: 6, end: 6})
 	})
 })

--- a/packages/core/src/features/drag/DragController.ts
+++ b/packages/core/src/features/drag/DragController.ts
@@ -58,7 +58,7 @@ export class DragController {
 		const newValue = reorderDragRows(value, rows, action.source, action.target)
 		if (newValue !== value) {
 			const range = this.#rangeAfterDrag(action, rows, newValue)
-			if (range) this.caret.range(range)
+			if (range) this.caret.selection(range)
 			this.value.current(newValue)
 		}
 	}
@@ -70,7 +70,7 @@ export class DragController {
 		const newRowContent = createRowContent(this.props.options())
 		const newValue = addDragRow(value, rows, action.afterIndex, newRowContent)
 		const range = this.#rangeAfterDrag(action, rows, newValue)
-		if (range) this.caret.range(range)
+		if (range) this.caret.selection(range)
 		this.value.current(newValue)
 	}
 
@@ -79,7 +79,7 @@ export class DragController {
 		const rows = this.parsing.tokens()
 		const newValue = deleteDragRow(value, rows, action.index)
 		const range = this.#rangeAfterDrag(action, rows, newValue)
-		if (range) this.caret.range(range)
+		if (range) this.caret.selection(range)
 		this.value.current(newValue)
 	}
 
@@ -88,7 +88,7 @@ export class DragController {
 		const rows = this.parsing.tokens()
 		const newValue = duplicateDragRow(value, rows, action.index)
 		const range = this.#rangeAfterDrag(action, rows, newValue)
-		if (range) this.caret.range(range)
+		if (range) this.caret.selection(range)
 		this.value.current(newValue)
 	}
 

--- a/packages/core/src/features/keyboard/arrowNav.ts
+++ b/packages/core/src/features/keyboard/arrowNav.ts
@@ -27,7 +27,7 @@ export function enableArrowNav(store: KbCtx): void {
 
 function shiftFocus(store: KbCtx, event: KeyboardEvent, direction: 'prev' | 'next'): boolean {
 	// Resolve the "current" token from the focused DOM element, not from
-	// caret.range. At a position exactly between two tokens the position alone
+	// caret.selection. At a position exactly between two tokens the position alone
 	// is ambiguous; the active element tells us which token the user is
 	// actually standing on.
 	const active = document.activeElement instanceof HTMLElement ? document.activeElement : undefined

--- a/packages/core/src/features/keyboard/input.spec.ts
+++ b/packages/core/src/features/keyboard/input.spec.ts
@@ -98,7 +98,7 @@ describe('handleBeforeInput()', () => {
 
 		expect(event.defaultPrevented).toBe(true)
 		expect(replaceRange).toHaveBeenCalledWith({start: 1, end: 1}, 'x')
-		expect(store.caret.range()).toEqual({start: 2, end: 2})
+		expect(store.caret.selection()).toEqual({start: 2, end: 2})
 		container.remove()
 	})
 

--- a/packages/core/src/features/keyboard/input.ts
+++ b/packages/core/src/features/keyboard/input.ts
@@ -68,7 +68,7 @@ function handleDeleteKey(store: KbCtx, event: KeyboardEvent): void {
 	if (store.slots.isBlock()) return
 	if (event.key !== KEYBOARD.BACKSPACE && event.key !== KEYBOARD.DELETE) return
 
-	if (store.caret.isFullSelection()) {
+	if (store.caret.isAllSelected()) {
 		event.preventDefault()
 		replaceAllContentWith(store, '')
 		return
@@ -87,7 +87,7 @@ function handleDeleteKey(store: KbCtx, event: KeyboardEvent): void {
 }
 
 export function handleBeforeInput(store: KbCtx, event: InputEvent): void {
-	if (store.caret.isFullSelection()) {
+	if (store.caret.isAllSelected()) {
 		if (event.inputType === 'insertFromPaste') {
 			event.preventDefault()
 			return
@@ -250,7 +250,7 @@ function adjacentMarkRange(tokens: readonly Token[], position: number, backward:
 }
 
 export function handlePaste(store: KbCtx, event: ClipboardEvent): void {
-	if (!store.caret.isFullSelection()) return
+	if (!store.caret.isAllSelected()) return
 
 	event.preventDefault()
 	const c = store.dom.container()

--- a/packages/core/src/features/overlay/OverlayController.spec.ts
+++ b/packages/core/src/features/overlay/OverlayController.spec.ts
@@ -140,7 +140,7 @@ describe('OverlayController', () => {
 			store.overlay.select({mark, match})
 
 			expect(replaceRange).toHaveBeenCalledWith({start: 6, end: 9}, '@[world]')
-			expect(store.caret.range()).toEqual({start: 14, end: 14})
+			expect(store.caret.selection()).toEqual({start: 14, end: 14})
 			expect(store.overlay.match()).toBeUndefined()
 			store.props.set({options: []})
 		})

--- a/packages/core/src/features/overlay/OverlayController.ts
+++ b/packages/core/src/features/overlay/OverlayController.ts
@@ -146,10 +146,10 @@ export class OverlayController {
 	}
 
 	#probeTriggerFromCaretRange(): OverlayMatch | undefined {
-		const range = this.caret.range()
-		if (!range || range.start !== range.end) return
+		const sel = this.caret.selection()
+		if (!sel || sel.start !== sel.end) return
 
-		const cursor = range.start
+		const cursor = sel.start
 		const value = this.value.current()
 		const left = value.slice(0, cursor)
 		const right = value.slice(cursor)

--- a/packages/core/src/features/value/README.md
+++ b/packages/core/src/features/value/README.md
@@ -16,8 +16,8 @@ Owns accepted serialized editor value state and the raw-position edit pipeline.
 
 ## Commands
 
-| Command     | Purpose                                                                                                                                                          |
-| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Command     | Purpose                                                                                                                                                              |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `replace()` | Replace a raw serialized range with bounds validation. Callers that want a specific post-edit caret write `store.caret.selection({start, end})` in the same handler. |
 
 Drag, clipboard, overlay, block editing, inline input, and mark commands use

--- a/packages/core/src/features/value/README.md
+++ b/packages/core/src/features/value/README.md
@@ -18,7 +18,7 @@ Owns accepted serialized editor value state and the raw-position edit pipeline.
 
 | Command     | Purpose                                                                                                                                                          |
 | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `replace()` | Replace a raw serialized range with bounds validation. Callers that want a specific post-edit caret write `store.caret.range({start, end})` in the same handler. |
+| `replace()` | Replace a raw serialized range with bounds validation. Callers that want a specific post-edit caret write `store.caret.selection({start, end})` in the same handler. |
 
 Drag, clipboard, overlay, block editing, inline input, and mark commands use
 `replace()` or write `current()` directly instead of mutating tokens

--- a/packages/core/src/shared/signals/model.spec.ts
+++ b/packages/core/src/shared/signals/model.spec.ts
@@ -1,5 +1,6 @@
 import {describe, it, expect, vi} from 'vitest'
 
+import {shallow} from '../utils/shallow'
 import {signal, effect, model, isReactive} from './signal'
 
 describe('model', () => {
@@ -143,6 +144,67 @@ describe('model', () => {
 			get: value => value,
 			set: (_next, previous) => previous,
 		})
+		expect(isReactive(m)).toBe(true)
+	})
+})
+
+describe('model — upgrade: optional fields and equals', () => {
+	it('returns undefined initially when default is omitted', () => {
+		const m = model<string>({})
+		expect(m()).toBeUndefined()
+	})
+
+	it('writes value when set is omitted (identity default)', () => {
+		const m = model<string>({default: () => 'a'})
+		expect(m()).toBe('a')
+		m('b')
+		expect(m()).toBe('b')
+	})
+
+	it('treats m(undefined) as a no-op when set is omitted', () => {
+		const m = model<string>({default: () => 'a'})
+		m('b')
+		m(undefined)
+		expect(m()).toBe('b')
+	})
+
+	it('reads via custom get when default is omitted', () => {
+		const m = model<string>({get: value => value ?? 'fallback'})
+		expect(m()).toBe('fallback')
+		m('written')
+		expect(m()).toBe('written')
+	})
+
+	it('skips subscribers when equals reports unchanged', () => {
+		const m = model<{x: number}>({default: () => ({x: 1}), equals: shallow})
+		const runs = vi.fn()
+		const dispose = effect(() => {
+			m()
+			runs()
+		})
+		expect(runs).toHaveBeenCalledTimes(1)
+		m({x: 1})
+		expect(runs).toHaveBeenCalledTimes(1)
+		m({x: 2})
+		expect(runs).toHaveBeenCalledTimes(2)
+		dispose()
+	})
+
+	it('uses reference equality when equals is omitted', () => {
+		const m = model<{x: number}>({default: () => ({x: 1})})
+		const runs = vi.fn()
+		const dispose = effect(() => {
+			m()
+			runs()
+		})
+		expect(runs).toHaveBeenCalledTimes(1)
+		m({x: 1})
+		expect(runs).toHaveBeenCalledTimes(2)
+		dispose()
+	})
+
+	it('isReactive returns true for a model with no options', () => {
+		const m = model<string>({})
 		expect(isReactive(m)).toBe(true)
 	})
 })

--- a/packages/core/src/shared/signals/signal.ts
+++ b/packages/core/src/shared/signals/signal.ts
@@ -610,24 +610,43 @@ export function untracked<T>(fn: () => T): T {
 // ---------------------------------------------------------------------------
 
 export function model<T>(opts: {
+	default?: undefined
+	equals?: (a: T | undefined, b: T | undefined) => boolean
+	get?: (value: T | undefined) => T | undefined
+	set?: (next: T | undefined, previous: T | undefined) => T | undefined
+}): Signal<T | undefined>
+export function model<T>(opts: {
 	default: () => T
-	get: (value: T) => T
-	set: (next: T | undefined, previous: T) => T
+	equals?: (a: T, b: T) => boolean
+	get?: (value: T) => T
+	set?: (next: T | undefined, previous: T) => T
+}): Signal<T>
+export function model<T>(opts: {
+	default?: () => T
+	equals?: (a: T, b: T) => boolean
+	get?: (value: T) => T
+	set?: (next: T | undefined, previous: T) => T
 }): Signal<T> {
 	let internal: Signal<T> | undefined
 	const ensureInternal = (): Signal<T> => {
-		internal ??= signal(untracked(opts.default))
+		if (internal !== undefined) return internal
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- undefined is a valid seed for the no-default overload; signal() handles hasDefault correctly
+		const seed = opts.default !== undefined ? untracked(opts.default) : (undefined as T)
+		internal = signal<T>(seed, {equals: opts.equals})
 		return internal
 	}
 
+	const getFn = opts.get ?? ((value: T) => value)
+	const setFn = opts.set ?? ((next: T | undefined, previous: T) => next ?? previous)
+
 	// Reads go through computed so opts.get is memoized and external signals
 	// read inside opts.get propagate to subscribers.
-	const reader = computed(() => opts.get(ensureInternal()()))
+	const reader = computed(() => getFn(ensureInternal()()))
 
 	const callable = function modelOper(...args: [T | undefined] | []): T | void {
 		if (args.length === 0) return reader()
 		const sig = ensureInternal()
-		sig(opts.set(args[0], sig()))
+		sig(setFn(args[0], sig()))
 	}
 
 	Object.defineProperty(callable, 'name', {value: 'bound ' + computedOper.name})

--- a/packages/core/src/store/Store.spec.ts
+++ b/packages/core/src/store/Store.spec.ts
@@ -71,8 +71,8 @@ describe('Store', () => {
 
 		it('leave other keys unchanged when one signal is updated', () => {
 			const store = new Store()
-			store.caret.isSelecting(true)
-			expect(store.caret.isSelecting()).toBe(true)
+			store.caret.isUserSelecting(true)
+			expect(store.caret.isUserSelecting()).toBe(true)
 			expect(store.parsing.tokens()).toEqual([])
 		})
 
@@ -81,14 +81,14 @@ describe('Store', () => {
 			const effectSpy = vi.fn()
 			effect(() => {
 				store.parsing.tokens()
-				store.caret.isSelecting()
+				store.caret.isUserSelecting()
 				effectSpy()
 			})
 			effectSpy.mockClear()
 			const token = {type: 'text' as const, content: 'a', position: {start: 0, end: 1}}
 			batch(() => {
 				store.parsing.tokens([token])
-				store.caret.isSelecting(true)
+				store.caret.isUserSelecting(true)
 			})
 			expect(effectSpy).toHaveBeenCalledTimes(1)
 		})

--- a/packages/core/src/store/Store.ts
+++ b/packages/core/src/store/Store.ts
@@ -31,7 +31,7 @@ export class Store {
 
 	readonly dom = new DomController(this.lifecycle, this.props, this.parsing, this.value)
 
-	readonly caret = new CaretModel(this.lifecycle, this.dom)
+	readonly caret = new CaretModel(this.lifecycle, this.dom, this.value)
 
 	readonly overlay = new OverlayController(this.lifecycle, this.props, this.value, this.dom, this.caret, this.parsing)
 	readonly keyboard = new KeyboardController(

--- a/packages/website/src/content/docs/development/architecture.md
+++ b/packages/website/src/content/docs/development/architecture.md
@@ -316,7 +316,7 @@ class Store {
     // Features live directly on store, not nested under .feature
     readonly lifecycle: Lifecycle          // mounted, unmounted, rendered events
     readonly props:     PropsModel         // framework-provided configuration
-    readonly caret:     CaretModel         // range, position (computed), isUserSelecting
+    readonly caret:     CaretModel         // selection, position (computed), isUserSelecting, isFullSelection
     readonly mark:      MarkFeature        // mark slot resolution
     readonly slots:     SlotsFeature       // isBlock, isDraggable, slot component/props
     readonly value:     ValueModel         // current, replace()
@@ -378,7 +378,7 @@ Signal subscription order is significant: `ParseController` subscribes to `value
 | **DragController**            | Drag-and-drop reordering of blocks                       |
 | **ClipboardController**       | Clipboard copy/cut handling                              |
 
-`KeyboardController` internally composes three modules: input handling, block editing, and arrow navigation. `CaretModel` exposes a `range: Signal<Range | undefined>` as the single source of truth for the caret/selection position, a writable `position: Signal<number | undefined>` computed bound to `range.start` (writes collapse the range), and an `isUserSelecting: Signal<boolean>` for drag-selection state.
+`KeyboardController` internally composes three modules: input handling, block editing, and arrow navigation. `CaretModel` exposes a `selection: Signal<Range | undefined>` as the single source of truth for the caret/selection position, a writable `position: Signal<number | undefined>` computed bound to `selection.start` (writes collapse the range), an `isUserSelecting: Signal<boolean>` for selection-in-progress state, and `isFullSelection: Signal<boolean>` derived from `selection` and the raw value length.
 
 ## Lifecycle Timing
 
@@ -433,8 +433,8 @@ Core owns token addresses, DOM registration, raw selection mapping, raw value mu
 Caret responsibilities are split into a stateful feature and a stateless helper
 module:
 
-- `CaretModel` (feature) owns the reactive caret/selection state — `range`,
-  `position`, and `isUserSelecting` signals — plus document-level mouse and
+- `CaretModel` (feature) owns the reactive caret/selection state — `selection`,
+  `position`, `isUserSelecting`, and `isFullSelection` signals — plus document-level mouse and
   selectionchange listeners that keep the signals in sync with the browser
   selection. It depends on `DomController` for DOM placement
   (`dom.placeAt` / `dom.placeRange`) and never touches the DOM directly for

--- a/packages/website/src/content/docs/development/architecture.md
+++ b/packages/website/src/content/docs/development/architecture.md
@@ -316,7 +316,7 @@ class Store {
     // Features live directly on store, not nested under .feature
     readonly lifecycle: Lifecycle          // mounted, unmounted, rendered events
     readonly props:     PropsModel         // framework-provided configuration
-    readonly caret:     CaretModel         // selection, position (computed), isUserSelecting, isFullSelection
+    readonly caret:     CaretModel         // selection, position (computed), isUserSelecting, isAllSelected
     readonly mark:      MarkFeature        // mark slot resolution
     readonly slots:     SlotsFeature       // isBlock, isDraggable, slot component/props
     readonly value:     ValueModel         // current, replace()
@@ -378,7 +378,7 @@ Signal subscription order is significant: `ParseController` subscribes to `value
 | **DragController**            | Drag-and-drop reordering of blocks                       |
 | **ClipboardController**       | Clipboard copy/cut handling                              |
 
-`KeyboardController` internally composes three modules: input handling, block editing, and arrow navigation. `CaretModel` exposes a `selection: Signal<Range | undefined>` as the single source of truth for the caret/selection position, a writable `position: Signal<number | undefined>` computed bound to `selection.start` (writes collapse the range), an `isUserSelecting: Signal<boolean>` for selection-in-progress state, and `isFullSelection: Signal<boolean>` derived from `selection` and the raw value length.
+`KeyboardController` internally composes three modules: input handling, block editing, and arrow navigation. `CaretModel` exposes a `selection: Signal<Range | undefined>` as the single source of truth for the caret/selection position, a writable `position: Signal<number | undefined>` computed bound to `selection.start` (writes collapse the range), an `isUserSelecting: Signal<boolean>` for selection-in-progress state, and `isAllSelected: Signal<boolean>` derived from `selection` and the raw value length.
 
 ## Lifecycle Timing
 
@@ -434,7 +434,7 @@ Caret responsibilities are split into a stateful feature and a stateless helper
 module:
 
 - `CaretModel` (feature) owns the reactive caret/selection state — `selection`,
-  `position`, `isUserSelecting`, and `isFullSelection` signals — plus document-level mouse and
+  `position`, `isUserSelecting`, and `isAllSelected` signals — plus document-level mouse and
   selectionchange listeners that keep the signals in sync with the browser
   selection. It depends on `DomController` for DOM placement
   (`dom.placeAt` / `dom.placeRange`) and never touches the DOM directly for

--- a/packages/website/src/content/docs/development/architecture.md
+++ b/packages/website/src/content/docs/development/architecture.md
@@ -316,7 +316,7 @@ class Store {
     // Features live directly on store, not nested under .feature
     readonly lifecycle: Lifecycle          // mounted, unmounted, rendered events
     readonly props:     PropsModel         // framework-provided configuration
-    readonly caret:     CaretModel         // range, position (computed), isSelecting
+    readonly caret:     CaretModel         // range, position (computed), isUserSelecting
     readonly mark:      MarkFeature        // mark slot resolution
     readonly slots:     SlotsFeature       // isBlock, isDraggable, slot component/props
     readonly value:     ValueModel         // current, replace()
@@ -378,7 +378,7 @@ Signal subscription order is significant: `ParseController` subscribes to `value
 | **DragController**            | Drag-and-drop reordering of blocks                       |
 | **ClipboardController**       | Clipboard copy/cut handling                              |
 
-`KeyboardController` internally composes three modules: input handling, block editing, and arrow navigation. `CaretModel` exposes a `range: Signal<Range | undefined>` as the single source of truth for the caret/selection position, a writable `position: Signal<number | undefined>` computed bound to `range.start` (writes collapse the range), and an `isSelecting: Signal<boolean>` for drag-selection state.
+`KeyboardController` internally composes three modules: input handling, block editing, and arrow navigation. `CaretModel` exposes a `range: Signal<Range | undefined>` as the single source of truth for the caret/selection position, a writable `position: Signal<number | undefined>` computed bound to `range.start` (writes collapse the range), and an `isUserSelecting: Signal<boolean>` for drag-selection state.
 
 ## Lifecycle Timing
 
@@ -434,7 +434,7 @@ Caret responsibilities are split into a stateful feature and a stateless helper
 module:
 
 - `CaretModel` (feature) owns the reactive caret/selection state — `range`,
-  `position`, and `isSelecting` signals — plus document-level mouse and
+  `position`, and `isUserSelecting` signals — plus document-level mouse and
   selectionchange listeners that keep the signals in sync with the browser
   selection. It depends on `DomController` for DOM placement
   (`dom.placeAt` / `dom.placeRange`) and never touches the DOM directly for

--- a/packages/website/src/content/docs/development/architecture.md
+++ b/packages/website/src/content/docs/development/architecture.md
@@ -87,7 +87,7 @@ Both framework adapters share the same component structure:
         ↓
 3. store.dom maps the DOM selection or input target range to a raw value range
         ↓
-4. KeyboardController writes store.caret.range({start, end}) with the desired post-edit position,
+4. KeyboardController writes store.caret.selection({start, end}) with the desired post-edit position,
    then calls store.value.replace() or store.value.current()
         ↓
 5. ValueModel updates uncontrolled state or notifies controlled parents
@@ -98,10 +98,10 @@ Both framework adapters share the same component structure:
         ↓
 8. React/Vue re-renders via the framework `useMarkput()` hook
         ↓
-9. DomController applies caret.range to the DOM after the adapter registers the new DOM
+9. DomController applies caret.selection to the DOM after the adapter registers the new DOM
 ```
 
-There is one serialized value edit path for user mutations: features describe the raw range and replacement text, optionally write `store.caret.range` to set the post-edit caret, then call `store.value.replace()` or `store.value.current()`. `DomController` owns DOM-to-raw boundary mapping and applies `caret.range` to the DOM after every render, while `ParseController` owns parser selection and string-to-token parsing.
+There is one serialized value edit path for user mutations: features describe the raw range and replacement text, optionally write `store.caret.selection` to set the post-edit caret, then call `store.value.replace()` or `store.value.current()`. `DomController` owns DOM-to-raw boundary mapping and applies `caret.selection` to the DOM after every render, while `ParseController` owns parser selection and string-to-token parsing.
 
 ### Trigger Flow (Overlay Opens)
 
@@ -463,7 +463,7 @@ const rect = caretDom.getRect()
 - text token roots are reconciled as editable text surfaces;
 - mark roots receive focusability state.
 
-It exposes raw boundary helpers used by keyboard, clipboard, overlay, block editing, drag, and mark commands. It also applies `caret.range` to the DOM after every render; ranges that cannot be placed are cleared and reported through DOM diagnostics.
+It exposes raw boundary helpers used by keyboard, clipboard, overlay, block editing, drag, and mark commands. It also applies `caret.selection` to the DOM after every render; ranges that cannot be placed are cleared and reported through DOM diagnostics.
 
 ## Framework Hooks
 

--- a/packages/website/src/content/docs/guides/keyboard-handling.md
+++ b/packages/website/src/content/docs/guides/keyboard-handling.md
@@ -11,8 +11,8 @@ Markput handles text input, deletion, paste, overlay insertion, block editing, a
 1. React/Vue render adapter-owned token shells and text surfaces.
 2. The adapter registers the root with `store.dom.container` and child structure through `store.dom.controlFor(path?)` (for non-editable controls inside a token) and `store.dom.childrenFor(ownerPath)` (for nested `__slot__` child sequence hosts).
 3. Keyboard handlers convert the browser selection to a raw serialized range through `store.dom.readRawSelection()` or `store.dom.rawPositionFromBoundary()`.
-4. Edits call `store.value.replace()` and optionally write `store.caret.range()` to set the post-edit caret.
-5. `DomController` applies `caret.range` to the DOM after the next render.
+4. Edits call `store.value.replace()` and optionally write `store.caret.selection()` to set the post-edit caret.
+5. `DomController` applies `caret.selection` to the DOM after the next render.
 
 Production code should not infer token identity from DOM child order or public data attributes.
 
@@ -22,7 +22,7 @@ Inline text input uses the current raw selection:
 
 ```ts
 store.value.replace(selection.range, text)
-store.caret.range({start: selection.range.start + text.length, end: selection.range.start + text.length})
+store.caret.selection({start: selection.range.start + text.length, end: selection.range.start + text.length})
 ```
 
 Controlled editors emit `onChange` first and update the accepted value after the matching prop echo.
@@ -59,7 +59,7 @@ The hook no longer exposes a DOM ref. Focus moves through registered token shell
 
 ## Overlay Triggers
 
-Overlay trigger probing uses the current raw caret position (`caret.range()`). During input, core probes the caret range which is updated synchronously with value edits.
+Overlay trigger probing uses the current raw caret position (`caret.selection()`). During input, core probes the caret range which is updated synchronously with value edits.
 
 ## Custom Keyboard Handlers
 


### PR DESCRIPTION
## Summary
- Add to `model()` primitive overload with optional fields and structural equality checks
- Refactor caret model: rename `range` → `selection`, `isSelecting` → `isUserSelecting`, `isFullSelection` → `isAllSelected`
- Make `isAllSelected` a computed signal derived from `ValueModel`
- Simplify `selectAll` method to set full selection range
- Update architecture docs to reflect new caret API surface
- Update all consumers (dom, drag, keyboard, overlay) for renamed APIs