### PR TITLE
refactor(core): derive tokens from computed, add watch immediate option

### DIFF
--- a/packages/core/src/features/block/BlockController.spec.ts
+++ b/packages/core/src/features/block/BlockController.spec.ts
@@ -1,11 +1,6 @@
 import {describe, it, expect, vi, beforeEach} from 'vitest'
 
 import {Store} from '../../store/Store'
-import type {TextToken} from '../parsing'
-
-function text(content: string, start: number): TextToken {
-	return {type: 'text', content, position: {start, end: start + content.length}}
-}
 
 describe('BlockController', () => {
 	let store: Store
@@ -40,10 +35,14 @@ describe('BlockController', () => {
 	})
 
 	it('commits drag edits through current() and writes caret.selection', () => {
-		store.props.set({layout: 'block', draggable: true})
+		store.props.set({
+			layout: 'block',
+			draggable: true,
+			Mark: () => null,
+			options: [{markup: '__slot__\n\n'}],
+		})
 		store.lifecycle.mounted()
 		store.value.current('alpha\n\nbeta\n\n')
-		store.tokens.current([text('alpha', 0), text('beta', 7)])
 		const currentSpy = vi.spyOn(store.value, 'current')
 
 		store.block.action({type: 'delete', index: 0})

--- a/packages/core/src/features/dom/DomIndexer.ts
+++ b/packages/core/src/features/dom/DomIndexer.ts
@@ -58,9 +58,10 @@ export class DomIndexer {
 		private readonly tokens: TokenModel
 	) {
 		lifecycle.onMounted(() => {
-			watch(lifecycle.rendered, () => {
-				this.#handleRendered()
-			})
+			// Container mounts before MarkedInput, so the first lifecycle.rendered()
+			// is emitted before this watch subscribes. Run the initial commit here
+			// instead of relying on a follow-up rendered event.
+			watch(lifecycle.rendered, () => this.#handleRendered(), {immediate: true})
 			watch(props.readOnly, () => this.reconcile())
 			watch(host.isUserSelecting, () => this.reconcile())
 		})

--- a/packages/core/src/features/dom/DomIndexer.ts
+++ b/packages/core/src/features/dom/DomIndexer.ts
@@ -1,5 +1,5 @@
 import type {NodeLocationResult, TokenAddress, TokenPath} from '../../shared/editorContracts'
-import {batch, computed, signal, watch} from '../../shared/signals/index.js'
+import {batch, signal, watch} from '../../shared/signals/index.js'
 import type {Signal} from '../../shared/signals/index.js'
 import type {Token} from '../parsing'
 import {pathEquals, pathKey} from '../parsing/tokenIndex'
@@ -61,10 +61,7 @@ export class DomIndexer {
 			watch(lifecycle.rendered, () => {
 				this.#handleRendered()
 			})
-			watch(
-				computed(() => props.readOnly()),
-				() => this.reconcile()
-			)
+			watch(props.readOnly, () => this.reconcile())
 			watch(host.isUserSelecting, () => this.reconcile())
 		})
 	}

--- a/packages/core/src/features/parsing/TokenModel.ts
+++ b/packages/core/src/features/parsing/TokenModel.ts
@@ -19,10 +19,12 @@ export class TokenModel {
 	readonly #parser: Computed<Parser | undefined> = computed(() => {
 		const Mark = this.props.Mark()
 		const options = this.props.options()
+		// TODO maybe in the future it place in one again
 		const hasMark = Mark != null || options.some(opt => 'Mark' in opt && opt.Mark != null)
 		if (!hasMark) return
 		const markups = options.map(opt => opt.markup)
 		if (!markups.some(Boolean)) return
+		//TODO this.slots.isBlock() smelling here
 		return new Parser(markups, this.slots.isBlock() ? {skipEmptyText: true} : undefined)
 	})
 

--- a/packages/core/src/features/parsing/TokenModel.ts
+++ b/packages/core/src/features/parsing/TokenModel.ts
@@ -1,7 +1,6 @@
-import {signal, computed, watch} from '../../shared/signals/index.js'
-import type {Computed, Signal} from '../../shared/signals/index.js'
+import {computed} from '../../shared/signals/index.js'
+import type {Computed} from '../../shared/signals/index.js'
 import type {SlotsFeature} from '../slots/SlotsFeature'
-import type {Lifecycle} from '../state/Lifecycle'
 import type {PropsModel} from '../state/PropsModel'
 import type {ValueModel} from '../state/ValueModel'
 import {Parser} from './parser/Parser'
@@ -10,7 +9,11 @@ import {createTextToken} from './parser/utils/createTextToken'
 import {createTokenIndex, type TokenIndex} from './tokenIndex'
 
 export class TokenModel {
-	readonly current: Signal<Token[]> = signal<Token[]>([])
+	readonly current: Computed<Token[]> = computed(() => {
+		const parser = this.#parser()
+		const value = this.value.current()
+		return parser ? parser.parse(value) : [createTextToken(value)]
+	})
 	readonly index: Computed<TokenIndex> = computed(() => createTokenIndex(this.current()))
 
 	readonly #parser: Computed<Parser | undefined> = computed(() => {
@@ -24,23 +27,8 @@ export class TokenModel {
 	})
 
 	constructor(
-		lifecycle: Lifecycle,
 		private readonly value: ValueModel,
 		private readonly props: PropsModel,
 		private readonly slots: SlotsFeature
-	) {
-		lifecycle.onMounted(() => {
-			watch(
-				() => [this.value.current(), this.#parser()],
-				() => this.#reparse(),
-				{immediate: true}
-			)
-		})
-	}
-
-	#reparse(): void {
-		const parser = this.#parser()
-		const value = this.value.current()
-		this.current(parser ? parser.parse(value) : [createTextToken(value)])
-	}
+	) {}
 }

--- a/packages/core/src/features/parsing/TokenModel.ts
+++ b/packages/core/src/features/parsing/TokenModel.ts
@@ -30,9 +30,11 @@ export class TokenModel {
 		private readonly slots: SlotsFeature
 	) {
 		lifecycle.onMounted(() => {
-			this.#reparse()
-			watch(this.value.current, () => this.#reparse())
-			watch(this.#parser, () => this.#reparse())
+			watch(
+				() => [this.value.current(), this.#parser()],
+				() => this.#reparse(),
+				{immediate: true}
+			)
 		})
 	}
 

--- a/packages/core/src/shared/signals/README.md
+++ b/packages/core/src/shared/signals/README.md
@@ -206,9 +206,9 @@ stop()
 count(2) // no output — both effects cleaned up
 ```
 
-### `watch(source, callback)`
+### `watch(source, callback, options?)`
 
-Watches a reactive source for changes. Skips the first run (unlike `effect`), and provides the previous value to the callback.
+Watches a reactive source for changes. Skips the first run by default (unlike `effect`); pass `{immediate: true}` to fire on the first run as well. Provides the previous value to the callback.
 
 ```ts
 const count = signal(0)
@@ -219,6 +219,23 @@ const dispose = watch(count, (newVal, oldVal) => {
 
 count(1) // Console: 0 -> 1
 count(5) // Console: 1 -> 5
+```
+
+To run the callback immediately (not just on changes), pass `{immediate: true}`. The first call receives `(currentValue, undefined)`:
+
+```ts
+const count = signal(5)
+
+watch(
+    count,
+    (newVal, oldVal) => {
+        console.log(`${oldVal} -> ${newVal}`)
+    },
+    {immediate: true}
+)
+// Console: undefined -> 5
+count(10)
+// Console: 5 -> 10
 ```
 
 Accepts three source types:

--- a/packages/core/src/shared/signals/signal.ts
+++ b/packages/core/src/shared/signals/signal.ts
@@ -520,21 +520,41 @@ export function effectScope(fn: () => void): () => void {
 // watch() — skip-first-run helper for event subscriptions
 // ---------------------------------------------------------------------------
 
-export function watch<T>(dep: Signal<T>, fn: (newValue: T, oldValue: T | undefined) => void): () => void
-export function watch<T>(dep: Event<T>, fn: (newValue: T, oldValue: T | undefined) => void): () => void
-export function watch<T>(dep: () => T, fn: (newValue: T, oldValue: T | undefined) => void): () => void
+interface WatchOptions {
+	immediate?: boolean
+}
+
+export function watch<T>(
+	dep: Signal<T>,
+	fn: (newValue: T, oldValue: T | undefined) => void,
+	opts?: WatchOptions
+): () => void
+export function watch<T>(
+	dep: Event<T>,
+	fn: (newValue: T, oldValue: T | undefined) => void,
+	opts?: WatchOptions
+): () => void
+export function watch<T>(
+	dep: () => T,
+	fn: (newValue: T, oldValue: T | undefined) => void,
+	opts?: WatchOptions
+): () => void
 export function watch<T>(
 	dep: Signal<T> | Event<T> | (() => T),
-	fn: (newValue: T, oldValue: T | undefined) => void
+	fn: (newValue: T, oldValue: T | undefined) => void,
+	opts?: WatchOptions
 ): () => void {
 	let initialized = false
 	let oldValue: T | undefined
 	return effect(() => {
-		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Event<T> returns T | undefined before first emit, but watch skips the first run so callback always receives T
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Event<T> returns T | undefined before first emit; callers using watch() with Event must accept that the first immediate call may pass undefined when the event has not yet emitted
 		const newValue = ('read' in dep ? dep.read() : dep()) as T
 		if (!initialized) {
 			initialized = true
 			oldValue = newValue
+			if (opts?.immediate) {
+				untracked(() => fn(newValue, undefined))
+			}
 			return
 		}
 		const prev = oldValue

--- a/packages/core/src/shared/signals/signals.spec.ts
+++ b/packages/core/src/shared/signals/signals.spec.ts
@@ -631,6 +631,45 @@ describe('watch()', () => {
 
 		expect(seen).toEqual(['b', 'c'])
 	})
+
+	it('fires callback immediately when immediate: true', () => {
+		const s = signal(0)
+		const fn = vi.fn()
+
+		const dispose = watch(s, fn, {immediate: true})
+		disposers.push(dispose)
+
+		expect(fn).toHaveBeenCalledTimes(1)
+		expect(fn).toHaveBeenCalledWith(0, undefined)
+
+		s(1)
+		expect(fn).toHaveBeenCalledTimes(2)
+		expect(fn).toHaveBeenCalledWith(1, 0)
+	})
+
+	it('disposer stops future calls with immediate: true', () => {
+		const s = signal(0)
+		const fn = vi.fn()
+
+		const dispose = watch(s, fn, {immediate: true})
+		disposers.push(dispose)
+
+		expect(fn).toHaveBeenCalledTimes(1)
+
+		dispose()
+		s(1)
+		expect(fn).toHaveBeenCalledTimes(1)
+	})
+
+	it('defaults to skip-first-run when immediate is omitted', () => {
+		const s = signal(0)
+		const fn = vi.fn()
+
+		const dispose = watch(s, fn)
+		disposers.push(dispose)
+
+		expect(fn).not.toHaveBeenCalled()
+	})
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/store/Store.spec.ts
+++ b/packages/core/src/store/Store.spec.ts
@@ -7,7 +7,7 @@ import {Store} from './Store'
 describe('Store', () => {
 	it('construct with no arguments', () => {
 		const store = new Store()
-		expect(store.tokens.current()).toEqual([])
+		expect(store.tokens.current()).toEqual([{type: 'text', content: '', position: {start: 0, end: 0}}])
 		expect(store.props.readOnly()).toBe(false)
 	})
 
@@ -68,7 +68,7 @@ describe('Store', () => {
 			const store = new Store()
 			store.dom.isUserSelecting(true)
 			expect(store.dom.isUserSelecting()).toBe(true)
-			expect(store.tokens.current()).toEqual([])
+			expect(store.tokens.current()).toEqual([{type: 'text', content: '', position: {start: 0, end: 0}}])
 		})
 
 		it('batch multiple internal writes so effects fire once', () => {
@@ -80,9 +80,8 @@ describe('Store', () => {
 				effectSpy()
 			})
 			effectSpy.mockClear()
-			const token = {type: 'text' as const, content: 'a', position: {start: 0, end: 1}}
 			batch(() => {
-				store.tokens.current([token])
+				store.value.current('a')
 				store.dom.isUserSelecting(true)
 			})
 			expect(effectSpy).toHaveBeenCalledTimes(1)
@@ -112,11 +111,13 @@ describe('Store', () => {
 			// Should not throw
 		})
 
-		it('does not modify state when props.set is called', () => {
+		it('reflects controlled value via tokens without changing internal state', () => {
 			const store = new Store()
-			const tokensBefore = store.tokens.current()
-			store.props.set({value: 'test'})
-			expect(store.tokens.current()).toBe(tokensBefore)
+			store.value.current('internal')
+			store.props.set({value: 'controlled'})
+			expect(store.value.current()).toBe('controlled')
+			store.props.set({value: undefined})
+			expect(store.value.current()).toBe('internal')
 		})
 
 		it('ignores direct signal writes on props (readonly guard)', () => {

--- a/packages/core/src/store/Store.ts
+++ b/packages/core/src/store/Store.ts
@@ -24,7 +24,7 @@ export class Store {
 
 	readonly slots = new SlotsFeature(this.props)
 
-	readonly tokens = new TokenModel(this.lifecycle, this.value, this.props, this.slots)
+	readonly tokens = new TokenModel(this.value, this.props, this.slots)
 
 	readonly dom = new DomModel(this.lifecycle, this.props, this.tokens)
 


### PR DESCRIPTION
## Summary

- Convert `TokenModel.current` from a writable signal to a `computed`, removing the imperative `#reparse()` method and its `watch` subscriptions
- Add `{immediate: true}` option to `watch()` so callers can fire on first run instead of skipping it
- Simplify `DomIndexer.watch()` by passing the signal directly instead of wrapping in `computed()`
- Update `BlockController` and `Store` tests to reflect the new derived-token behavior

## Test Plan

- [x] `pnpm -w exec vitest run packages/core/src/shared/signals/signals.spec.ts packages/core/src/store/Store.spec.ts packages/core/src/features/block/BlockController.spec.ts` — 131/131 pass
- [x] `pnpm run typecheck` — 0 errors
- [x] `pnpm run lint:check` — 0 errors