### PR TITLE
refactor(core): route block/keyboard edits through EditController with batched writes

### DIFF
--- a/docs/superpowers/reviews/2026-05-23-core-audit-consolidated.md
+++ b/docs/superpowers/reviews/2026-05-23-core-audit-consolidated.md
@@ -3,7 +3,7 @@
 Date: 2026-05-23
 Scope: `packages/core/src/**` and adapter wiring.
 
-Eight open issues against the current `next` branch, plus five deferred
+Seven open issues against the current `next` branch, plus five deferred
 items with documented rationale. Verified by re-reading each cited file
 and running `pnpm test` (972 passed).
 
@@ -73,31 +73,7 @@ Fix: a shared `listenToContainer(store, setup)` that watches
 Risk: behavior-change (small) — only matters when the container changes
 after mount.
 
-### 4. `EditController` adoption is partial
-
-`EditController.replace(range, replacement)` batches the value write with
-caret placement and gates on `value.replace()` acceptance. Adopters:
-keyboard inline input, overlay insert, clipboard cut, `MarkController`,
-block Enter on text rows.
-
-Direct writers still call `value.current(next)` + manual
-`selection.position(...)`:
-
-- `keyboard/input.ts:221` — `replaceAllContentWith`
-- `keyboard/blockEdit.ts:85, 97, 120, 136, 178` — block delete/Enter on
- non-text rows
-- `block/BlockController.ts:48, 60, 69, 78` — drag reorder/add/delete/
- duplicate
-
-Subscribers can observe `value` and `selection` out of sync on the same
-tick.
-
-Fix: extend `EditController` if `Range` is awkward — e.g. `replaceAll(next)`
-or `replaceWithCaret(range, replacement, caretAt)` — and route the
-remaining sites through it.
-Risk: behavior-change (small).
-
-### 5. Overlay ships a fake `MarkToken`
+### 4. Overlay ships a fake `MarkToken`
 
 `features/overlay/createMarkFromOverlay.ts` builds a `MarkToken` with
 empty `children`, fabricated `descriptor` (`segments: []`,
@@ -114,7 +90,7 @@ Fix: change `select` to
 update both `useOverlay` hooks.
 Risk: behavior-change (small, internal API).
 
-### 6. Overlay trigger probing reads global selection
+### 5. Overlay trigger probing reads global selection
 
 `features/overlay/OverlayController.ts:56` — `watch(value.current)` →
 `#probeTrigger()` doesn't check whether the current selection belongs to
@@ -133,7 +109,7 @@ outside it, and add the same `contains(activeElement)` check inside the
 `value.current` watcher.
 Risk: behavior-change (small).
 
-### 7. `PropsModel.set` accepts inherited keys
+### 6. `PropsModel.set` accepts inherited keys
 
 `features/state/PropsModel.ts:48-52`:
 
@@ -154,7 +130,7 @@ before invoking.
 Risk: behavior-change (small) — silently drops non-signal keys instead of
 executing them.
 
-### 8. Stale feature READMEs
+### 7. Stale feature READMEs
 
 - `features/clipboard/README.md:7-10` — references `CopyFeature` (renamed
  `ClipboardController`) and `clearMarkupPaste` (deleted).

--- a/packages/core/src/features/block/BlockController.spec.ts
+++ b/packages/core/src/features/block/BlockController.spec.ts
@@ -1,5 +1,6 @@
 import {describe, it, expect, vi, beforeEach} from 'vitest'
 
+import {effect} from '../../shared/signals'
 import {Store} from '../../store/Store'
 
 describe('BlockController', () => {
@@ -49,5 +50,47 @@ describe('BlockController', () => {
 
 		expect(currentSpy).toHaveBeenCalledWith('beta\n\n')
 		expect(store.selection.range()).toEqual({start: 6, end: 6})
+	})
+
+	it('writes value and caret as a single batched tick', () => {
+		store.props.set({
+			layout: 'block',
+			draggable: true,
+			Mark: () => null,
+			options: [{markup: '__slot__\n\n'}],
+		})
+		store.lifecycle.mounted()
+		store.value.current('alpha\n\nbeta\n\n')
+
+		let runs = 0
+		const dispose = effect(() => {
+			store.value.current()
+			store.selection.range()
+			runs++
+		})
+		const initial = runs
+
+		store.block.action({type: 'delete', index: 0})
+
+		expect(runs - initial).toBe(1)
+		dispose()
+	})
+
+	it('skips writes when reorder is a no-op', () => {
+		store.props.set({
+			layout: 'block',
+			draggable: true,
+			Mark: () => null,
+			options: [{markup: '__slot__\n\n'}],
+		})
+		store.lifecycle.mounted()
+		store.value.current('alpha\n\nbeta\n\n')
+		const replaceSpy = vi.spyOn(store.value, 'replace')
+		const positionSpy = vi.spyOn(store.selection, 'position')
+
+		store.block.action({type: 'reorder', source: 0, target: 0})
+
+		expect(replaceSpy).not.toHaveBeenCalled()
+		expect(positionSpy).not.toHaveBeenCalled()
 	})
 })

--- a/packages/core/src/features/block/BlockController.ts
+++ b/packages/core/src/features/block/BlockController.ts
@@ -1,6 +1,7 @@
 import type {Range} from '../../shared/editorContracts'
 import {event, watch} from '../../shared/signals'
 import type {DragAction} from '../../shared/types'
+import type {EditController} from '../edit'
 import type {Token} from '../parsing'
 import type {TokenModel} from '../parsing/TokenModel'
 import type {SelectionController} from '../selection/SelectionController'
@@ -17,7 +18,8 @@ export class BlockController {
 		private readonly props: PropsModel,
 		private readonly value: ValueModel,
 		private readonly tokens: TokenModel,
-		private readonly selection: SelectionController
+		private readonly selection: SelectionController,
+		private readonly edit: EditController
 	) {
 		watch(this.action, action => {
 			if (!this.props.layout.isBlock() || !this.props.draggable()) return
@@ -42,11 +44,9 @@ export class BlockController {
 		const value = this.value.current()
 		const rows = this.tokens.current()
 		const newValue = reorderDragRows(value, rows, action.source, action.target)
-		if (newValue !== value) {
-			const range = this.#rangeAfterDrag(action, rows, newValue)
-			if (range) this.selection.range(range)
-			this.value.current(newValue)
-		}
+		if (newValue === value) return
+		const caretAt = this.#rangeAfterDrag(action, rows, newValue)?.start
+		this.edit.replace({start: 0, end: -1}, newValue, caretAt)
 	}
 
 	#add(action: Extract<DragAction, {type: 'add'}>) {
@@ -55,27 +55,24 @@ export class BlockController {
 		const rows = rawRows.length > 0 ? rawRows : [EMPTY_TEXT_TOKEN]
 		const newRowContent = createRowContent(this.props.options())
 		const newValue = addDragRow(value, rows, action.afterIndex, newRowContent)
-		const range = this.#rangeAfterDrag(action, rows, newValue)
-		if (range) this.selection.range(range)
-		this.value.current(newValue)
+		const caretAt = this.#rangeAfterDrag(action, rows, newValue)?.start
+		this.edit.replace({start: 0, end: -1}, newValue, caretAt)
 	}
 
 	#delete(action: Extract<DragAction, {type: 'delete'}>) {
 		const value = this.value.current()
 		const rows = this.tokens.current()
 		const newValue = deleteDragRow(value, rows, action.index)
-		const range = this.#rangeAfterDrag(action, rows, newValue)
-		if (range) this.selection.range(range)
-		this.value.current(newValue)
+		const caretAt = this.#rangeAfterDrag(action, rows, newValue)?.start
+		this.edit.replace({start: 0, end: -1}, newValue, caretAt)
 	}
 
 	#duplicate(action: Extract<DragAction, {type: 'duplicate'}>) {
 		const value = this.value.current()
 		const rows = this.tokens.current()
 		const newValue = duplicateDragRow(value, rows, action.index)
-		const range = this.#rangeAfterDrag(action, rows, newValue)
-		if (range) this.selection.range(range)
-		this.value.current(newValue)
+		const caretAt = this.#rangeAfterDrag(action, rows, newValue)?.start
+		this.edit.replace({start: 0, end: -1}, newValue, caretAt)
 	}
 
 	#rangeAfterDrag(action: DragAction, previousRows: readonly Token[], nextValue: string): Range | undefined {

--- a/packages/core/src/features/block/README.md
+++ b/packages/core/src/features/block/README.md
@@ -1,10 +1,10 @@
-# Drag Feature
+# Block Feature
 
-Manages the drag-and-drop block editing mode where each row/token is rendered as a separate draggable block. Subscribes to drag action events and dispatches operations like reorder, add, delete, duplicate, and merge.
+Manages the block editing mode where each row/token is rendered as a separate draggable block. Subscribes to drag action events and routes value mutations through `store.edit.replace()` so subscribers observe a batched value/caret update per drag operation.
 
 ## Components
 
-- **DragController**: Controller class that subscribes to `store.drag.action` and dispatches drag operations
+- **BlockController**: Subscribes to `store.block.action` (a reactive event) and dispatches drag operations (reorder, add, delete, duplicate). Receives `EditController` so all writes go through the single batched write path.
 - **getAlwaysShowHandle**: Extracts `alwaysShowHandle` from `DraggableConfig`
 - **EMPTY_TEXT_TOKEN**: Constant used as placeholder when no rows exist
 
@@ -14,4 +14,4 @@ The feature uses pure functions from `operations.ts` for manipulating the raw va
 
 ## Usage
 
-The feature is registered by the Store and activates when drag mode is enabled. Drag actions are dispatched via `store.drag.action`.
+The feature is registered by the Store and activates when block layout and `draggable` are both enabled. Drag actions are dispatched via `store.block.action({...})`.

--- a/packages/core/src/features/clipboard/README.md
+++ b/packages/core/src/features/clipboard/README.md
@@ -4,10 +4,9 @@ Provides copy, cut, and paste operations with rich markup support. On copy, writ
 
 ## Components
 
-- **CopyFeature**: Feature class handling `copy` and `cut` events — serializes selected tokens to markup/plain/HTML and writes to clipboard; on cut, also deletes the selected tokens
+- **ClipboardController**: Controller class handling `copy` and `cut` events — serializes selected tokens to markup/plain/HTML and writes to clipboard; on cut, also deletes the selected tokens through `store.edit.replace()`
 - **captureMarkupPaste**: Captures markput MIME data from a ClipboardEvent
 - **consumeMarkupPaste**: Reads and clears captured markput paste data for a container
-- **clearMarkupPaste**: Clears captured markput paste data without reading
 - **DOM raw selection**: Clipboard uses `store.dom.readRawSelection()` to map browser selections to serialized raw ranges.
 
 ## Usage
@@ -19,4 +18,4 @@ if (raw.ok) {
 }
 ```
 
-The `CopyFeature` is registered by the Store automatically. The custom MIME type (`application/x-markput`) preserves full markup syntax on internal copy/paste operations.
+The `ClipboardController` is registered by the Store automatically. The custom MIME type (`application/x-markput`) preserves full markup syntax on internal copy/paste operations.

--- a/packages/core/src/features/dom/README.md
+++ b/packages/core/src/features/dom/README.md
@@ -1,13 +1,13 @@
 # DOM Feature
 
-Owns rendered DOM structure, token-to-element indexing, raw boundary mapping, and structural text reconciliation. Caret placement back into the DOM is the responsibility of `CaretModel` (see `../caret/README.md`).
+Owns rendered DOM structure, token-to-element indexing, raw boundary mapping, and structural text reconciliation. Caret placement back into the DOM is the responsibility of `SelectionController`.
 
 ## Layout
 
-- `DomModel.ts` — public facade exposed as `store.dom`. Owns `container`, ref registries (`controlFor` / `childrenFor`), composition flags, the click-on-empty listener, and the `index` / `indexed` / `diagnostics` / `readOnly` surface. Exposes read-only views into the index (`locateNode`, `pathElements`, `pathElementsFor`) and the boundary mapping (`rawPositionFromBoundary`, `readRawSelection`).
+- `DomModel.ts` — public facade exposed as `store.dom`. Owns `container`, ref registries (`controlFor` / `childrenFor`), composition flags, the click-on-empty listener, and the `index` / `indexed` / `readOnly` surface. Exposes read-only views into the index (`locateNode`, `pathElements`, `pathElementsFor`) and the boundary mapping (`rawPositionFromBoundary`, `readRawSelection`).
 - `DomIndexer.ts` — rebuilds the token-to-element index after `lifecycle.rendered`, keeps `#pathElements` / `#elementRoles` in sync, and reconciles structural text surfaces (text content + `contentEditable`) when `props.readOnly` changes or selection mode toggles.
 - `DomBoundary.ts` — converts DOM `(node, offset)` boundaries and the current browser selection into raw value positions. Used by the value pipeline and keyboard handlers.
-- `textOffsets.ts` — pure helpers for walking text content (`textOffsetWithin`, `textLength`, `splitsSurrogatePair`, `hasEditableAncestorBefore`, etc.). Also consumed by `CaretModel`'s inlined placement helpers.
+- `textOffsets.ts` — pure helpers for walking text content (`textOffsetWithin`, `textLength`, `hasEditableAncestorBefore`, etc.). Also consumed by `SelectionController`'s inlined placement helpers.
 
 ## Registration
 
@@ -15,7 +15,7 @@ React/Vue register the root through `store.dom.container` and block controls thr
 
 ## Indexing
 
-The index is built after `lifecycle.rendered()` from direct rendered token roots. Out-of-shape DOM trees produce `dom.diagnostics` events (`ambiguousStructure`, `stalePath`, `missingContainer`, etc.) rather than throwing.
+The index is built after `lifecycle.rendered()` from direct rendered token roots. Out-of-shape DOM trees are surfaced through the indexed status, not through thrown errors.
 
 ## Notes
 

--- a/packages/core/src/features/edit/EditController.spec.ts
+++ b/packages/core/src/features/edit/EditController.spec.ts
@@ -71,4 +71,36 @@ describe('EditController', () => {
 		expect(store.value.current()).toBe('hello')
 		expect(store.selection.range()).toEqual({start: 5, end: 5})
 	})
+
+	it('honors explicit caretAt over the natural end of the replacement', () => {
+		const store = new Store()
+		store.props.set({defaultValue: 'hello world'})
+		store.lifecycle.mounted()
+
+		store.edit.replace({start: 0, end: 5}, 'hi', 0)
+
+		expect(store.value.current()).toBe('hi world')
+		expect(store.selection.range()).toEqual({start: 0, end: 0})
+	})
+
+	it('normalizes negative range.end to the current value length', () => {
+		const store = new Store()
+		store.props.set({defaultValue: 'hello world'})
+		store.lifecycle.mounted()
+
+		store.edit.replace({start: 0, end: -1}, 'replaced')
+
+		expect(store.value.current()).toBe('replaced')
+		expect(store.selection.range()).toEqual({start: 8, end: 8})
+	})
+
+	it('normalizes negative range.end on an empty value', () => {
+		const store = new Store()
+		store.lifecycle.mounted()
+
+		store.edit.replace({start: 0, end: -1}, 'first')
+
+		expect(store.value.current()).toBe('first')
+		expect(store.selection.range()).toEqual({start: 5, end: 5})
+	})
 })

