### PR TITLE
refactor(core): decouple TokenModel from SlotsFeature and clean up Store initialization

### DIFF
--- a/packages/core/src/features/block/BlockController.ts
+++ b/packages/core/src/features/block/BlockController.ts
@@ -4,7 +4,6 @@ import type {DragAction} from '../../shared/types'
 import type {Token} from '../parsing'
 import type {TokenModel} from '../parsing/TokenModel'
 import type {SelectionController} from '../selection/SelectionController'
-import type {SlotsFeature} from '../slots/SlotsFeature'
 import type {PropsModel} from '../state/PropsModel'
 import type {ValueModel} from '../state/ValueModel'
 import {createRowContent} from './createRowContent'
@@ -18,11 +17,10 @@ export class BlockController {
 		private readonly props: PropsModel,
 		private readonly value: ValueModel,
 		private readonly tokens: TokenModel,
-		private readonly selection: SelectionController,
-		slots: SlotsFeature
+		private readonly selection: SelectionController
 	) {
 		watch(this.action, action => {
-			if (!slots.isDragEnabled()) return
+			if (!this.props.layout.isBlock() || !this.props.draggable()) return
 			switch (action.type) {
 				case 'reorder':
 					this.#reorder(action)

--- a/packages/core/src/features/dom/DomIndexer.ts
+++ b/packages/core/src/features/dom/DomIndexer.ts
@@ -148,7 +148,7 @@ export class DomIndexer {
 		}
 
 		const tokens = this.tokens.current()
-		if (this.props.layout() === 'block') {
+		if (this.props.layout.isBlock()) {
 			this.#indexBlockTokens(container, tokens, tokenIndex, controlElements, pathElements, elementRoles)
 		} else {
 			this.#indexTokenSequence(

--- a/packages/core/src/features/keyboard/KeyboardController.ts
+++ b/packages/core/src/features/keyboard/KeyboardController.ts
@@ -2,7 +2,6 @@ import type {DomModel} from '../dom/DomModel'
 import type {EditController} from '../edit'
 import type {TokenModel} from '../parsing/TokenModel'
 import type {SelectionController} from '../selection/SelectionController'
-import type {SlotsFeature} from '../slots/SlotsFeature'
 import type {Lifecycle} from '../state/Lifecycle'
 import type {PropsModel} from '../state/PropsModel'
 import type {ValueModel} from '../state/ValueModel'
@@ -17,11 +16,10 @@ export class KeyboardController {
 		value: ValueModel,
 		selection: SelectionController,
 		edit: EditController,
-		slots: SlotsFeature,
 		tokens: TokenModel,
 		props: PropsModel
 	) {
-		const ctx = {dom, value, selection, edit, slots, tokens, props}
+		const ctx = {dom, value, selection, edit, tokens, props}
 		lifecycle.onMounted(() => {
 			enableInput(ctx)
 			enableBlockEdit(ctx)

--- a/packages/core/src/features/keyboard/arrowNav.ts
+++ b/packages/core/src/features/keyboard/arrowNav.ts
@@ -2,14 +2,14 @@ import {KEYBOARD} from '../../shared/constants'
 import {listen} from '../../shared/signals/index.js'
 import type {Store} from '../../store/Store'
 
-type KbCtx = Pick<Store, 'dom' | 'selection' | 'slots' | 'tokens'>
+type KbCtx = Pick<Store, 'dom' | 'selection' | 'props' | 'tokens'>
 
 export function enableArrowNav(store: KbCtx): void {
 	const container = store.dom.container()
 	if (!container) return
 
 	listen(container, 'keydown', e => {
-		if (store.slots.isBlock()) return
+		if (store.props.layout.isBlock()) return
 
 		if (e.key === KEYBOARD.LEFT) {
 			shiftFocus(store, e, 'prev')
@@ -18,7 +18,7 @@ export function enableArrowNav(store: KbCtx): void {
 		}
 
 		if ((e.ctrlKey || e.metaKey) && e.code === 'KeyA') {
-			if (store.slots.isBlock()) return
+			if (store.props.layout.isBlock()) return
 			e.preventDefault()
 			store.selection.selectAll()
 		}

--- a/packages/core/src/features/keyboard/blockEdit.ts
+++ b/packages/core/src/features/keyboard/blockEdit.ts
@@ -4,7 +4,7 @@ import type {Range} from '../../shared/editorContracts'
 import {listen} from '../../shared/signals/index.js'
 import type {Store} from '../../store/Store'
 
-type KbCtx = Pick<Store, 'dom' | 'value' | 'selection' | 'edit' | 'slots' | 'tokens' | 'props'>
+type KbCtx = Pick<Store, 'dom' | 'value' | 'selection' | 'edit' | 'tokens' | 'props'>
 import {createRowContent} from '../block/createRowContent'
 import {addDragRow, getMergeDragRowJoinPos, mergeDragRows, canMergeRows} from '../block/operations'
 import {consumeMarkupPaste} from '../clipboard'
@@ -22,7 +22,7 @@ export function enableBlockEdit(store: KbCtx): void {
 	if (!container) return
 
 	listen(container, 'keydown', e => {
-		if (!store.slots.isBlock()) return
+		if (!store.props.layout.isBlock()) return
 
 		if (e.key === KEYBOARD.LEFT || e.key === KEYBOARD.RIGHT) {
 			handleBlockArrowLeftRight(store, e, e.key === KEYBOARD.LEFT ? 'left' : 'right')
@@ -38,7 +38,7 @@ export function enableBlockEdit(store: KbCtx): void {
 		container,
 		'beforeinput',
 		e => {
-			if (!store.slots.isBlock()) return
+			if (!store.props.layout.isBlock()) return
 			if (e.defaultPrevented) return
 			handleBlockBeforeInput(store, e)
 		},

--- a/packages/core/src/features/keyboard/input.ts
+++ b/packages/core/src/features/keyboard/input.ts
@@ -3,7 +3,7 @@ import type {Range} from '../../shared/editorContracts'
 import {listen} from '../../shared/signals/index.js'
 import type {Store} from '../../store/Store'
 
-type KbCtx = Pick<Store, 'dom' | 'value' | 'selection' | 'edit' | 'slots' | 'tokens'>
+type KbCtx = Pick<Store, 'dom' | 'value' | 'selection' | 'edit' | 'props' | 'tokens'>
 import {captureMarkupPaste, consumeMarkupPaste} from '../clipboard'
 import type {Token} from '../parsing'
 import {rawRangeFromInputEvent} from './inputRange'
@@ -34,7 +34,7 @@ export function enableInput(store: KbCtx): void {
 		const range = compositionRange
 		compositionRange = undefined
 		store.dom.compositionEnded()
-		if (store.slots.isBlock()) return
+		if (store.props.layout.isBlock()) return
 		if (!range) return
 		const data = e.data
 		store.edit.replace(range, data)
@@ -55,7 +55,7 @@ export function enableInput(store: KbCtx): void {
 }
 
 function handleDeleteKey(store: KbCtx, event: KeyboardEvent): void {
-	if (store.slots.isBlock()) return
+	if (store.props.layout.isBlock()) return
 	if (event.key !== KEYBOARD.BACKSPACE && event.key !== KEYBOARD.DELETE) return
 
 	if (store.selection.isAllSelected()) {
@@ -87,7 +87,7 @@ export function handleBeforeInput(store: KbCtx, event: InputEvent): void {
 		return
 	}
 
-	if (store.slots.isBlock()) return
+	if (store.props.layout.isBlock()) return
 
 	const raw = rawRangeFromInputEvent(store, event)
 	if (!raw.ok) return

--- a/packages/core/src/features/parsing/TokenModel.spec.ts
+++ b/packages/core/src/features/parsing/TokenModel.spec.ts
@@ -93,4 +93,32 @@ describe('TokenModel', () => {
 			stop()
 		})
 	})
+
+	describe('block layout empty text filtering', () => {
+		it('filters out empty text tokens when layout is block', () => {
+			store.props.set({
+				Mark: () => null,
+				layout: 'block',
+				options: [{markup: '@[__value__]'}],
+				defaultValue: '@[hello]',
+			})
+			store.lifecycle.mounted()
+			expect(store.tokens.current()).toHaveLength(1)
+			expect(store.tokens.current()[0].type).toBe('mark')
+		})
+
+		it('does not filter out empty text tokens when layout is inline', () => {
+			store.props.set({
+				Mark: () => null,
+				layout: 'inline',
+				options: [{markup: '@[__value__]'}],
+				defaultValue: '@[hello]',
+			})
+			store.lifecycle.mounted()
+			expect(store.tokens.current()).toHaveLength(3)
+			expect(store.tokens.current()[0].type).toBe('text')
+			expect(store.tokens.current()[1].type).toBe('mark')
+			expect(store.tokens.current()[2].type).toBe('text')
+		})
+	})
 })

--- a/packages/core/src/features/parsing/TokenModel.ts
+++ b/packages/core/src/features/parsing/TokenModel.ts
@@ -12,7 +12,7 @@ export class TokenModel {
 		const parser = this.#parser()
 		const value = this.value.current()
 		const tokens = parser ? parser.parse(value) : [createTextToken(value)]
-		return this.props.layout() === 'block' ? filterEmptyText(tokens) : tokens
+		return this.props.layout.isBlock() ? filterEmptyText(tokens) : tokens
 	})
 	readonly index: Computed<TokenIndex> = computed(() => createTokenIndex(this.current()))
 

--- a/packages/core/src/features/parsing/TokenModel.ts
+++ b/packages/core/src/features/parsing/TokenModel.ts
@@ -7,13 +7,6 @@ import type {Token} from './parser/types'
 import {createTextToken} from './parser/utils/createTextToken'
 import {createTokenIndex, type TokenIndex} from './tokenIndex'
 
-function filterEmptyText(tokens: Token[]): Token[] {
-	return tokens.filter(token => {
-		if (token.type !== 'text') return true
-		return token.position.start !== token.position.end
-	})
-}
-
 export class TokenModel {
 	readonly current: Computed<Token[]> = computed(() => {
 		const parser = this.#parser()
@@ -38,4 +31,11 @@ export class TokenModel {
 		private readonly value: ValueModel,
 		private readonly props: PropsModel
 	) {}
+}
+
+function filterEmptyText(tokens: Token[]): Token[] {
+	return tokens.filter(token => {
+		if (token.type !== 'text') return true
+		return token.position.start !== token.position.end
+	})
 }

--- a/packages/core/src/features/parsing/TokenModel.ts
+++ b/packages/core/src/features/parsing/TokenModel.ts
@@ -1,6 +1,5 @@
 import {computed} from '../../shared/signals/index.js'
 import type {Computed} from '../../shared/signals/index.js'
-import type {SlotsFeature} from '../slots/SlotsFeature'
 import type {PropsModel} from '../state/PropsModel'
 import type {ValueModel} from '../state/ValueModel'
 import {Parser} from './parser/Parser'
@@ -24,13 +23,11 @@ export class TokenModel {
 		if (!hasMark) return
 		const markups = options.map(opt => opt.markup)
 		if (!markups.some(Boolean)) return
-		//TODO this.slots.isBlock() smelling here
-		return new Parser(markups, this.slots.isBlock() ? {skipEmptyText: true} : undefined)
+		return new Parser(markups, this.props.layout() === 'block' ? {skipEmptyText: true} : undefined)
 	})
 
 	constructor(
 		private readonly value: ValueModel,
-		private readonly props: PropsModel,
-		private readonly slots: SlotsFeature
+		private readonly props: PropsModel
 	) {}
 }

--- a/packages/core/src/features/parsing/TokenModel.ts
+++ b/packages/core/src/features/parsing/TokenModel.ts
@@ -7,11 +7,19 @@ import type {Token} from './parser/types'
 import {createTextToken} from './parser/utils/createTextToken'
 import {createTokenIndex, type TokenIndex} from './tokenIndex'
 
+function filterEmptyText(tokens: Token[]): Token[] {
+	return tokens.filter(token => {
+		if (token.type !== 'text') return true
+		return token.position.start !== token.position.end
+	})
+}
+
 export class TokenModel {
 	readonly current: Computed<Token[]> = computed(() => {
 		const parser = this.#parser()
 		const value = this.value.current()
-		return parser ? parser.parse(value) : [createTextToken(value)]
+		const tokens = parser ? parser.parse(value) : [createTextToken(value)]
+		return this.props.layout() === 'block' ? filterEmptyText(tokens) : tokens
 	})
 	readonly index: Computed<TokenIndex> = computed(() => createTokenIndex(this.current()))
 
@@ -23,7 +31,7 @@ export class TokenModel {
 		if (!hasMark) return
 		const markups = options.map(opt => opt.markup)
 		if (!markups.some(Boolean)) return
-		return new Parser(markups, this.props.layout() === 'block' ? {skipEmptyText: true} : undefined)
+		return new Parser(markups)
 	})
 
 	constructor(

--- a/packages/core/src/features/parsing/parser/Parser.spec.ts
+++ b/packages/core/src/features/parsing/parser/Parser.spec.ts
@@ -1417,75 +1417,7 @@ describe('Parser', () => {
 		})
 	})
 
-	describe('ParseOptions', () => {
-		describe('skipEmptyText', () => {
-			it('removes zero-length text tokens', () => {
-				const parser = new Parser(markups, {skipEmptyText: true})
-				const result = parser.parse('@[hello](world)')
-
-				expect(tokensToDebugTree(result)).toMatchInlineSnapshot(`
-					"0: MARK "@[hello](world)" [0-15] [value="hello", meta="world"]"
-				`)
-			})
-
-			it('keeps non-empty text tokens', () => {
-				const parser = new Parser(markups, {skipEmptyText: true})
-				const result = parser.parse('Hello @[world](test) and #[tag]')
-
-				expect(tokensToDebugTree(result)).toMatchInlineSnapshot(`
-					"0: TEXT "Hello " [0-6]
-					 1: MARK "@[world](test)" [6-20] [value="world", meta="test"]
-					 2: TEXT " and " [20-25]
-					 3: MARK "#[tag]" [25-31] [value="tag"]"
-				`)
-			})
-
-			it('preserves all text tokens in nested children', () => {
-				const parser = new Parser(['@[__slot__]', '#[__slot__]'], {skipEmptyText: true})
-				const result = parser.parse('@[hello #[world]]')
-
-				const mark = getMarkToken(result)
-				expect(mark.children).toHaveLength(3)
-				expect(mark.children[0].type).toBe('text')
-				expect(mark.children[0].content).toBe('hello ')
-				expect(mark.children[1].type).toBe('mark')
-				expect(mark.children[2].type).toBe('text')
-				expect(mark.children[2].position.start).toBe(mark.children[2].position.end)
-			})
-
-			it('handles adjacent marks by removing empty text between them', () => {
-				const parser = new Parser(markups, {skipEmptyText: true})
-				const result = parser.parse('#[tag1]#[tag2]#[tag3]')
-
-				expect(result).toHaveLength(3)
-				expect(result.every(t => t.type === 'mark')).toBe(true)
-			})
-
-			it('works via static Parser.parse()', () => {
-				const result = Parser.parse('@[hello](world)', {
-					markup: ['@[__value__](__meta__)'],
-					skipEmptyText: true,
-				})
-
-				expect(result).toHaveLength(1)
-				expect(result[0].type).toBe('mark')
-			})
-		})
-	})
-
 	describe('slot-leading single-segment patterns', () => {
-		it('parses __slot__\\n\\n into mark tokens with slot content', () => {
-			const parser = new Parser(['__slot__\n\n'], {skipEmptyText: true})
-			const result = parser.parse('First\n\nSecond\n\n')
-
-			expect(tokensToDebugTree(result)).toMatchInlineSnapshot(`
-				"0: MARK "First↲↲" [0-7] [value="", slot="First"]
-					0.0: TEXT "First" [0-5]
-				 1: MARK "Second↲↲" [7-15] [value="", slot="Second"]
-					1.0: TEXT "Second" [7-13]"
-			`)
-		})
-
 		it('produces correct token structure with boundary text tokens', () => {
 			const parser = new Parser(['__slot__\n\n'])
 			const result = parser.parse('First\n\nSecond\n\n')
@@ -1502,14 +1434,15 @@ describe('Parser', () => {
 		})
 
 		it('handles trailing text without delimiter as text token', () => {
-			const parser = new Parser(['__slot__\n\n'], {skipEmptyText: true})
+			const parser = new Parser(['__slot__\n\n'])
 			const result = parser.parse('First\n\nTrailing')
 
-			expect(result).toHaveLength(2)
-			expect(result[0].type).toBe('mark')
-			expect(result[0].content).toBe('First\n\n')
-			expect(result[1].type).toBe('text')
-			expect(result[1].content).toBe('Trailing')
+			expect(result).toHaveLength(3)
+			expect(result[0].type).toBe('text')
+			expect(result[1].type).toBe('mark')
+			expect(result[1].content).toBe('First\n\n')
+			expect(result[2].type).toBe('text')
+			expect(result[2].content).toBe('Trailing')
 		})
 
 		it('handles empty input', () => {
@@ -1521,10 +1454,11 @@ describe('Parser', () => {
 		})
 
 		it('supports nesting with other markups', () => {
-			const parser = new Parser(['__slot__\n\n', '@[__value__]'], {skipEmptyText: true})
+			const parser = new Parser(['__slot__\n\n', '@[__value__]'])
 			const result = parser.parse('Hello @[world]\n\n')
 
-			expect(result).toHaveLength(1)
+			expect(result).toHaveLength(3)
+			expect(result[0].type).toBe('text')
 			const mark = getMarkToken(result)
 			expect(mark.type).toBe('mark')
 			expect(mark.content).toBe('Hello @[world]\n\n')
@@ -1533,14 +1467,7 @@ describe('Parser', () => {
 			expect(mark.children[0].content).toBe('Hello ')
 			expect(mark.children[1].type).toBe('mark')
 			expect(mark.children[2].type).toBe('text')
-		})
-
-		it('works with skipEmptyText', () => {
-			const parser = new Parser(['__slot__\n\n'], {skipEmptyText: true})
-			const result = parser.parse('First\n\nSecond\n\n')
-
-			expect(result).toHaveLength(2)
-			expect(result.every(t => t.type === 'mark')).toBe(true)
+			expect(result[2].type).toBe('text')
 		})
 
 		it('round-trips through Parser.stringify', () => {
@@ -1552,24 +1479,24 @@ describe('Parser', () => {
 		})
 
 		it('handles single paragraph', () => {
-			const parser = new Parser(['__slot__\n\n'], {skipEmptyText: true})
+			const parser = new Parser(['__slot__\n\n'])
 			const result = parser.parse('Only\n\n')
 
-			expect(result).toHaveLength(1)
-			expect(result[0].type).toBe('mark')
-			expect(result[0].content).toBe('Only\n\n')
+			expect(result).toHaveLength(3)
+			expect(result[1].type).toBe('mark')
+			expect(result[1].content).toBe('Only\n\n')
 			const mark = getMarkToken(result)
 			expect(mark.value).toBe('')
 			expect(mark.slot?.content).toBe('Only')
 		})
 
 		it('handles empty slot content (just delimiter)', () => {
-			const parser = new Parser(['__slot__\n\n'], {skipEmptyText: true})
+			const parser = new Parser(['__slot__\n\n'])
 			const result = parser.parse('\n\n')
 
-			expect(result).toHaveLength(1)
-			expect(result[0].type).toBe('mark')
-			expect(result[0].content).toBe('\n\n')
+			expect(result).toHaveLength(3)
+			expect(result[1].type).toBe('mark')
+			expect(result[1].content).toBe('\n\n')
 		})
 	})
 })

--- a/packages/core/src/features/parsing/parser/Parser.ts
+++ b/packages/core/src/features/parsing/parser/Parser.ts
@@ -35,8 +35,7 @@ export class Parser {
 	 *   - `__meta__` - metadata (plain text, no nesting)
 	 *   - `__slot__` - content supporting nested structures
 	 *   - `undefined` - skipped, but original array indices are preserved for descriptor matching
-	 * @param options - Optional parse options to control token output:
-	 *   - `skipEmptyText` - drop zero-length TextTokens (where start === end)
+	 * @param options - Optional parse options to control token output
 	 *
 	 * @example
 	 * ```typescript
@@ -53,7 +52,7 @@ export class Parser {
 		this.segmentMatcher = new SegmentMatcher(this.registry.segments)
 		this.patternMatcher = new PatternMatcher(this.registry)
 		this.parseOptions = options ?? {}
-		this.treeBuilder = new TreeBuilder(this.parseOptions)
+		this.treeBuilder = new TreeBuilder()
 	}
 
 	/**

--- a/packages/core/src/features/parsing/parser/core/TreeBuilder.ts
+++ b/packages/core/src/features/parsing/parser/core/TreeBuilder.ts
@@ -1,4 +1,4 @@
-import type {MarkToken, ParseOptions, PositionRange, TextToken, Token} from '../types'
+import type {MarkToken, PositionRange, TextToken, Token} from '../types'
 import {createTextToken} from '../utils/createTextToken'
 import type {Match} from './Match'
 
@@ -32,11 +32,6 @@ interface ParentContext {
 export class TreeBuilder {
 	// Instance fields - only what's needed for single pass
 	private input!: string
-	private readonly options: ParseOptions
-
-	constructor(options?: ParseOptions) {
-		this.options = options ?? {}
-	}
 
 	// ===== PUBLIC API =====
 
@@ -60,11 +55,10 @@ export class TreeBuilder {
 		this.input = input
 
 		if (matches.length === 0) {
-			return this.filterTokens([this.createTextToken(0, input.length)])
+			return [this.createTextToken(0, input.length)]
 		}
 
-		const tokens = this.buildSinglePass(matches)
-		return this.filterTokens(tokens)
+		return this.buildSinglePass(matches)
 	}
 
 	// ===== SINGLE-PASS ALGORITHM =====
@@ -250,17 +244,5 @@ export class TreeBuilder {
 			start: match.gaps.slot.start,
 			end: match.gaps.slot.end,
 		}
-	}
-
-	// ===== TOKEN FILTERING. TODO: Is a hack =====
-
-	private filterTokens(tokens: Token[]): Token[] {
-		const {skipEmptyText} = this.options
-		if (!skipEmptyText) return tokens
-
-		return tokens.filter(token => {
-			if (token.type !== 'text') return true
-			return token.position.start !== token.position.end
-		})
 	}
 }

--- a/packages/core/src/features/parsing/parser/types.ts
+++ b/packages/core/src/features/parsing/parser/types.ts
@@ -30,10 +30,7 @@ export interface MarkToken {
 	children: Token[]
 }
 
-export interface ParseOptions {
-	/** Drop zero-length TextTokens (where start === end) */
-	skipEmptyText?: boolean
-}
+export interface ParseOptions {}
 
 /**
  * Position range representing a span in text with start and end positions

--- a/packages/core/src/features/slots/SlotsFeature.spec.ts
+++ b/packages/core/src/features/slots/SlotsFeature.spec.ts
@@ -8,17 +8,8 @@ describe('SlotsFeature', () => {
 		expect('container' in store.slots).toBe(false)
 	})
 
-	it('exposes layout slot computed values', () => {
-		const store = new Store()
-		expect(store.slots.isBlock()).toBe(false)
-		expect(store.slots.isDragEnabled()).toBe(false)
-		expect(typeof store.slots.containerComponent()).toBeTruthy()
-	})
-
 	it('exposes every slot computed', () => {
 		const store = new Store()
-		expect(typeof store.slots.isBlock()).toBe('boolean')
-		expect(typeof store.slots.isDragEnabled()).toBe('boolean')
 		expect(typeof store.slots.containerComponent()).toBeTruthy()
 		expect(typeof store.slots.containerProps()).toBe('object')
 		expect(typeof store.slots.blockComponent()).toBeTruthy()

--- a/packages/core/src/features/slots/SlotsFeature.ts
+++ b/packages/core/src/features/slots/SlotsFeature.ts
@@ -34,16 +34,12 @@ function buildContainerProps(
 }
 
 export class SlotsFeature {
-	readonly isBlock: Computed<boolean> = computed(() => this.props.layout() === 'block')
-	readonly isDragEnabled: Computed<boolean> = computed(
-		() => this.props.layout() === 'block' && !!this.props.draggable()
-	)
 	readonly containerComponent: Computed<Slot> = computed(() => resolveSlot('container', this.props.slots()))
 	readonly containerProps: Computed<{className: string | undefined; style?: CSSProperties; [key: string]: unknown}> =
 		computed(
 			() =>
 				buildContainerProps(
-					this.isDragEnabled(),
+					this.props.layout.isBlock() && !!this.props.draggable(),
 					this.props.readOnly(),
 					this.props.className(),
 					this.props.style(),

--- a/packages/core/src/features/state/PropsModel.ts
+++ b/packages/core/src/features/state/PropsModel.ts
@@ -21,7 +21,12 @@ export class PropsModel {
 	readonly options = signal<CoreOption[]>(DEFAULT_OPTIONS, {readonly: true})
 	readonly readOnly = signal<boolean>(false, {readonly: true})
 
-	readonly layout = signal<'inline' | 'block'>('inline', {readonly: true})
+	readonly layout = signal('inline' as 'inline' | 'block', {
+		readonly: true,
+		computed: self => ({
+			isBlock: () => self() === 'block',
+		}),
+	})
 	readonly draggable = signal<boolean | DraggableConfig>(false, {readonly: true})
 
 	readonly showOverlayOn = signal<OverlayTrigger>('change', {readonly: true})

--- a/packages/core/src/shared/signals/signal.ts
+++ b/packages/core/src/shared/signals/signal.ts
@@ -348,9 +348,24 @@ interface SignalOptions<T> {
 	readonly?: boolean
 }
 
+export type ComputedRecord<C> = {
+	readonly [K in keyof C]: C[K] extends () => infer R ? Computed<R> : never
+}
+
+interface SignalOptionsWithComputed<T, C> extends SignalOptions<T> {
+	computed: (self: Signal<T>) => C
+}
+
+export function signal<T, C extends Record<string, () => unknown> = Record<string, () => unknown>>(
+	initial: T,
+	opts: SignalOptionsWithComputed<T, C>
+): Signal<T> & ComputedRecord<C>
 export function signal<T = never>(initial: undefined, opts?: SignalOptions<T | undefined>): Signal<T | undefined>
 export function signal<T>(initial: T, opts?: SignalOptions<T>): Signal<T>
-export function signal<T>(initial: T, opts?: SignalOptions<T>): Signal<T> {
+export function signal<T>(
+	initial: T,
+	opts?: SignalOptions<T> | SignalOptionsWithComputed<T, Record<string, () => unknown>>
+): Signal<T> {
 	const node: SignalNode<T> = {
 		currentValue: initial,
 		pendingValue: initial,
@@ -363,9 +378,20 @@ export function signal<T>(initial: T, opts?: SignalOptions<T>): Signal<T> {
 		flags: ReactiveFlags.Mutable,
 	}
 	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- callable matches Signal<T> interface but TS can't verify the overloaded call signature
-	return (signalOper as (this: SignalNode<T>, ...value: [T | undefined] | []) => T | boolean).bind(
+	const bound = (signalOper as (this: SignalNode<T>, ...value: [T | undefined] | []) => T | boolean).bind(
 		node
 	) as unknown as Signal<T>
+
+	if (opts && 'computed' in opts) {
+		const getters = opts.computed(bound)
+		const views: Record<string, Computed<unknown>> = {}
+		for (const key of Object.keys(getters)) {
+			views[key] = computed(getters[key])
+		}
+		Object.assign(bound, views)
+	}
+
+	return bound
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/shared/signals/signals.spec.ts
+++ b/packages/core/src/shared/signals/signals.spec.ts
@@ -356,6 +356,80 @@ describe('signal<T>', () => {
 })
 
 // ---------------------------------------------------------------------------
+// signal<T> with computed views
+// ---------------------------------------------------------------------------
+
+describe('signal<T> with computed views', () => {
+	beforeEach(() => vi.clearAllMocks())
+
+	it('expose attached computeds as Computed values', () => {
+		const layout = signal('inline' as 'inline' | 'block', {
+			computed: self => ({
+				isBlock: () => self() === 'block',
+			}),
+		})
+		const isBlockResult: boolean = layout.isBlock()
+		expect(typeof layout.isBlock).toBe('function')
+		expect(isBlockResult).toBe(false)
+		expect(isReactive(layout.isBlock)).toBe(true)
+	})
+
+	it('recompute attached views when the signal updates', () => {
+		const layout = signal('inline' as 'inline' | 'block', {
+			computed: self => ({
+				isBlock: () => self() === 'block',
+			}),
+		})
+
+		const runs = vi.fn()
+		trackedEffect(() => {
+			layout.isBlock()
+			runs()
+		})
+		expect(runs).toHaveBeenCalledTimes(1)
+
+		layout('block')
+		expect(layout.isBlock()).toBe(true)
+		expect(runs).toHaveBeenCalledTimes(2)
+	})
+
+	it('still treat the augmented value as a normal signal', () => {
+		const layout = signal('inline' as 'inline' | 'block', {
+			computed: self => ({isBlock: () => self() === 'block'}),
+		})
+		expect(isReactive(layout)).toBe(true)
+		layout('block')
+		expect(layout()).toBe('block')
+	})
+
+	it('support multiple computed views on one signal', () => {
+		const layout = signal('inline' as 'inline' | 'block', {
+			computed: self => ({
+				isBlock: () => self() === 'block',
+				isInline: () => self() === 'inline',
+			}),
+		})
+		expect(layout.isBlock()).toBe(false)
+		expect(layout.isInline()).toBe(true)
+		layout('block')
+		expect(layout.isBlock()).toBe(true)
+		expect(layout.isInline()).toBe(false)
+	})
+
+	it('honor readonly while still exposing computed views', () => {
+		const layout = signal('inline' as 'inline' | 'block', {
+			readonly: true,
+			computed: self => ({isBlock: () => self() === 'block'}),
+		})
+		expect(layout.isBlock()).toBe(false)
+		// Readonly signals reject external writes by returning false without mutating
+		expect(layout('block')).toBe(false)
+		expect(layout()).toBe('inline')
+		expect(layout.isBlock()).toBe(false)
+	})
+})
+
+// ---------------------------------------------------------------------------
 // event<T>()
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/store/Store.spec.ts
+++ b/packages/core/src/store/Store.spec.ts
@@ -286,49 +286,50 @@ describe('Store', () => {
 		it('return false when layout is inline', () => {
 			const store = new Store()
 			store.props.set({layout: 'inline'})
-			expect(store.slots.isBlock()).toBe(false)
+			expect(store.props.layout.isBlock()).toBe(false)
 		})
 
 		it('return true when layout is block', () => {
 			const store = new Store()
 			store.props.set({layout: 'block'})
-			expect(store.slots.isBlock()).toBe(true)
+			expect(store.props.layout.isBlock()).toBe(true)
 		})
 
 		it('default to false', () => {
 			const store = new Store()
-			expect(store.slots.isBlock()).toBe(false)
+			expect(store.props.layout.isBlock()).toBe(false)
 		})
 	})
 
-	describe('isDragEnabled', () => {
-		it('returns false when layout is inline even if draggable is true', () => {
+	describe('drag-enabled container padding', () => {
+		it('skip drag-handle padding when layout is inline even if draggable is true', () => {
 			const store = new Store()
 			store.props.set({layout: 'inline', draggable: true})
-			expect(store.slots.isDragEnabled()).toBe(false)
+			expect(store.slots.containerProps().style?.paddingLeft).toBeUndefined()
 		})
 
-		it('returns false when draggable is false', () => {
+		it('skip drag-handle padding when draggable is false', () => {
 			const store = new Store()
 			store.props.set({layout: 'block', draggable: false})
-			expect(store.slots.isDragEnabled()).toBe(false)
+			expect(store.slots.containerProps().style?.paddingLeft).toBeUndefined()
 		})
 
-		it('returns true when layout is block and draggable is true', () => {
+		it('apply drag-handle padding when layout is block and draggable is true', () => {
 			const store = new Store()
 			store.props.set({layout: 'block', draggable: true})
-			expect(store.slots.isDragEnabled()).toBe(true)
+			expect(store.slots.containerProps().style?.paddingLeft).toBe(24)
 		})
 
-		it('returns true when layout is block and draggable is a DraggableConfig', () => {
+		it('apply drag-handle padding when draggable is a DraggableConfig', () => {
 			const store = new Store()
 			store.props.set({layout: 'block', draggable: {alwaysShowHandle: true}})
-			expect(store.slots.isDragEnabled()).toBe(true)
+			expect(store.slots.containerProps().style?.paddingLeft).toBe(24)
 		})
 
-		it('defaults to false', () => {
+		it('skip drag-handle padding in read-only mode', () => {
 			const store = new Store()
-			expect(store.slots.isDragEnabled()).toBe(false)
+			store.props.set({layout: 'block', draggable: true, readOnly: true})
+			expect(store.slots.containerProps().style?.paddingLeft).toBeUndefined()
 		})
 	})
 

--- a/packages/core/src/store/Store.ts
+++ b/packages/core/src/store/Store.ts
@@ -45,11 +45,10 @@ export class Store {
 		this.value,
 		this.selection,
 		this.edit,
-		this.slots,
 		this.tokens,
 		this.props
 	)
-	readonly block = new BlockController(this.props, this.value, this.tokens, this.selection, this.slots)
+	readonly block = new BlockController(this.props, this.value, this.tokens, this.selection)
 	readonly clipboard = new ClipboardController(this.lifecycle, this.edit, this.dom, this.tokens)
 
 	readonly handler = new MarkputHandler(this.dom, this.overlay, this.selection)

--- a/packages/core/src/store/Store.ts
+++ b/packages/core/src/store/Store.ts
@@ -21,10 +21,9 @@ export class Store {
 	readonly lifecycle = new Lifecycle()
 	readonly props = new PropsModel()
 	readonly value = new ValueModel(this.props)
+	readonly tokens = new TokenModel(this.value, this.props)
 
 	readonly slots = new SlotsFeature(this.props)
-
-	readonly tokens = new TokenModel(this.value, this.props)
 
 	readonly dom = new DomModel(this.lifecycle, this.props, this.tokens)
 

--- a/packages/core/src/store/Store.ts
+++ b/packages/core/src/store/Store.ts
@@ -24,7 +24,7 @@ export class Store {
 
 	readonly slots = new SlotsFeature(this.props)
 
-	readonly tokens = new TokenModel(this.value, this.props, this.slots)
+	readonly tokens = new TokenModel(this.value, this.props)
 
 	readonly dom = new DomModel(this.lifecycle, this.props, this.tokens)
 

--- a/packages/react/markput/src/components/Container.tsx
+++ b/packages/react/markput/src/components/Container.tsx
@@ -8,7 +8,7 @@ export const Container = memo(() => {
 	const {dom, lifecycle, isBlock, tokens, key, Component, props} = useMarkput(s => ({
 		dom: s.dom,
 		lifecycle: s.lifecycle,
-		isBlock: s.slots.isBlock,
+		isBlock: s.props.layout.isBlock,
 		tokens: s.tokens.current,
 		key: s.key,
 		Component: s.slots.containerComponent,

--- a/packages/vue/markput/src/components/Container.vue
+++ b/packages/vue/markput/src/components/Container.vue
@@ -8,7 +8,7 @@ import Token from './Token.vue'
 
 const store = useStore()
 const result = useMarkput(s => ({
-	isBlock: s.slots.isBlock,
+	isBlock: s.props.layout.isBlock,
 	tokens: s.tokens.current,
 	key: s.key,
 }))

--- a/packages/website/src/content/docs/api/type-aliases/Markup.md
+++ b/packages/website/src/content/docs/api/type-aliases/Markup.md
@@ -23,7 +23,7 @@ type Markup =
   | `${MetaMarkup}${SlotMarkup}${ValueMarkup}`;
 ```
 
-Defined in: [core/src/features/parsing/parser/types.ts:64](https://github.com/Nowely/marked-input/blob/next/packages/core/src/features/parsing/parser/types.ts#L64)
+Defined in: [core/src/features/parsing/parser/types.ts:61](https://github.com/Nowely/marked-input/blob/next/packages/core/src/features/parsing/parser/types.ts#L61)
 
 Modern Markup type supporting value, meta, and slot placeholders
 


### PR DESCRIPTION
## Summary
- Decoupled `TokenModel` from `SlotsFeature` to simplify dependencies in the store core.
- Streamlined `Store` initialization to avoid duplicate declarations of `TokenModel`.
- Replaced `SlotsFeature` layout checks with `PropsModel` block layout checks.
- Cleaned up parser config by filtering empty text directly inside `TokenModel`.

## Test Plan
- Run existing vitest test suite (`pnpm test` passed completely with 49 files and 972 tests).