### PR TITLE
refactor(edit): introduce EditController for centralized single-range edits

### DIFF
--- a/packages/core/src/features/clipboard/ClipboardController.ts
+++ b/packages/core/src/features/clipboard/ClipboardController.ts
@@ -1,12 +1,11 @@
 import type {Range} from '../../shared/editorContracts'
 import {listen} from '../../shared/signals/index.js'
-import type {CaretModel} from '../caret/CaretModel'
 import type {DomController} from '../dom/DomController'
+import type {EditController} from '../edit'
 import type {Lifecycle} from '../lifecycle/Lifecycle'
 import {toString} from '../parsing'
 import type {Token} from '../parsing'
 import type {ParseController} from '../parsing/ParseController'
-import type {ValueModel} from '../value/ValueModel'
 import {MARKPUT_MIME} from './pasteMarkup'
 
 function htmlFromRange(range: globalThis.Range): string {
@@ -38,10 +37,9 @@ function trimTokensForRawRange(tokens: readonly Token[], range: Range): Token[] 
 export class ClipboardController {
 	constructor(
 		private readonly lifecycle: Lifecycle,
-		private readonly value: ValueModel,
+		private readonly edit: EditController,
 		private readonly dom: DomController,
-		private readonly parsing: ParseController,
-		private readonly caret: CaretModel
+		private readonly parsing: ParseController
 	) {
 		lifecycle.onMounted(() => {
 			// The container must be registered before mounted() fires (adapter
@@ -56,8 +54,7 @@ export class ClipboardController {
 				if (!this.#handleCopy(e)) return
 				const raw = dom.readRawSelection()
 				if (!raw.ok || raw.value.range.start === raw.value.range.end) return
-				caret.position(raw.value.range.start)
-				value.replace(raw.value.range, '')
+				edit.replace(raw.value.range, '')
 			})
 		})
 	}

--- a/packages/core/src/features/edit/EditController.spec.ts
+++ b/packages/core/src/features/edit/EditController.spec.ts
@@ -1,0 +1,74 @@
+import {describe, it, expect, vi} from 'vitest'
+
+import {Store} from '../../store/Store'
+
+describe('EditController', () => {
+	it('exposes replace on the store', () => {
+		const store = new Store()
+
+		expect(typeof store.edit.replace).toBe('function')
+	})
+
+	it('replaces value and places caret after replacement', () => {
+		const store = new Store()
+		store.props.set({defaultValue: 'hello world'})
+		store.lifecycle.mounted()
+
+		store.edit.replace({start: 6, end: 11}, 'markput')
+
+		expect(store.value.current()).toBe('hello markput')
+		expect(store.caret.selection()).toEqual({start: 13, end: 13})
+	})
+
+	it('places caret at range start when deleting', () => {
+		const store = new Store()
+		store.props.set({defaultValue: 'hello world'})
+		store.lifecycle.mounted()
+
+		store.edit.replace({start: 5, end: 11}, '')
+
+		expect(store.value.current()).toBe('hello')
+		expect(store.caret.selection()).toEqual({start: 5, end: 5})
+	})
+
+	it('does not move caret or change value for invalid ranges', () => {
+		const store = new Store()
+		const onChange = vi.fn()
+		store.props.set({defaultValue: 'hello', onChange})
+		store.lifecycle.mounted()
+		store.caret.position(2)
+
+		store.edit.replace({start: 4, end: 2}, 'x')
+
+		expect(onChange).not.toHaveBeenCalled()
+		expect(store.value.current()).toBe('hello')
+		expect(store.caret.selection()).toEqual({start: 2, end: 2})
+	})
+
+	it('does not move caret or change value when readOnly', () => {
+		const store = new Store()
+		const onChange = vi.fn()
+		store.props.set({defaultValue: 'hello', readOnly: true, onChange})
+		store.lifecycle.mounted()
+		store.caret.position(1)
+
+		store.edit.replace({start: 1, end: 4}, 'i')
+
+		expect(onChange).not.toHaveBeenCalled()
+		expect(store.value.current()).toBe('hello')
+		expect(store.caret.selection()).toEqual({start: 1, end: 1})
+	})
+
+	it('calls onChange and records caret intent in controlled mode', () => {
+		const store = new Store()
+		const onChange = vi.fn()
+		store.props.set({value: 'hello', onChange})
+		store.lifecycle.mounted()
+
+		store.edit.replace({start: 0, end: 5}, 'world')
+
+		expect(onChange).toHaveBeenCalledWith('world')
+		expect(store.value.current()).toBe('hello')
+		expect(store.caret.selection()).toEqual({start: 5, end: 5})
+	})
+})

--- a/packages/core/src/features/edit/EditController.ts
+++ b/packages/core/src/features/edit/EditController.ts
@@ -1,0 +1,31 @@
+import type {Range} from '../../shared/editorContracts'
+import {replaceInString} from '../../shared/utils'
+import type {CaretModel} from '../caret/CaretModel'
+import type {PropsModel} from '../props/PropsModel'
+import type {ValueModel} from '../value'
+
+/**
+ * Single write path for text edits — centralizes read-only gating and caret
+ * placement so callers (clipboard, keyboard, overlay) don't reimplement them.
+ */
+export class EditController {
+	constructor(
+		private readonly props: PropsModel,
+		private readonly value: ValueModel,
+		private readonly caret: CaretModel
+	) {}
+
+	/**
+	 * Replaces `range` with `replacement` and collapses the caret to the end
+	 * of the inserted text. Caret is set before {@link ValueModel.replace} so
+	 * subscribers observe a consistent value/selection pair on the same tick.
+	 */
+	replace(range: Range, replacement: string): void {
+		if (this.props.readOnly()) return
+		const next = replaceInString(this.value.current(), range, replacement)
+		if (next === undefined) return
+
+		this.caret.position(range.start + replacement.length)
+		this.value.replace(range, replacement)
+	}
+}

--- a/packages/core/src/features/edit/EditController.ts
+++ b/packages/core/src/features/edit/EditController.ts
@@ -1,31 +1,23 @@
 import type {Range} from '../../shared/editorContracts'
-import {replaceInString} from '../../shared/utils'
+import {batch} from '../../shared/signals'
 import type {CaretModel} from '../caret/CaretModel'
-import type {PropsModel} from '../props/PropsModel'
 import type {ValueModel} from '../value'
 
 /**
- * Single write path for text edits — centralizes read-only gating and caret
- * placement so callers (clipboard, keyboard, overlay) don't reimplement them.
+ * Single write path for text edits — delegates gating to {@link ValueModel.replace}
+ * and only moves the caret when the edit is accepted. Wrapped in {@link batch}
+ * so subscribers observe a consistent value/selection pair on one tick.
  */
 export class EditController {
 	constructor(
-		private readonly props: PropsModel,
 		private readonly value: ValueModel,
 		private readonly caret: CaretModel
 	) {}
 
-	/**
-	 * Replaces `range` with `replacement` and collapses the caret to the end
-	 * of the inserted text. Caret is set before {@link ValueModel.replace} so
-	 * subscribers observe a consistent value/selection pair on the same tick.
-	 */
 	replace(range: Range, replacement: string): void {
-		if (this.props.readOnly()) return
-		const next = replaceInString(this.value.current(), range, replacement)
-		if (next === undefined) return
-
-		this.caret.position(range.start + replacement.length)
-		this.value.replace(range, replacement)
+		batch(() => {
+			if (!this.value.replace(range, replacement)) return
+			this.caret.position(range.start + replacement.length)
+		})
 	}
 }

--- a/packages/core/src/features/edit/index.ts
+++ b/packages/core/src/features/edit/index.ts
@@ -1,0 +1,1 @@
+export {EditController} from './EditController'

--- a/packages/core/src/features/keyboard/KeyboardController.ts
+++ b/packages/core/src/features/keyboard/KeyboardController.ts
@@ -1,5 +1,6 @@
 import type {CaretModel} from '../caret/CaretModel'
 import type {DomController} from '../dom/DomController'
+import type {EditController} from '../edit'
 import type {Lifecycle} from '../lifecycle/Lifecycle'
 import type {ParseController} from '../parsing/ParseController'
 import type {PropsModel} from '../props/PropsModel'
@@ -15,11 +16,12 @@ export class KeyboardController {
 		dom: DomController,
 		value: ValueModel,
 		caret: CaretModel,
+		edit: EditController,
 		slots: SlotsFeature,
 		parsing: ParseController,
 		props: PropsModel
 	) {
-		const ctx = {dom, value, caret, slots, parsing, props}
+		const ctx = {dom, value, caret, edit, slots, parsing, props}
 		lifecycle.onMounted(() => {
 			enableInput(ctx)
 			enableBlockEdit(ctx)

--- a/packages/core/src/features/keyboard/blockEdit.ts
+++ b/packages/core/src/features/keyboard/blockEdit.ts
@@ -4,7 +4,7 @@ import type {BoundaryPositionResult, Range, RawSelectionResult} from '../../shar
 import {listen} from '../../shared/signals/index.js'
 import type {Store} from '../../store/Store'
 
-type KbCtx = Pick<Store, 'dom' | 'value' | 'caret' | 'slots' | 'parsing' | 'props'>
+type KbCtx = Pick<Store, 'dom' | 'value' | 'caret' | 'edit' | 'slots' | 'parsing' | 'props'>
 import * as caretDom from '../caret/caretDom'
 import {consumeMarkupPaste} from '../clipboard'
 import {addDragRow, getMergeDragRowJoinPos, mergeDragRows, canMergeRows} from '../drag/operations'
@@ -189,9 +189,7 @@ function handleEnter(store: KbCtx, event: KeyboardEvent) {
 
 	const raw = store.dom.readRawSelection()
 	const absolutePos = raw.ok ? raw.value.range.start : token.position.end
-	const pos = absolutePos + newRowContent.length
-	store.caret.position(pos)
-	store.value.replace({start: absolutePos, end: absolutePos}, newRowContent)
+	store.edit.replace({start: absolutePos, end: absolutePos}, newRowContent)
 }
 
 function focusRow(store: KbCtx, token: Token, row: HTMLElement, caret: 'start' | 'end'): void {
@@ -325,9 +323,7 @@ function replaceBlockRange(store: KbCtx, event: InputEvent, replacement: string)
 	if (!range) return
 
 	event.preventDefault()
-	const pos = range.start + replacement.length
-	store.caret.position(pos)
-	store.value.replace(range, replacement)
+	store.edit.replace(range, replacement)
 }
 
 function rawRangeFromInputEvent(store: KbCtx, event: InputEvent): RawSelectionResult {

--- a/packages/core/src/features/keyboard/input.spec.ts
+++ b/packages/core/src/features/keyboard/input.spec.ts
@@ -88,7 +88,7 @@ describe('replaceAllContentWith()', () => {
 describe('handleBeforeInput()', () => {
 	it('inserts text through replaceRange using target ranges', () => {
 		const {store, container, textNode} = mountStructuralInline()
-		const replaceRange = vi.spyOn(store.value, 'replace')
+		const replaceRange = vi.spyOn(store.edit, 'replace')
 		const range = document.createRange()
 		range.setStart(textNode, 1)
 		range.setEnd(textNode, 1)
@@ -159,6 +159,7 @@ describe('composition input', () => {
 		container.dispatchEvent(compositionEnd)
 
 		expect(store.value.current()).toBe('aXb')
+		expect(store.caret.selection()).toEqual({start: 2, end: 2})
 		container.remove()
 	})
 })

--- a/packages/core/src/features/keyboard/input.ts
+++ b/packages/core/src/features/keyboard/input.ts
@@ -3,7 +3,7 @@ import type {BoundaryPositionResult, Range, RawSelectionResult} from '../../shar
 import {listen} from '../../shared/signals/index.js'
 import type {Store} from '../../store/Store'
 
-type KbCtx = Pick<Store, 'dom' | 'value' | 'caret' | 'slots' | 'parsing'>
+type KbCtx = Pick<Store, 'dom' | 'value' | 'caret' | 'edit' | 'slots' | 'parsing'>
 import {captureMarkupPaste, consumeMarkupPaste} from '../clipboard'
 import type {Token} from '../parsing'
 
@@ -45,9 +45,7 @@ export function enableInput(store: KbCtx): void {
 		if (store.slots.isBlock()) return
 		if (!range) return
 		const data = e.data
-		const pos = range.start + data.length
-		store.caret.position(pos)
-		store.value.replace(range, data)
+		store.edit.replace(range, data)
 	})
 
 	listen(
@@ -82,8 +80,7 @@ function handleDeleteKey(store: KbCtx, event: KeyboardEvent): void {
 	if (!range) return
 
 	event.preventDefault()
-	store.caret.position(range.start)
-	store.value.replace(range, '')
+	store.edit.replace(range, '')
 }
 
 export function handleBeforeInput(store: KbCtx, event: InputEvent): void {
@@ -110,9 +107,7 @@ export function handleBeforeInput(store: KbCtx, event: InputEvent): void {
 	if (!range) return
 
 	event.preventDefault()
-	const pos = range.start + replacement.length
-	store.caret.position(pos)
-	store.value.replace(range, replacement)
+	store.edit.replace(range, replacement)
 }
 
 export function applySpanInput(focus: SpanInputTarget, event: InputEvent): boolean {

--- a/packages/core/src/features/overlay/OverlayController.spec.ts
+++ b/packages/core/src/features/overlay/OverlayController.spec.ts
@@ -120,8 +120,8 @@ describe('OverlayController', () => {
 	})
 
 	describe('select()', () => {
-		it('replaces the trigger range through the value pipeline', () => {
-			const replaceRange = vi.spyOn(store.value, 'replace')
+		it('delegates trigger replacement to the edit coordinator', () => {
+			const replaceRange = vi.spyOn(store.edit, 'replace')
 			const mark = {
 				type: 'text' as const,
 				content: 'world',
@@ -140,7 +140,6 @@ describe('OverlayController', () => {
 			store.overlay.select({mark, match})
 
 			expect(replaceRange).toHaveBeenCalledWith({start: 6, end: 9}, '@[world]')
-			expect(store.caret.selection()).toEqual({start: 14, end: 14})
 			expect(store.overlay.match()).toBeUndefined()
 			store.props.set({options: []})
 		})

--- a/packages/core/src/features/overlay/OverlayController.ts
+++ b/packages/core/src/features/overlay/OverlayController.ts
@@ -7,6 +7,7 @@ import {TriggerFinder} from '../caret'
 import * as caretDom from '../caret/caretDom'
 import type {CaretModel} from '../caret/CaretModel'
 import type {DomController} from '../dom/DomController'
+import type {EditController} from '../edit'
 import type {Lifecycle} from '../lifecycle/Lifecycle'
 import type {Token} from '../parsing'
 import {annotate} from '../parsing'
@@ -43,6 +44,7 @@ export class OverlayController {
 		private readonly value: ValueModel,
 		private readonly dom: DomController,
 		private readonly caret: CaretModel,
+		private readonly edit: EditController,
 		private readonly parsing: ParseController
 	) {
 		const hasOverlayTrigger = computed(() => this.props.options().some(opt => opt.overlay?.trigger != null))
@@ -119,9 +121,7 @@ export class OverlayController {
 										value: mark.content,
 									})
 
-						const pos = range.start + annotation.length
-						this.caret.position(pos)
-						this.value.replace(range, annotation)
+						this.edit.replace(range, annotation)
 						this.match(undefined)
 					})
 				})

--- a/packages/core/src/features/value/ValueModel.spec.ts
+++ b/packages/core/src/features/value/ValueModel.spec.ts
@@ -1,5 +1,6 @@
 import {describe, it, expect, vi} from 'vitest'
 
+import {replaceInString} from '../../shared/utils'
 import {Store} from '../../store/Store'
 
 describe('ValueModel', () => {
@@ -116,6 +117,16 @@ describe('ValueModel', () => {
 
 			store.props.set({value: 'world'})
 			expect(store.value.current()).toBe('world')
+		})
+
+		it('returns replaced string for a valid range', () => {
+			expect(replaceInString('hello world', {start: 6, end: 11}, 'markput')).toBe('hello markput')
+		})
+
+		it('returns undefined for invalid replacement ranges', () => {
+			expect(replaceInString('hello', {start: -1, end: 1}, 'x')).toBeUndefined()
+			expect(replaceInString('hello', {start: 4, end: 2}, 'x')).toBeUndefined()
+			expect(replaceInString('hello', {start: 0, end: 6}, 'x')).toBeUndefined()
 		})
 	})
 })

--- a/packages/core/src/features/value/ValueModel.ts
+++ b/packages/core/src/features/value/ValueModel.ts
@@ -19,9 +19,17 @@ export class ValueModel {
 
 	constructor(private readonly props: PropsModel) {}
 
-	replace(range: Range, replacement: string): void {
+	/**
+	 * Attempts to replace `range` with `replacement`. Returns `true` when the
+	 * edit was accepted (range valid and not read-only), `false` otherwise.
+	 * Callers use the return value to gate downstream side effects such as
+	 * caret placement.
+	 */
+	replace(range: Range, replacement: string): boolean {
+		if (this.props.readOnly()) return false
 		const next = replaceInString(this.current(), range, replacement)
-		if (next === undefined) return
+		if (next === undefined) return false
 		this.current(next)
+		return true
 	}
 }

--- a/packages/core/src/features/value/ValueModel.ts
+++ b/packages/core/src/features/value/ValueModel.ts
@@ -1,5 +1,6 @@
 import type {Range} from '../../shared/editorContracts'
 import {computed, model} from '../../shared/signals/index.js'
+import {replaceInString} from '../../shared/utils'
 import type {PropsModel} from '../props/PropsModel'
 
 export class ValueModel {
@@ -19,9 +20,8 @@ export class ValueModel {
 	constructor(private readonly props: PropsModel) {}
 
 	replace(range: Range, replacement: string): void {
-		const current = this.current()
-		if (range.start < 0 || range.end < range.start || range.end > current.length) return
-		const next = current.slice(0, range.start) + replacement + current.slice(range.end)
+		const next = replaceInString(this.current(), range, replacement)
+		if (next === undefined) return
 		this.current(next)
 	}
 }

--- a/packages/core/src/shared/utils/index.ts
+++ b/packages/core/src/shared/utils/index.ts
@@ -1,3 +1,4 @@
 export {shallow} from './shallow'
 export {cx} from './cx'
 export {merge} from './merge'
+export {replaceInString} from './replaceInString'

--- a/packages/core/src/shared/utils/replaceInString.ts
+++ b/packages/core/src/shared/utils/replaceInString.ts
@@ -1,0 +1,6 @@
+import type {Range} from '../editorContracts'
+
+export function replaceInString(current: string, range: Range, replacement: string): string | undefined {
+	if (range.start < 0 || range.end < range.start || range.end > current.length) return undefined
+	return current.slice(0, range.start) + replacement + current.slice(range.end)
+}

--- a/packages/core/src/store/Store.ts
+++ b/packages/core/src/store/Store.ts
@@ -2,6 +2,7 @@ import {CaretModel} from '../features/caret'
 import {ClipboardController} from '../features/clipboard'
 import {DomController} from '../features/dom'
 import {DragController} from '../features/drag'
+import {EditController} from '../features/edit'
 import {KeyboardController} from '../features/keyboard'
 import {Lifecycle} from '../features/lifecycle'
 import {MarkFeature} from '../features/mark'
@@ -32,19 +33,29 @@ export class Store {
 	readonly dom = new DomController(this.lifecycle, this.props, this.parsing, this.value)
 
 	readonly caret = new CaretModel(this.lifecycle, this.dom, this.value)
+	readonly edit = new EditController(this.props, this.value, this.caret)
 
-	readonly overlay = new OverlayController(this.lifecycle, this.props, this.value, this.dom, this.caret, this.parsing)
+	readonly overlay = new OverlayController(
+		this.lifecycle,
+		this.props,
+		this.value,
+		this.dom,
+		this.caret,
+		this.edit,
+		this.parsing
+	)
 	readonly keyboard = new KeyboardController(
 		this.lifecycle,
 		this.dom,
 		this.value,
 		this.caret,
+		this.edit,
 		this.slots,
 		this.parsing,
 		this.props
 	)
 	readonly drag = new DragController(this.props, this.value, this.parsing, this.caret)
-	readonly clipboard = new ClipboardController(this.lifecycle, this.value, this.dom, this.parsing, this.caret)
+	readonly clipboard = new ClipboardController(this.lifecycle, this.edit, this.dom, this.parsing)
 
 	readonly handler = new MarkputHandler(this.dom, this.overlay, this.parsing)
 }

--- a/packages/core/src/store/Store.ts
+++ b/packages/core/src/store/Store.ts
@@ -33,7 +33,7 @@ export class Store {
 	readonly dom = new DomController(this.lifecycle, this.props, this.parsing, this.value)
 
 	readonly caret = new CaretModel(this.lifecycle, this.dom, this.value)
-	readonly edit = new EditController(this.props, this.value, this.caret)
+	readonly edit = new EditController(this.value, this.caret)
 
 	readonly overlay = new OverlayController(
 		this.lifecycle,

--- a/packages/website/src/content/docs/development/architecture.md
+++ b/packages/website/src/content/docs/development/architecture.md
@@ -87,8 +87,7 @@ Both framework adapters share the same component structure:
         ↓
 3. store.dom maps the DOM selection or input target range to a raw value range
         ↓
-4. KeyboardController writes store.caret.selection({start, end}) with the desired post-edit position,
-   then calls store.value.replace() or store.value.current()
+4. KeyboardController calls store.edit.replace() for single-range user edits, or writes store.caret.selection({start, end}) and store.value.current() for whole-value edits that are not expressed as one replacement range
         ↓
 5. ValueModel updates uncontrolled state or notifies controlled parents
         ↓
@@ -101,7 +100,7 @@ Both framework adapters share the same component structure:
 9. DomController applies caret.selection to the DOM after the adapter registers the new DOM
 ```
 
-There is one serialized value edit path for user mutations: features describe the raw range and replacement text, optionally write `store.caret.selection` to set the post-edit caret, then call `store.value.replace()` or `store.value.current()`. `DomController` owns DOM-to-raw boundary mapping and applies `caret.selection` to the DOM after every render, while `ParseController` owns parser selection and string-to-token parsing.
+Single-range user mutations go through `store.edit.replace()`: features describe the raw range and replacement text, and the edit coordinator records the default post-edit caret before delegating to `store.value.replace()`. Lower-level raw value mutations still go through `store.value.replace()` or `store.value.current()`. `DomController` owns DOM-to-raw boundary mapping and applies `caret.selection` to the DOM after every render, while `ParseController` owns parser selection and string-to-token parsing.
 
 ### Trigger Flow (Overlay Opens)
 
@@ -320,6 +319,7 @@ class Store {
     readonly mark:      MarkFeature        // mark slot resolution
     readonly slots:     SlotsFeature       // isBlock, isDraggable, slot component/props
     readonly value:     ValueModel         // current, replace()
+    readonly edit:      EditController     // replace() — single-range user edit + caret intent
     readonly parsing:   ParseController    // tokens, parser, token index
     readonly dom:       DomController      // DOM refs, raw mapping, range placement
     readonly overlay:   OverlayController  // match, element, slot, select, close
@@ -360,14 +360,15 @@ const tokens = useMarkput(s => s.parsing.tokens())
 
 ## Features
 
-11 features, each declaring its dependencies as positional constructor parameters with concrete feature types. The dependency graph is acyclic — features can only depend on features constructed above them in `Store`. They never import each other directly; all cross-feature access goes through the injected constructor parameters. `MarkputHandler` and `KeyboardController` behavior modules retain the full `Store` as an adapter boundary.
+12 features, each declaring its dependencies as positional constructor parameters with concrete feature types. The dependency graph is acyclic — features can only depend on features constructed above them in `Store`. They never import each other directly; all cross-feature access goes through the injected constructor parameters. `MarkputHandler` and `KeyboardController` behavior modules retain the full `Store` as an adapter boundary.
 
 Signal subscription order is significant: `ParseController` subscribes to `value.current` inside its `onMounted` hook before any other consumer registers a watcher in `onMounted`. This guarantees that when downstream listeners observe a `value.current` change, `parsing.tokens()` already reflects the new value.
 
 | Feature                       | Responsibility                                           |
 | ----------------------------- | -------------------------------------------------------- |
 | **Lifecycle**                 | Mount/unmount/render lifecycle events                     |
-| **ValueModel**                | Accepted serialized value state, edit commands           |
+| **ValueModel**                | Accepted serialized value state, raw range replacement   |
+| **EditController**            | Single-range user edit coordination (value + caret intent) |
 | **ParseController**           | Token parsing, parser selection, reparse event            |
 | **MarkFeature**               | Mark slot resolution                                      |
 | **OverlayController**         | Overlay trigger detection, position, open/close           |


### PR DESCRIPTION
## Summary

- Introduces `EditController` as the single write path for single-range user text edits, combining `value.replace()` and `caret.position()` into one `batch()`-wrapped call
- All existing callers (keyboard input, block edit, overlay select, clipboard cut) now use `store.edit.replace()` instead of separate `value.replace()` + `caret.position()` pairs
- `ValueModel.replace()` now returns a boolean success flag and gates on `readOnly` — downstream side effects use the return value to decide whether to proceed
- Extracts `replaceInString` utility with proper range validation (negative start, inverted range, out-of-bounds)
- Updates architecture docs to reflect the new 12th feature

## Why

Previously every caller manually paired `value.replace()` with `caret.position()`, leading to inconsistent caret placement and potential race conditions where subscribers saw intermediate value/selection states. Centralizing through `EditController` ensures atomic writes and a single place for correctness.