--- a/packages/core/src/features/edit/EditController.ts
+++ b/packages/core/src/features/edit/EditController.ts
@@ -7,6 +7,12 @@ import type {ValueModel} from '../state'
  * Single write path for text edits — delegates gating to {@link ValueModel.replace}
  * and only moves the caret when the edit is accepted. Wrapped in {@link batch}
  * so subscribers observe a consistent value/selection pair on one tick.
+ *
+ * - `range.end < 0` is normalized to the current value length. Use
+ *   `{start: 0, end: -1}` for whole-value replacements.
+ * - `caretAt` overrides the default post-edit caret (which is
+ *   `range.start + replacement.length`). Used by sites whose desired caret
+ *   is not the natural end of the replacement (e.g. block reorder).
  */
 export class EditController {
 	constructor(
@@ -14,10 +20,11 @@ export class EditController {
 		private readonly selection: SelectionController
 	) {}
 
-	replace(range: Range, replacement: string): void {
+	replace(range: Range, replacement: string, caretAt?: number): void {
 		batch(() => {
-			if (!this.value.replace(range, replacement)) return
-			this.selection.position(range.start + replacement.length)
+			const normalized: Range = range.end < 0 ? {start: range.start, end: this.value.current().length} : range
+			if (!this.value.replace(normalized, replacement)) return
+			this.selection.position(caretAt ?? normalized.start + replacement.length)
 		})
 	}
 }

--- a/packages/core/src/features/keyboard/blockEdit.ts
+++ b/packages/core/src/features/keyboard/blockEdit.ts
@@ -81,8 +81,7 @@ function handleDelete(store: KbCtx, event: KeyboardEvent) {
 						})()
 			const previous = rows.at(Math.max(0, blockIndex - 1))
 			const pos = previous ? previous.position.end : 0
-			store.selection.position(pos)
-			store.value.current(newValue)
+			store.edit.replace({start: 0, end: -1}, newValue, pos)
 			return
 		}
 
@@ -93,8 +92,7 @@ function handleDelete(store: KbCtx, event: KeyboardEvent) {
 				event.preventDefault()
 				const joinPos = getMergeDragRowJoinPos(rows, blockIndex)
 				const newValue = mergeDragRows(value, rows, blockIndex)
-				store.selection.position(joinPos)
-				store.value.current(newValue)
+				store.edit.replace({start: 0, end: -1}, newValue, joinPos)
 				return
 			}
 			event.preventDefault()
@@ -116,8 +114,7 @@ function handleDelete(store: KbCtx, event: KeyboardEvent) {
 				event.preventDefault()
 				const joinPos = getMergeDragRowJoinPos(rows, blockIndex)
 				const newValue = mergeDragRows(value, rows, blockIndex)
-				store.selection.position(joinPos)
-				store.value.current(newValue)
+				store.edit.replace({start: 0, end: -1}, newValue, joinPos)
 				return
 			}
 			event.preventDefault()
@@ -132,8 +129,7 @@ function handleDelete(store: KbCtx, event: KeyboardEvent) {
 				event.preventDefault()
 				const joinPos = getMergeDragRowJoinPos(rows, blockIndex + 1)
 				const newValue = mergeDragRows(value, rows, blockIndex + 1)
-				store.selection.position(joinPos)
-				store.value.current(newValue)
+				store.edit.replace({start: 0, end: -1}, newValue, joinPos)
 				return
 			}
 			event.preventDefault()
@@ -174,8 +170,7 @@ function handleEnter(store: KbCtx, event: KeyboardEvent) {
 	if (!isTextLikeRow(token)) {
 		const newValue = addDragRow(value, rows, blockIndex, newRowContent)
 		const pos = token.position.end + newRowContent.length
-		store.selection.position(pos)
-		store.value.current(newValue)
+		store.edit.replace({start: 0, end: -1}, newValue, pos)
 		return
 	}
 

--- a/packages/core/src/features/keyboard/input.spec.ts
+++ b/packages/core/src/features/keyboard/input.spec.ts
@@ -1,7 +1,7 @@
 import {describe, it, expect, vi} from 'vitest'
 
 import {Store} from '../../store/Store'
-import {applySpanInput, enableInput, handleBeforeInput, replaceAllContentWith} from './input'
+import {applySpanInput, enableInput, handleBeforeInput} from './input'
 
 function mountStructuralInline(value = 'hello') {
 	const store = new Store()
@@ -67,21 +67,6 @@ describe('applySpanInput()', () => {
 		expect(event.preventDefault).toHaveBeenCalledOnce()
 		expect(focus.content).toBe('')
 		expect(focus.caret).toBe(0)
-	})
-})
-
-describe('replaceAllContentWith()', () => {
-	it('controlled full-content replace emits without committing current', () => {
-		const store = new Store()
-		const onChange = vi.fn()
-		store.props.set({value: 'hello', onChange})
-		store.lifecycle.mounted()
-
-		replaceAllContentWith(store, 'world')
-
-		expect(onChange).toHaveBeenCalledWith('world')
-		expect(store.value.current()).toBe('hello')
-		expect(store.tokens.current()).toEqual([{type: 'text', content: 'hello', position: {start: 0, end: 5}}])
 	})
 })
 

--- a/packages/core/src/features/keyboard/input.ts
+++ b/packages/core/src/features/keyboard/input.ts
@@ -60,7 +60,7 @@ function handleDeleteKey(store: KbCtx, event: KeyboardEvent): void {
 
 	if (store.selection.isAllSelected()) {
 		event.preventDefault()
-		replaceAllContentWith(store, '')
+		store.edit.replace({start: 0, end: -1}, '')
 		return
 	}
 
@@ -83,7 +83,7 @@ export function handleBeforeInput(store: KbCtx, event: InputEvent): void {
 		}
 		event.preventDefault()
 		const newContent = event.inputType.startsWith('delete') ? '' : (event.data ?? '')
-		replaceAllContentWith(store, newContent)
+		store.edit.replace({start: 0, end: -1}, newContent)
 		return
 	}
 
@@ -213,10 +213,5 @@ export function handlePaste(store: KbCtx, event: ClipboardEvent): void {
 	const c = store.dom.container()
 	const markup = c ? consumeMarkupPaste(c) : undefined
 	const newContent = markup ?? event.clipboardData?.getData('text/plain') ?? ''
-	replaceAllContentWith(store, newContent)
-}
-
-export function replaceAllContentWith(store: KbCtx, newContent: string): void {
-	store.selection.position(newContent.length)
-	store.value.current(newContent)
+	store.edit.replace({start: 0, end: -1}, newContent)
 }

--- a/packages/core/src/store/Store.ts
+++ b/packages/core/src/store/Store.ts
@@ -48,7 +48,7 @@ export class Store {
 		this.tokens,
 		this.props
 	)
-	readonly block = new BlockController(this.props, this.value, this.tokens, this.selection)
+	readonly block = new BlockController(this.props, this.value, this.tokens, this.selection, this.edit)
 	readonly clipboard = new ClipboardController(this.lifecycle, this.edit, this.dom, this.tokens)
 
 	readonly handler = new MarkputHandler(this.dom, this.overlay, this.selection)

--- a/packages/website/src/content/docs/development/architecture.md
+++ b/packages/website/src/content/docs/development/architecture.md
@@ -87,7 +87,7 @@ Both framework adapters share the same component structure:
         ↓
 3. store.dom maps the DOM selection or input target range to a raw value range
         ↓
-4. KeyboardController calls store.edit.replace() for single-range user edits, or writes store.caret.selection({start, end}) and store.value.current() for whole-value edits that are not expressed as one replacement range
+4. KeyboardController calls store.edit.replace() for every user edit — single-range or whole-value (whole-value writes pass {start: 0, end: -1} as the sentinel and a caretAt for the post-edit caret)
         ↓
 5. ValueModel updates uncontrolled state or notifies controlled parents
         ↓
@@ -100,7 +100,7 @@ Both framework adapters share the same component structure:
 9. DomController applies caret.selection to the DOM after the adapter registers the new DOM
 ```
 
-Single-range user mutations go through `store.edit.replace()`: features describe the raw range and replacement text, and the edit coordinator records the default post-edit caret before delegating to `store.value.replace()`. Lower-level raw value mutations still go through `store.value.replace()` or `store.value.current()`. `DomController` owns DOM-to-raw boundary mapping and applies `caret.selection` to the DOM after every render, while `ParseController` owns parser selection and string-to-token parsing.
+All user mutations go through `store.edit.replace()`: features describe the raw range (or `{start: 0, end: -1}` for whole-value writes) plus replacement text, and the edit coordinator places the post-edit caret — either at `range.start + replacement.length` or at an explicit `caretAt` argument — inside a single batch before delegating to `store.value.replace()`. Programmatic raw mutations may still call `store.value.replace()` or `store.value.current()`. `DomController` owns DOM-to-raw boundary mapping and applies `caret.selection` to the DOM after every render, while `ParseController` owns parser selection and string-to-token parsing.
 
 ### Trigger Flow (Overlay Opens)
 
@@ -319,7 +319,7 @@ class Store {
     readonly caret:     CaretModel         // selection, position (computed), isUserSelecting, isAllSelected
     readonly slots:     SlotsFeature       // isBlock, isDragEnabled, slot component/props, mark resolver
     readonly value:     ValueModel         // current, replace()
-    readonly edit:      EditController     // replace() — single-range user edit + caret intent
+    readonly edit:      EditController     // replace(range, replacement, caretAt?) — single batched write path
     readonly parsing:   ParseController    // tokens, parser, token index
     readonly dom:       DomController      // DOM refs, raw mapping, range placement
     readonly overlay:   OverlayController  // match, element, slot, select, close
@@ -368,7 +368,7 @@ Signal subscription order is significant: `ParseController` subscribes to `value
 | ----------------------------- | -------------------------------------------------------- |
 | **Lifecycle**                 | Mount/unmount/render lifecycle events                     |
 | **ValueModel**                | Accepted serialized value state, raw range replacement   |
-| **EditController**            | Single-range user edit coordination (value + caret intent) |
+| **EditController**            | Unified user edit path: `replace(range, replacement, caretAt?)`, `{end: -1}` resolves to current value length |
 | **ParseController**           | Token parsing, parser selection, reparse event            |
 | **OverlayController**         | Overlay trigger detection, position, open/close           |
 | **SlotsFeature**              | Container ref, slot component/props resolution, mark resolver |


### PR DESCRIPTION
## Summary

- All block and keyboard whole-value writes (`BlockController`, `blockEdit.ts`, `input.ts`) now go through `store.edit.replace()` instead of calling `store.selection.position()` + `store.value.current()` separately
- `EditController.replace` accepts optional `caretAt` to override the default post-edit caret position, used by drag operations where the desired position is not the natural end of the replacement
- `{start: 0, end: -1}` sentinel normalises to current value length for whole-value replacements
- Subscribers always observe a consistent value/selection pair in a single batch tick — eliminates the race where a `selection` watcher could read the old value after a two-step unbatched write

## Test plan

- [ ] `pnpm --filter @markput/core test --run` — all core tests pass
- [ ] `BlockController` spec: new tests for batched tick and no-op reorder skip
- [ ] `EditController` spec: new tests for explicit `caretAt`, negative `end` normalization on non-empty and empty values

🤖 Generated with [Claude Code](https://claude.com/claude-code)