### PR TITLE
refactor(core): replace Lifecycle with Host and clean up container usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,152 +8,83 @@ components through annotated markup patterns.
 Packages:
 
 - `packages/core/` (`@markput/core`): dependency-free TypeScript runtime.
-  Features live under `src/features/<feature-name>/`, shared utilities under
-  `src/shared/`.
 - `packages/react/markput/` (`@markput/react`): React adapter.
 - `packages/vue/markput/` (`@markput/vue`): Vue adapter.
 - `packages/storybook/` (`@markput/storybook`): shared stories and browser
-  tests. Test helpers in `src/shared/lib/`.
-- `packages/react/app/`, `packages/vue/app/`: E2E demo apps.
-- `packages/website/` (`@markput/website`): Astro/Starlight docs in
-  `src/content/docs/`.
+  tests for React and Vue.
+- `packages/react/app/`, `packages/vue/app/`: demo apps.
+- `packages/website/` (`@markput/website`): Astro/Starlight docs.
 
-Default branch: `next`. Shared dependency versions live in the pnpm catalog
-in `pnpm-workspace.yaml`. Use `pnpm` for everything.
+Default branch: `next`. Use `pnpm` for all installs and scripts. Shared
+dependency versions live in the pnpm catalog in `pnpm-workspace.yaml`.
 
 ## Commands
 
-- Setup: `pnpm install`, `pnpm exec playwright install chromium`
-- Focused test: `pnpm -w exec vitest run path/to/file.spec.ts`
+- Setup: `pnpm install`, then `pnpm exec playwright install chromium` when
+  browser tests are needed.
+- Focused test: `pnpm -w exec vitest run path/to/file.spec.ts`.
 - Full checks: `pnpm test`, `pnpm run build`, `pnpm run typecheck`,
-  `pnpm run lint:check`, `pnpm run format:check`
-- Fixers: `pnpm run lint`, `pnpm run format`
+  `pnpm run lint:check`, `pnpm run format:check`.
+- Fixers: `pnpm run lint`, `pnpm run format`.
 - Dev servers: `pnpm run dev`, `pnpm run dev:sb:react`,
-  `pnpm run dev:sb:vue`, `pnpm run dev:react:app`, `pnpm run dev:vue:app`
+  `pnpm run dev:sb:vue`, `pnpm run dev:react:app`, `pnpm run dev:vue:app`,
+  `pnpm run dev:website`.
 
-## Architecture Guardrails
+## Architecture Work
 
-Read `packages/website/src/content/docs/development/architecture.md` before
-changing core behavior, feature boundaries, token rendering, DOM mapping, or
-caret recovery.
+This file is an operating guide, not the architecture source of truth. Before
+changing core behavior, feature boundaries, token rendering, DOM mapping, caret
+recovery, or adapter wiring, read the relevant code and the current docs under
+`packages/website/src/content/docs/development/`.
 
-The Store orchestrates Signals, feature modules, DOM registration, value edits,
-caret recovery, the parser, BlockRegistry, and the event bus. Features
-communicate through `store.<feature>.*`, `store.props`, `store.dom`, and
-`store.caret`, never through direct feature imports.
+The core architecture is actively evolving. Do not preserve stale patterns just
+because they appear in older docs or comments. If code, tests, and docs
+disagree, verify the intended behavior and update the stale source as part of
+the change or call out the mismatch.
 
-Ownership rules:
+Keep ownership boundaries explicit. Runtime state should have one clear owner,
+DOM-to-token questions should go through the DOM/mapping layer that owns them,
+and framework adapters should not reach into core internals unless that is the
+public contract being changed.
 
-- `store.props`: framework-provided configuration. Set via `store.props.set()`.
-- `store.dom`: DOM refs, structural registration, and DOM-to-token mapping.
-- `store.value`: accepted serialized value and replacement APIs.
-- `store.caret`: caret state (`range: Signal<RawRange | undefined>`).
-- `store.slots`: slot components and slot props.
-- Parser: token addresses and the token index derived from options, drag mode,
-  and Mark components.
+## Engineering Defaults
 
-Hard rules:
+- Reuse before adding. Search for existing utilities, hooks, helpers, and test
+  helpers before introducing new ones.
+- Upgrade a close existing abstraction instead of forking a near-duplicate.
+- Push back on over-engineered specs, hidden scope creep, mirrored state, DOM
+  guesses, duplicated parsing/serialization, ad-hoc caches, and untyped
+  boundaries.
+- Prefer clear, direct code over clever code. Performance claims need a
+  benchmark or a documented hot path.
+- Comments should explain constraints or non-obvious trade-offs, not narrate
+  what the code already says.
 
-- Do not mirror runtime state across features. If two features need the same
-  fact, expose it from the feature or store object that owns that fact.
-- DOM/token mapping must go through `store.dom`. Do not infer token location
-  outside `DomController` from DOM child order, public data attributes, user refs,
-  or framework-rendered wrapper shape.
-- User value mutations must go through `store.value.replace()` or
-  `store.value.current()` with raw positions. Callers that want a specific
-  post-edit caret write `store.caret.range({start, end})` in the same handler.
-  Do not write `store.value.current()` directly for user edits.
-- Token objects are parse results, not durable identities. Do not keep a token
-  object for later mutation or comparison across edits; use token addresses,
-  shape snapshots, or clone the token state before comparing.
-- New reactive state must live in the owner of the underlying concept. Do not
-  add ad-hoc Signals that mirror state already owned by another feature.
-- Components depend on the smallest established abstraction that fits: prefer
-  `store.dom`, `store.value`, `store.caret`, `store.parsing`, and slot APIs
-  over direct cross-feature imports or DOM guesses.
-- Temporary compatibility bridges must be named, documented as temporary, and
-  include the condition for removal once the owning feature exists.
+## Testing
 
-## Reuse Before You Add
-
-Before writing a new util, helper, hook, type, or abstraction, search for one
-that already does almost the same thing.
-
-- If an existing util is close but not quite right, **upgrade it** instead of
-  forking a near-duplicate. Adjust its signature, add an option, generalize
-  the implementation.
-- If two places solve the same problem differently, surface the inconsistency
-  and propose a single shared owner.
-- New abstractions need a justification. "Slightly different shape" is not
-  one. "Three callers need this and the existing util cannot represent X" is.
-
-## Spec, Plan, and Architecture Review
-
-When you receive a spec, plan, or design — even a small one — review it before
-implementing. Push back early, not after the code is written.
-
-Flag and propose alternatives for:
-
-- **Over-engineering**: configuration knobs nobody asked for, premature
-  generic types, layers of indirection for a single call site, "future-proof"
-  extension points without a concrete second use case.
-- **Scope creep**: changes that quietly grow beyond the stated goal.
-- **Bad architecture**: state mirrored between features, DOM inferred without
-  `store.dom`, parser logic leaking into adapters, framework code reaching
-  into core internals, abstractions that hide a single concrete behavior.
-- **Code smells**: deep parameter chains, boolean flags driving branches,
-  duplicated parsing/serialization, ad-hoc caches, untyped `any` boundaries.
-
-When something looks dramatically wrong or wasteful, say so plainly and
-propose a concrete better approach. Do not silently implement a bad request.
-
-## Code Quality
-
-- Prefer **clear, readable code** over clever or micro-optimized code. A
-  slower-but-obvious implementation is acceptable unless a benchmark in
-  `packages/core/` or a documented hot path says otherwise. Performance
-  trade-offs need a measurement, not a hunch.
-- Names describe intent, not type or implementation.
-- Functions do one thing. Split when a function needs a comment to explain
-  what its halves do.
-- Avoid comments that narrate the code. Comments explain _why_, constraints,
-  or non-obvious trade-offs.
-
-## Testing Policy
-
-- Test files: `*.spec.ts`, `*.spec.tsx`, or framework-specific storybook
+- Test files are `*.spec.ts`, `*.spec.tsx`, or framework-specific Storybook
   names. Do not add `*.test.ts`.
 - Core unit tests live next to the source and use Vitest.
-- Test names use imperative present without "should":
+- Test names use imperative present without "should", for example
   `it('returns undefined when token missing')`.
 - Parser tests use `toMatchInlineSnapshot()` with `tokensToDebugTree()`.
 - Use `@faker-js/faker` for generated test data.
 - Storybook files live in `packages/storybook/src/pages/` as
   `*.react.stories.tsx`, `*.react.spec.tsx`, `*.vue.stories.ts`, or
   `*.vue.spec.ts`.
-- Browser tests compose Storybook stories and use real Vitest Browser Mode
-  with Playwright. Reuse focus helpers from
-  `packages/storybook/src/shared/lib/focus.ts`; Vue tests can use
-  `withProps()` from `packages/storybook/src/shared/lib/testUtils.vue.ts`.
-- Keep core public functions covered by co-located unit tests.
+- Browser tests use real Vitest Browser Mode with Playwright. Reuse shared
+  helpers from `packages/storybook/src/shared/lib/`.
 
-### HTML / DOM Snapshot Failures
+### Snapshot Failures
 
-When an HTML or DOM snapshot test fails, **do not regenerate it
-automatically**. The snapshot is the contract.
-
-1. Diff the old vs new structure and explain _why_ it changed.
-2. Verify the new structure is intentional: same semantic shape, expected
-   nesting, no accidental extra wrappers, attribute order or ARIA roles
-   preserved where they matter.
-3. If the change is correct, update the snapshot and note in the PR what
-   structural change caused it.
-4. If you cannot explain the diff, treat it as a regression.
+Do not regenerate HTML or DOM snapshots automatically. First diff the old and
+new structure, explain why it changed, and verify the new structure is
+intentional. If you cannot explain the diff, treat it as a regression.
 
 ## Checks
 
-For code, behavior, public API, package config, or build config changes, run
-before finalizing:
+For code, behavior, public API, package config, or build config changes, run the
+full checks when practical:
 
 1. `pnpm test`
 2. `pnpm run build`
@@ -161,24 +92,20 @@ before finalizing:
 4. `pnpm run lint:check`
 5. `pnpm run format:check`
 
-Focused checks are fine during iteration. Report any skipped check with the
+Focused checks are fine during iteration. Report skipped checks with the
 reason.
 
-For docs-only changes, run `pnpm exec oxfmt --check <changed-files>` (or note
-that the file is excluded by `oxfmt.config.ts`). For changes under
-`packages/website/src/content/docs/**` that touch MDX, frontmatter,
-navigation, or config, also run `pnpm -F @markput/website run build`.
+For docs-only changes, run `pnpm exec oxfmt --check <changed-files>` or note
+that the file is excluded by `oxfmt.config.ts`. For website docs changes that
+touch MDX, frontmatter, navigation, or config, also run
+`pnpm -F @markput/website run build`.
 
-Update `packages/website/src/content/docs/` whenever public API, behavior, or
-architecture changes. If runtime behavior and docs disagree, fix the docs or
-flag the inconsistency.
+Update docs under `packages/website/src/content/docs/` whenever public API,
+behavior, or settled architecture changes.
 
-## Communication With This User
+## Communication
 
-- The user is not a native English speaker. When useful, you may add a short
-  "**Language tips**" section for unclear or ungrammatical phrasing from their
-  last message: give the corrected version and briefly say why. Keep it 2-5
-  lines, friendly, not pedantic. Do not force this section on every reply.
-- Ask before installing dependencies or editing the `pnpm-workspace.yaml`
-  catalog.
+- Ask when requirements are unclear.
+- The user is not a native English speaker. When useful, add a short
+  "**Language tips**" section with a corrected phrase and brief explanation.
 - PR titles use Conventional Commits.

--- a/packages/core/src/features/block/BlockController.spec.ts
+++ b/packages/core/src/features/block/BlockController.spec.ts
@@ -19,7 +19,7 @@ describe('BlockController', () => {
 				value: 'test',
 				onChange: () => {},
 			})
-			store.lifecycle.mounted()
+			store.host.mounted()
 
 			// disable drag
 			store.props.set({layout: 'inline', draggable: false})
@@ -42,7 +42,7 @@ describe('BlockController', () => {
 			Mark: () => null,
 			options: [{markup: '__slot__\n\n'}],
 		})
-		store.lifecycle.mounted()
+		store.host.mounted()
 		store.value.current('alpha\n\nbeta\n\n')
 		const currentSpy = vi.spyOn(store.value, 'current')
 
@@ -59,7 +59,7 @@ describe('BlockController', () => {
 			Mark: () => null,
 			options: [{markup: '__slot__\n\n'}],
 		})
-		store.lifecycle.mounted()
+		store.host.mounted()
 		store.value.current('alpha\n\nbeta\n\n')
 
 		let runs = 0
@@ -83,7 +83,7 @@ describe('BlockController', () => {
 			Mark: () => null,
 			options: [{markup: '__slot__\n\n'}],
 		})
-		store.lifecycle.mounted()
+		store.host.mounted()
 		store.value.current('alpha\n\nbeta\n\n')
 		const replaceSpy = vi.spyOn(store.value, 'replace')
 		const positionSpy = vi.spyOn(store.selection, 'position')

--- a/packages/core/src/features/block/BlockController.spec.ts
+++ b/packages/core/src/features/block/BlockController.spec.ts
@@ -19,8 +19,6 @@ describe('BlockController', () => {
 				value: 'test',
 				onChange: () => {},
 			})
-			store.host.mounted()
-
 			// disable drag
 			store.props.set({layout: 'inline', draggable: false})
 
@@ -42,7 +40,6 @@ describe('BlockController', () => {
 			Mark: () => null,
 			options: [{markup: '__slot__\n\n'}],
 		})
-		store.host.mounted()
 		store.value.current('alpha\n\nbeta\n\n')
 		const currentSpy = vi.spyOn(store.value, 'current')
 
@@ -59,7 +56,6 @@ describe('BlockController', () => {
 			Mark: () => null,
 			options: [{markup: '__slot__\n\n'}],
 		})
-		store.host.mounted()
 		store.value.current('alpha\n\nbeta\n\n')
 
 		let runs = 0
@@ -83,7 +79,6 @@ describe('BlockController', () => {
 			Mark: () => null,
 			options: [{markup: '__slot__\n\n'}],
 		})
-		store.host.mounted()
 		store.value.current('alpha\n\nbeta\n\n')
 		const replaceSpy = vi.spyOn(store.value, 'replace')
 		const positionSpy = vi.spyOn(store.selection, 'position')

--- a/packages/core/src/features/clipboard/ClipboardController.ts
+++ b/packages/core/src/features/clipboard/ClipboardController.ts
@@ -8,15 +8,12 @@ import {MARKPUT_MIME} from './pasteMarkup'
 
 export class ClipboardController {
 	constructor(
-		private readonly host: Host,
-		private readonly edit: EditController,
+		host: Host,
+		edit: EditController,
 		private readonly dom: DomModel,
 		private readonly tokens: TokenModel
 	) {
-		host.onMounted(() => {
-			const container = host.container()
-			if (!container) return
-
+		host.onMounted(container => {
 			listen(container, 'copy', e => {
 				this.#handleCopy(e)
 			})

--- a/packages/core/src/features/clipboard/ClipboardController.ts
+++ b/packages/core/src/features/clipboard/ClipboardController.ts
@@ -3,18 +3,18 @@ import type {DomModel} from '../dom/DomModel'
 import type {EditController} from '../edit'
 import type {TokenModel} from '../parsing/TokenModel'
 import {serializeRange} from '../parsing/utils/serializeRange'
-import type {Lifecycle} from '../state/Lifecycle'
+import type {Host} from '../state/Host'
 import {MARKPUT_MIME} from './pasteMarkup'
 
 export class ClipboardController {
 	constructor(
-		private readonly lifecycle: Lifecycle,
+		private readonly host: Host,
 		private readonly edit: EditController,
 		private readonly dom: DomModel,
 		private readonly tokens: TokenModel
 	) {
-		lifecycle.onMounted(() => {
-			const container = dom.container()
+		host.onMounted(() => {
+			const container = host.container()
 			if (!container) return
 
 			listen(container, 'copy', e => {

--- a/packages/core/src/features/dom/DomIndexer.ts
+++ b/packages/core/src/features/dom/DomIndexer.ts
@@ -5,7 +5,7 @@ import type {Token} from '../parsing'
 import {pathEquals, pathKey} from '../parsing/tokenIndex'
 import type {TokenIndex} from '../parsing/tokenIndex'
 import type {TokenModel} from '../parsing/TokenModel'
-import type {Lifecycle} from '../state/Lifecycle'
+import type {Host} from '../state/Host'
 import type {PropsModel} from '../state/PropsModel'
 
 export type RegisteredRole =
@@ -53,15 +53,15 @@ export class DomIndexer {
 
 	constructor(
 		private readonly host: DomIndexerHost,
-		private readonly lifecycle: Lifecycle,
+		hostModel: Host,
 		private readonly props: PropsModel,
 		private readonly tokens: TokenModel
 	) {
-		lifecycle.onMounted(() => {
-			// Container mounts before MarkedInput, so the first lifecycle.rendered()
-			// is emitted before this watch subscribes. Run the initial commit here
-			// instead of relying on a follow-up rendered event.
-			watch(lifecycle.rendered, () => this.#handleRendered(), {immediate: true})
+		hostModel.onMounted(() => {
+			// Container mounts before MarkedInput, so the first rendered() event
+			// is emitted before this watch subscribes. Run the initial commit
+			// here instead of relying on a follow-up rendered event.
+			watch(hostModel.rendered, () => this.#handleRendered(), {immediate: true})
 			watch(props.readOnly, () => this.reconcile())
 			watch(host.isUserSelecting, () => this.reconcile())
 		})

--- a/packages/core/src/features/dom/DomModel.spec.ts
+++ b/packages/core/src/features/dom/DomModel.spec.ts
@@ -6,7 +6,7 @@ import {Store} from '../../store/Store'
 function enableStructuralStore(value: string, props: Parameters<Store['props']['set']>[0] = {}) {
 	const store = new Store()
 	store.props.set({defaultValue: value, ...props})
-	store.lifecycle.mounted()
+	store.host.mounted()
 	return store
 }
 
@@ -16,8 +16,8 @@ function mountStructuralInline(value: string) {
 	const textSurface = document.createElement('span')
 	container.append(textSurface)
 	document.body.append(container)
-	store.dom.container(container)
-	store.lifecycle.rendered()
+	store.host.container(container)
+	store.host.rendered()
 	const textNode = textSurface.firstChild
 	if (!(textNode instanceof Text)) throw new Error('Structural text surface did not render a text node')
 	return {store, container, textSurface, textNode}
@@ -31,8 +31,8 @@ function mountStructuralInlineMark(value = 'hello @[world]') {
 	const after = document.createElement('span')
 	container.append(before, mark, after)
 	document.body.append(container)
-	store.dom.container(container)
-	store.lifecycle.rendered()
+	store.host.container(container)
+	store.host.rendered()
 	return {store, container, before, mark, after}
 }
 
@@ -48,8 +48,8 @@ function mountStructuralNested(value = '@[before @[nested] after]') {
 	outer.append(before, inner, after)
 	container.append(leading, outer, trailing)
 	document.body.append(container)
-	store.dom.container(container)
-	store.lifecycle.rendered()
+	store.host.container(container)
+	store.host.rendered()
 	return {store, container, leading, outer, before, inner, after, trailing}
 }
 
@@ -70,9 +70,9 @@ function mountStructuralNestedWithChildSequence(value = '@[before @[nested] afte
 	outer.append(control, host)
 	container.append(leading, outer, trailing)
 	document.body.append(container)
-	store.dom.container(container)
+	store.host.container(container)
 	store.dom.childrenFor([1])(host)
-	store.lifecycle.rendered()
+	store.host.rendered()
 	return {store, container, leading, outer, control, host, before, inner, after, trailing}
 }
 
@@ -87,7 +87,7 @@ function mountStructuralNestedWithDuplicateChildSequences(value = '@[before @[ne
 	outer.append(hostA, hostB)
 	container.append(leading, outer, trailing)
 	document.body.append(container)
-	store.dom.container(container)
+	store.host.container(container)
 	store.dom.childrenFor([1])(hostA)
 	store.dom.childrenFor([1])(hostB)
 	return {store, container, outer, hostA, hostB}
@@ -103,7 +103,7 @@ function mountStructuralNestedWithOutsideChildSequence(value = '@[before @[neste
 	leading.append(outsideHost)
 	container.append(leading, outer, trailing)
 	document.body.append(container)
-	store.dom.container(container)
+	store.host.container(container)
 	store.dom.childrenFor([1])(outsideHost)
 	return {store, container, outer, outsideHost}
 }
@@ -118,9 +118,9 @@ function mountStructuralBlockWithControl(value: string) {
 	row.append(control, textSurface)
 	container.append(row)
 	document.body.append(container)
-	store.dom.container(container)
+	store.host.container(container)
 	store.dom.controlFor([0])(control)
-	store.lifecycle.rendered()
+	store.host.rendered()
 	const textNode = textSurface.firstChild
 	const controlText = control.firstChild
 	if (!(textNode instanceof Text)) throw new Error('Structural block text surface did not render a text node')
@@ -140,10 +140,10 @@ function mountStructuralBlockWithControls(value: string) {
 	row.append(beforeControl, textSurface, afterControl)
 	container.append(row)
 	document.body.append(container)
-	store.dom.container(container)
+	store.host.container(container)
 	store.dom.controlFor([0])(beforeControl)
 	store.dom.controlFor([0])(afterControl)
-	store.lifecycle.rendered()
+	store.host.rendered()
 	const textNode = textSurface.firstChild
 	if (!(textNode instanceof Text)) throw new Error('Structural block text surface did not render a text node')
 	return {store, container, row, beforeControl, afterControl, textSurface, textNode}
@@ -157,18 +157,6 @@ describe('DomModel structural indexing', () => {
 		store = new Store()
 		store.props.set({Mark: () => null, options: [{markup: '@[__value__]'}]})
 		store.value.current('hello @[world]')
-	})
-
-	it('owns the container ref signal', () => {
-		const container = document.createElement('div')
-
-		store.dom.container(container)
-
-		expect(store.dom.container()).toBe(container)
-
-		store.dom.container(null)
-
-		expect(store.dom.container()).toBe(null)
 	})
 
 	it('publishes one dom index per rendered commit', () => {
@@ -257,7 +245,7 @@ describe('DomModel structural indexing', () => {
 	it('completes indexing when duplicate child sequence hosts are registered', () => {
 		const {store, container, outer} = mountStructuralNestedWithDuplicateChildSequences()
 
-		store.lifecycle.rendered()
+		store.host.rendered()
 
 		expect(store.dom.isIndexed()).toBe(true)
 		expect(store.dom.locateNode(outer)).toMatchObject({ok: true})
@@ -267,7 +255,7 @@ describe('DomModel structural indexing', () => {
 	it('completes indexing when child sequence host is outside owner mark root', () => {
 		const {store, container, outer} = mountStructuralNestedWithOutsideChildSequence()
 
-		store.lifecycle.rendered()
+		store.host.rendered()
 
 		expect(store.dom.isIndexed()).toBe(true)
 		expect(store.dom.locateNode(outer)).toMatchObject({ok: true})
@@ -304,8 +292,8 @@ describe('DomModel structural indexing', () => {
 		const trailing = document.createElement('span')
 		container.append(leading, outer, trailing)
 		document.body.append(container)
-		store.dom.container(container)
-		store.lifecycle.rendered()
+		store.host.container(container)
+		store.host.rendered()
 
 		expect(store.dom.isIndexed()).toBe(true)
 		expect(store.dom.locateNode(outer)).toMatchObject({ok: true})
@@ -316,7 +304,7 @@ describe('DomModel structural indexing', () => {
 		const {store, container} = mountStructuralInline('hello')
 
 		store.selection.range({start: 999, end: 999})
-		store.lifecycle.rendered()
+		store.host.rendered()
 
 		expect(store.selection.range()).toEqual({start: 5, end: 5})
 		container.remove()
@@ -326,7 +314,7 @@ describe('DomModel structural indexing', () => {
 		const {store, container} = mountStructuralInline('hello')
 
 		store.selection.range({start: 999, end: 1000})
-		store.lifecycle.rendered()
+		store.host.rendered()
 
 		expect(store.selection.range()).toEqual({start: 5, end: 5})
 		container.remove()
@@ -336,7 +324,7 @@ describe('DomModel structural indexing', () => {
 		const {store, container, textNode} = mountStructuralInline('hello')
 
 		store.selection.range({start: 3, end: 3})
-		store.lifecycle.rendered()
+		store.host.rendered()
 
 		const sel = window.getSelection()
 		expect(sel?.focusNode).toBe(textNode)
@@ -347,7 +335,7 @@ describe('DomModel structural indexing', () => {
 	it('clamps OOB range and places caret at clamped position', () => {
 		const {store, container} = mountStructuralInline('hello') // length 5
 		store.selection.range({start: 999, end: 999})
-		store.lifecycle.rendered()
+		store.host.rendered()
 
 		// clamped to maxPos (5); structural equality prevents re-fire
 		expect(store.selection.range()).toEqual({start: 5, end: 5})
@@ -358,7 +346,7 @@ describe('DomModel structural indexing', () => {
 		const {store, container} = mountStructuralInline('hello')
 		store.selection.range({start: 2, end: 2})
 		store.dom.isUserSelecting(true)
-		store.lifecycle.rendered()
+		store.host.rendered()
 
 		expect(store.selection.range()).toEqual({start: 2, end: 2})
 		container.remove()
@@ -395,7 +383,7 @@ describe('DomModel structural indexing', () => {
 			mark.append(descendant)
 			const descendantText = descendant.firstChild
 			if (!(descendantText instanceof Text)) throw new Error('Mark descendant did not render a text node')
-			store.lifecycle.rendered()
+			store.host.rendered()
 
 			expect(store.dom.rawPositionFromBoundary(descendantText, 0, 'after')).toEqual({
 				ok: false,
@@ -424,12 +412,12 @@ describe('DomModel structural indexing', () => {
 			const container = document.createElement('div')
 			document.body.appendChild(container)
 			store.props.set({defaultValue: 'hi'})
-			store.lifecycle.mounted()
-			store.dom.container(container)
+			store.host.mounted()
+			store.host.container(container)
 
 			const fired = vi.fn()
 			watch(store.dom.indexed, fired)
-			store.lifecycle.rendered()
+			store.host.rendered()
 			expect(fired).toHaveBeenCalledTimes(1)
 			container.remove()
 		})
@@ -441,9 +429,9 @@ describe('DomModel structural indexing', () => {
 			container.appendChild(span)
 			document.body.appendChild(container)
 			store.props.set({defaultValue: 'hello'})
-			store.lifecycle.mounted()
-			store.dom.container(container)
-			store.lifecycle.rendered()
+			store.host.mounted()
+			store.host.container(container)
+			store.host.rendered()
 
 			store.dom.isUserSelecting(true)
 			expect(span.contentEditable).toBe('false')
@@ -465,9 +453,9 @@ describe('DomModel structural indexing', () => {
 			document.body.appendChild(container)
 
 			store.props.set({defaultValue: ''})
-			store.dom.container(container)
-			store.lifecycle.mounted()
-			store.lifecycle.rendered()
+			store.host.container(container)
+			store.host.mounted()
+			store.host.rendered()
 
 			const focusSpy = vi.spyOn(span, 'focus')
 			container.dispatchEvent(new MouseEvent('click', {bubbles: true}))

--- a/packages/core/src/features/dom/DomModel.spec.ts
+++ b/packages/core/src/features/dom/DomModel.spec.ts
@@ -6,7 +6,6 @@ import {Store} from '../../store/Store'
 function enableStructuralStore(value: string, props: Parameters<Store['props']['set']>[0] = {}) {
 	const store = new Store()
 	store.props.set({defaultValue: value, ...props})
-	store.host.mounted()
 	return store
 }
 
@@ -412,7 +411,6 @@ describe('DomModel structural indexing', () => {
 			const container = document.createElement('div')
 			document.body.appendChild(container)
 			store.props.set({defaultValue: 'hi'})
-			store.host.mounted()
 			store.host.container(container)
 
 			const fired = vi.fn()
@@ -429,7 +427,6 @@ describe('DomModel structural indexing', () => {
 			container.appendChild(span)
 			document.body.appendChild(container)
 			store.props.set({defaultValue: 'hello'})
-			store.host.mounted()
 			store.host.container(container)
 			store.host.rendered()
 
@@ -454,7 +451,6 @@ describe('DomModel structural indexing', () => {
 
 			store.props.set({defaultValue: ''})
 			store.host.container(container)
-			store.host.mounted()
 			store.host.rendered()
 
 			const focusSpy = vi.spyOn(span, 'focus')

--- a/packages/core/src/features/dom/DomModel.ts
+++ b/packages/core/src/features/dom/DomModel.ts
@@ -9,7 +9,7 @@ import type {
 import {event, signal} from '../../shared/signals/index.js'
 import type {Signal} from '../../shared/signals/index.js'
 import type {TokenModel} from '../parsing/TokenModel'
-import type {Lifecycle} from '../state/Lifecycle'
+import type {Host} from '../state/Host'
 import type {PropsModel} from '../state/PropsModel'
 import {DomBoundary} from './DomBoundary'
 import type {DomBoundaryHost} from './DomBoundary'
@@ -17,7 +17,6 @@ import {DomIndexer} from './DomIndexer'
 import type {ChildSequenceRegistration, ControlRegistration, DomIndexerHost, PathElements} from './DomIndexer'
 
 export class DomModel {
-	readonly container = signal<HTMLElement | null>({initial: null})
 	readonly indexed = event<void>()
 	readonly isUserSelecting = signal<boolean>({initial: false})
 
@@ -31,19 +30,23 @@ export class DomModel {
 	readonly #boundary: DomBoundary
 	readonly isIndexed: Signal<boolean>
 
-	constructor(lifecycle: Lifecycle, props: PropsModel, tokens: TokenModel) {
+	constructor(
+		private readonly host: Host,
+		props: PropsModel,
+		tokens: TokenModel
+	) {
 		const indexerHost: DomIndexerHost = {
-			container: () => this.container(),
+			container: () => this.host.container(),
 			pendingControls: () => this.#pendingControls.values(),
 			pendingChildSequences: () => this.#pendingChildSequences.values(),
 			emitIndexed: () => this.indexed(),
 			isUserSelecting: this.isUserSelecting,
 		}
-		this.#indexer = new DomIndexer(indexerHost, lifecycle, props, tokens)
+		this.#indexer = new DomIndexer(indexerHost, host, props, tokens)
 		this.isIndexed = this.#indexer.isIndexed
 
 		const boundaryHost: DomBoundaryHost = {
-			container: () => this.container(),
+			container: () => this.host.container(),
 			isIndexed: () => this.isIndexed(),
 			isComposing: () => this.#isComposing,
 			locateNode: node => this.#indexer.locateNode(node),

--- a/packages/core/src/features/dom/README.md
+++ b/packages/core/src/features/dom/README.md
@@ -4,18 +4,18 @@ Owns rendered DOM structure, token-to-element indexing, raw boundary mapping, an
 
 ## Layout
 
-- `DomModel.ts` — public facade exposed as `store.dom`. Owns `container`, ref registries (`controlFor` / `childrenFor`), composition flags, the click-on-empty listener, and the `index` / `indexed` / `readOnly` surface. Exposes read-only views into the index (`locateNode`, `pathElements`, `pathElementsFor`) and the boundary mapping (`rawPositionFromBoundary`, `readRawSelection`).
-- `DomIndexer.ts` — rebuilds the token-to-element index after `lifecycle.rendered`, keeps `#pathElements` / `#elementRoles` in sync, and reconciles structural text surfaces (text content + `contentEditable`) when `props.readOnly` changes or selection mode toggles.
+- `DomModel.ts` — public facade exposed as `store.dom`. Reads the host element from `store.host.container`. Owns control/child-sequence ref registries (`controlFor` / `childrenFor`), composition flags, and the `index` / `indexed` / `readOnly` surface. Exposes read-only views into the index (`locateNode`, `pathElements`, `pathElementsFor`) and the boundary mapping (`rawPositionFromBoundary`, `readRawSelection`).
+- `DomIndexer.ts` — rebuilds the token-to-element index after `host.rendered`, keeps `#pathElements` / `#elementRoles` in sync, and reconciles structural text surfaces (text content + `contentEditable`) when `props.readOnly` changes or selection mode toggles.
 - `DomBoundary.ts` — converts DOM `(node, offset)` boundaries and the current browser selection into raw value positions. Used by the value pipeline and keyboard handlers.
 - `textOffsets.ts` — pure helpers for walking text content (`textOffsetWithin`, `textLength`, `hasEditableAncestorBefore`, etc.). Also consumed by `SelectionController`'s inlined placement helpers.
 
 ## Registration
 
-React/Vue register the root through `store.dom.container` and block controls through `store.dom.controlFor()`. Mark child slots use `store.dom.childrenFor()`.
+React/Vue register the root through `store.host.container` and register block controls through `store.dom.controlFor()`. Mark child slots use `store.dom.childrenFor()`.
 
 ## Indexing
 
-The index is built after `lifecycle.rendered()` from direct rendered token roots. Out-of-shape DOM trees are surfaced through the indexed status, not through thrown errors.
+The index is built after `host.rendered()` from direct rendered token roots. Out-of-shape DOM trees are surfaced through the indexed status, not through thrown errors.
 
 ## Notes
 

--- a/packages/core/src/features/edit/EditController.spec.ts
+++ b/packages/core/src/features/edit/EditController.spec.ts
@@ -12,8 +12,6 @@ describe('EditController', () => {
 	it('replaces value and places caret after replacement', () => {
 		const store = new Store()
 		store.props.set({defaultValue: 'hello world'})
-		store.host.mounted()
-
 		store.edit.replace({start: 6, end: 11}, 'markput')
 
 		expect(store.value.current()).toBe('hello markput')
@@ -23,8 +21,6 @@ describe('EditController', () => {
 	it('places caret at range start when deleting', () => {
 		const store = new Store()
 		store.props.set({defaultValue: 'hello world'})
-		store.host.mounted()
-
 		store.edit.replace({start: 5, end: 11}, '')
 
 		expect(store.value.current()).toBe('hello')
@@ -35,7 +31,6 @@ describe('EditController', () => {
 		const store = new Store()
 		const onChange = vi.fn()
 		store.props.set({defaultValue: 'hello', onChange})
-		store.host.mounted()
 		store.selection.position(2)
 
 		store.edit.replace({start: 4, end: 2}, 'x')
@@ -49,7 +44,6 @@ describe('EditController', () => {
 		const store = new Store()
 		const onChange = vi.fn()
 		store.props.set({defaultValue: 'hello', readOnly: true, onChange})
-		store.host.mounted()
 		store.selection.position(1)
 
 		store.edit.replace({start: 1, end: 4}, 'i')
@@ -63,8 +57,6 @@ describe('EditController', () => {
 		const store = new Store()
 		const onChange = vi.fn()
 		store.props.set({value: 'hello', onChange})
-		store.host.mounted()
-
 		store.edit.replace({start: 0, end: 5}, 'world')
 
 		expect(onChange).toHaveBeenCalledWith('world')
@@ -75,8 +67,6 @@ describe('EditController', () => {
 	it('honors explicit caretAt over the natural end of the replacement', () => {
 		const store = new Store()
 		store.props.set({defaultValue: 'hello world'})
-		store.host.mounted()
-
 		store.edit.replace({start: 0, end: 5}, 'hi', 0)
 
 		expect(store.value.current()).toBe('hi world')
@@ -86,8 +76,6 @@ describe('EditController', () => {
 	it('normalizes negative range.end to the current value length', () => {
 		const store = new Store()
 		store.props.set({defaultValue: 'hello world'})
-		store.host.mounted()
-
 		store.edit.replace({start: 0, end: -1}, 'replaced')
 
 		expect(store.value.current()).toBe('replaced')
@@ -96,8 +84,6 @@ describe('EditController', () => {
 
 	it('normalizes negative range.end on an empty value', () => {
 		const store = new Store()
-		store.host.mounted()
-
 		store.edit.replace({start: 0, end: -1}, 'first')
 
 		expect(store.value.current()).toBe('first')

--- a/packages/core/src/features/edit/EditController.spec.ts
+++ b/packages/core/src/features/edit/EditController.spec.ts
@@ -12,7 +12,7 @@ describe('EditController', () => {
 	it('replaces value and places caret after replacement', () => {
 		const store = new Store()
 		store.props.set({defaultValue: 'hello world'})
-		store.lifecycle.mounted()
+		store.host.mounted()
 
 		store.edit.replace({start: 6, end: 11}, 'markput')
 
@@ -23,7 +23,7 @@ describe('EditController', () => {
 	it('places caret at range start when deleting', () => {
 		const store = new Store()
 		store.props.set({defaultValue: 'hello world'})
-		store.lifecycle.mounted()
+		store.host.mounted()
 
 		store.edit.replace({start: 5, end: 11}, '')
 
@@ -35,7 +35,7 @@ describe('EditController', () => {
 		const store = new Store()
 		const onChange = vi.fn()
 		store.props.set({defaultValue: 'hello', onChange})
-		store.lifecycle.mounted()
+		store.host.mounted()
 		store.selection.position(2)
 
 		store.edit.replace({start: 4, end: 2}, 'x')
@@ -49,7 +49,7 @@ describe('EditController', () => {
 		const store = new Store()
 		const onChange = vi.fn()
 		store.props.set({defaultValue: 'hello', readOnly: true, onChange})
-		store.lifecycle.mounted()
+		store.host.mounted()
 		store.selection.position(1)
 
 		store.edit.replace({start: 1, end: 4}, 'i')
@@ -63,7 +63,7 @@ describe('EditController', () => {
 		const store = new Store()
 		const onChange = vi.fn()
 		store.props.set({value: 'hello', onChange})
-		store.lifecycle.mounted()
+		store.host.mounted()
 
 		store.edit.replace({start: 0, end: 5}, 'world')
 
@@ -75,7 +75,7 @@ describe('EditController', () => {
 	it('honors explicit caretAt over the natural end of the replacement', () => {
 		const store = new Store()
 		store.props.set({defaultValue: 'hello world'})
-		store.lifecycle.mounted()
+		store.host.mounted()
 
 		store.edit.replace({start: 0, end: 5}, 'hi', 0)
 
@@ -86,7 +86,7 @@ describe('EditController', () => {
 	it('normalizes negative range.end to the current value length', () => {
 		const store = new Store()
 		store.props.set({defaultValue: 'hello world'})
-		store.lifecycle.mounted()
+		store.host.mounted()
 
 		store.edit.replace({start: 0, end: -1}, 'replaced')
 
@@ -96,7 +96,7 @@ describe('EditController', () => {
 
 	it('normalizes negative range.end on an empty value', () => {
 		const store = new Store()
-		store.lifecycle.mounted()
+		store.host.mounted()
 
 		store.edit.replace({start: 0, end: -1}, 'first')
 

--- a/packages/core/src/features/keyboard/KeyboardController.ts
+++ b/packages/core/src/features/keyboard/KeyboardController.ts
@@ -2,7 +2,7 @@ import type {DomModel} from '../dom/DomModel'
 import type {EditController} from '../edit'
 import type {TokenModel} from '../parsing/TokenModel'
 import type {SelectionController} from '../selection/SelectionController'
-import type {Lifecycle} from '../state/Lifecycle'
+import type {Host} from '../state/Host'
 import type {PropsModel} from '../state/PropsModel'
 import type {ValueModel} from '../state/ValueModel'
 import {enableArrowNav} from './arrowNav'
@@ -11,7 +11,7 @@ import {enableInput} from './input'
 
 export class KeyboardController {
 	constructor(
-		lifecycle: Lifecycle,
+		host: Host,
 		dom: DomModel,
 		value: ValueModel,
 		selection: SelectionController,
@@ -19,8 +19,8 @@ export class KeyboardController {
 		tokens: TokenModel,
 		props: PropsModel
 	) {
-		const ctx = {dom, value, selection, edit, tokens, props}
-		lifecycle.onMounted(() => {
+		const ctx = {host, dom, value, selection, edit, tokens, props}
+		host.onMounted(() => {
 			enableInput(ctx)
 			enableBlockEdit(ctx)
 			enableArrowNav(ctx)

--- a/packages/core/src/features/keyboard/KeyboardController.ts
+++ b/packages/core/src/features/keyboard/KeyboardController.ts
@@ -19,11 +19,11 @@ export class KeyboardController {
 		tokens: TokenModel,
 		props: PropsModel
 	) {
-		const ctx = {host, dom, value, selection, edit, tokens, props}
-		host.onMounted(() => {
-			enableInput(ctx)
-			enableBlockEdit(ctx)
-			enableArrowNav(ctx)
+		const ctx = {dom, value, selection, edit, tokens, props}
+		host.onMounted(container => {
+			enableInput(ctx, container)
+			enableBlockEdit(ctx, container)
+			enableArrowNav(ctx, container)
 		})
 	}
 }

--- a/packages/core/src/features/keyboard/arrowNav.ts
+++ b/packages/core/src/features/keyboard/arrowNav.ts
@@ -2,12 +2,9 @@ import {KEYBOARD} from '../../shared/constants'
 import {listen} from '../../shared/signals/index.js'
 import type {Store} from '../../store/Store'
 
-type KbCtx = Pick<Store, 'host' | 'dom' | 'selection' | 'props' | 'tokens'>
+type KbCtx = Pick<Store, 'dom' | 'selection' | 'props' | 'tokens'>
 
-export function enableArrowNav(store: KbCtx): void {
-	const container = store.host.container()
-	if (!container) return
-
+export function enableArrowNav(store: KbCtx, container: HTMLElement): void {
 	listen(container, 'keydown', e => {
 		if (store.props.layout.isBlock()) return
 

--- a/packages/core/src/features/keyboard/arrowNav.ts
+++ b/packages/core/src/features/keyboard/arrowNav.ts
@@ -2,10 +2,10 @@ import {KEYBOARD} from '../../shared/constants'
 import {listen} from '../../shared/signals/index.js'
 import type {Store} from '../../store/Store'
 
-type KbCtx = Pick<Store, 'dom' | 'selection' | 'props' | 'tokens'>
+type KbCtx = Pick<Store, 'host' | 'dom' | 'selection' | 'props' | 'tokens'>
 
 export function enableArrowNav(store: KbCtx): void {
-	const container = store.dom.container()
+	const container = store.host.container()
 	if (!container) return
 
 	listen(container, 'keydown', e => {

--- a/packages/core/src/features/keyboard/blockEdit.ts
+++ b/packages/core/src/features/keyboard/blockEdit.ts
@@ -4,7 +4,7 @@ import type {Range} from '../../shared/editorContracts'
 import {listen} from '../../shared/signals/index.js'
 import type {Store} from '../../store/Store'
 
-type KbCtx = Pick<Store, 'dom' | 'value' | 'selection' | 'edit' | 'tokens' | 'props'>
+type KbCtx = Pick<Store, 'host' | 'dom' | 'value' | 'selection' | 'edit' | 'tokens' | 'props'>
 import {createRowContent} from '../block/createRowContent'
 import {addDragRow, getMergeDragRowJoinPos, mergeDragRows, canMergeRows} from '../block/operations'
 import {consumeMarkupPaste} from '../clipboard'
@@ -18,7 +18,7 @@ function isTextLikeRow(token: Token): boolean {
 }
 
 export function enableBlockEdit(store: KbCtx): void {
-	const container = store.dom.container()
+	const container = store.host.container()
 	if (!container) return
 
 	listen(container, 'keydown', e => {
@@ -47,7 +47,7 @@ export function enableBlockEdit(store: KbCtx): void {
 }
 
 function handleDelete(store: KbCtx, event: KeyboardEvent) {
-	const container = store.dom.container()
+	const container = store.host.container()
 	if (!container) return
 
 	const blockDivs = htmlChildren(container)
@@ -143,7 +143,7 @@ function handleEnter(store: KbCtx, event: KeyboardEvent) {
 	if (event.key !== KEYBOARD.ENTER) return
 	if (event.shiftKey) return
 
-	const container = store.dom.container()
+	const container = store.host.container()
 	if (!container) return
 
 	const activeElement = document.activeElement
@@ -195,7 +195,7 @@ function focusRow(store: KbCtx, token: Token, row: HTMLElement, caret: 'start' |
 }
 
 function handleBlockArrowLeftRight(store: KbCtx, event: KeyboardEvent, direction: 'left' | 'right'): boolean {
-	const container = store.dom.container()
+	const container = store.host.container()
 	if (!container) return false
 
 	const activeElement = document.activeElement
@@ -229,7 +229,7 @@ function handleBlockArrowLeftRight(store: KbCtx, event: KeyboardEvent, direction
 }
 
 function handleArrowUpDown(store: KbCtx, event: KeyboardEvent) {
-	const container = store.dom.container()
+	const container = store.host.container()
 	if (!container) return
 
 	const activeElement = document.activeElement
@@ -267,7 +267,7 @@ function handleArrowUpDown(store: KbCtx, event: KeyboardEvent) {
 }
 
 function handleBlockBeforeInput(store: KbCtx, event: InputEvent) {
-	const container = store.dom.container()
+	const container = store.host.container()
 	if (!container) return
 
 	const activeElement = document.activeElement
@@ -285,7 +285,7 @@ function handleBlockBeforeInput(store: KbCtx, event: InputEvent) {
 		}
 		case 'insertFromPaste':
 		case 'insertReplacementText': {
-			const c = store.dom.container()
+			const c = store.host.container()
 			const markup = c ? consumeMarkupPaste(c) : undefined
 			const pasteData = markup ?? event.dataTransfer?.getData('text/plain') ?? ''
 			replaceBlockRange(store, event, pasteData)

--- a/packages/core/src/features/keyboard/blockEdit.ts
+++ b/packages/core/src/features/keyboard/blockEdit.ts
@@ -4,7 +4,7 @@ import type {Range} from '../../shared/editorContracts'
 import {listen} from '../../shared/signals/index.js'
 import type {Store} from '../../store/Store'
 
-type KbCtx = Pick<Store, 'host' | 'dom' | 'value' | 'selection' | 'edit' | 'tokens' | 'props'>
+type KbCtx = Pick<Store, 'dom' | 'value' | 'selection' | 'edit' | 'tokens' | 'props'>
 import {createRowContent} from '../block/createRowContent'
 import {addDragRow, getMergeDragRowJoinPos, mergeDragRows, canMergeRows} from '../block/operations'
 import {consumeMarkupPaste} from '../clipboard'
@@ -17,21 +17,18 @@ function isTextLikeRow(token: Token): boolean {
 	return token.descriptor.hasSlot && token.descriptor.segments.length === 1
 }
 
-export function enableBlockEdit(store: KbCtx): void {
-	const container = store.host.container()
-	if (!container) return
-
+export function enableBlockEdit(store: KbCtx, container: HTMLElement): void {
 	listen(container, 'keydown', e => {
 		if (!store.props.layout.isBlock()) return
 
 		if (e.key === KEYBOARD.LEFT || e.key === KEYBOARD.RIGHT) {
-			handleBlockArrowLeftRight(store, e, e.key === KEYBOARD.LEFT ? 'left' : 'right')
+			handleBlockArrowLeftRight(store, container, e, e.key === KEYBOARD.LEFT ? 'left' : 'right')
 		} else if (e.key === KEYBOARD.UP || e.key === KEYBOARD.DOWN) {
-			handleArrowUpDown(store, e)
+			handleArrowUpDown(store, container, e)
 		}
 
-		handleDelete(store, e)
-		handleEnter(store, e)
+		handleDelete(store, container, e)
+		handleEnter(store, container, e)
 	})
 
 	listen(
@@ -40,16 +37,13 @@ export function enableBlockEdit(store: KbCtx): void {
 		e => {
 			if (!store.props.layout.isBlock()) return
 			if (e.defaultPrevented) return
-			handleBlockBeforeInput(store, e)
+			handleBlockBeforeInput(store, container, e)
 		},
 		true
 	)
 }
 
-function handleDelete(store: KbCtx, event: KeyboardEvent) {
-	const container = store.host.container()
-	if (!container) return
-
+function handleDelete(store: KbCtx, container: HTMLElement, event: KeyboardEvent) {
 	const blockDivs = htmlChildren(container)
 	const blockIndex = blockDivs.findIndex(
 		div => div === document.activeElement || div.contains(document.activeElement)
@@ -139,12 +133,9 @@ function handleDelete(store: KbCtx, event: KeyboardEvent) {
 	}
 }
 
-function handleEnter(store: KbCtx, event: KeyboardEvent) {
+function handleEnter(store: KbCtx, container: HTMLElement, event: KeyboardEvent) {
 	if (event.key !== KEYBOARD.ENTER) return
 	if (event.shiftKey) return
-
-	const container = store.host.container()
-	if (!container) return
 
 	const activeElement = document.activeElement
 	if (!isHtmlElement(activeElement) || !container.contains(activeElement)) return
@@ -194,10 +185,12 @@ function focusRow(store: KbCtx, token: Token, row: HTMLElement, caret: 'start' |
 	caretDom.setAtElement(row, Infinity)
 }
 
-function handleBlockArrowLeftRight(store: KbCtx, event: KeyboardEvent, direction: 'left' | 'right'): boolean {
-	const container = store.host.container()
-	if (!container) return false
-
+function handleBlockArrowLeftRight(
+	store: KbCtx,
+	container: HTMLElement,
+	event: KeyboardEvent,
+	direction: 'left' | 'right'
+): boolean {
 	const activeElement = document.activeElement
 	if (!isHtmlElement(activeElement) || !container.contains(activeElement)) return false
 
@@ -228,10 +221,7 @@ function handleBlockArrowLeftRight(store: KbCtx, event: KeyboardEvent, direction
 	return true
 }
 
-function handleArrowUpDown(store: KbCtx, event: KeyboardEvent) {
-	const container = store.host.container()
-	if (!container) return
-
+function handleArrowUpDown(store: KbCtx, container: HTMLElement, event: KeyboardEvent) {
 	const activeElement = document.activeElement
 	if (!isHtmlElement(activeElement) || !container.contains(activeElement)) return
 
@@ -266,10 +256,7 @@ function handleArrowUpDown(store: KbCtx, event: KeyboardEvent) {
 	}
 }
 
-function handleBlockBeforeInput(store: KbCtx, event: InputEvent) {
-	const container = store.host.container()
-	if (!container) return
-
+function handleBlockBeforeInput(store: KbCtx, container: HTMLElement, event: InputEvent) {
 	const activeElement = document.activeElement
 	if (!isHtmlElement(activeElement) || !container.contains(activeElement)) return
 
@@ -285,8 +272,7 @@ function handleBlockBeforeInput(store: KbCtx, event: InputEvent) {
 		}
 		case 'insertFromPaste':
 		case 'insertReplacementText': {
-			const c = store.host.container()
-			const markup = c ? consumeMarkupPaste(c) : undefined
+			const markup = consumeMarkupPaste(container)
 			const pasteData = markup ?? event.dataTransfer?.getData('text/plain') ?? ''
 			replaceBlockRange(store, event, pasteData)
 			break

--- a/packages/core/src/features/keyboard/input.spec.ts
+++ b/packages/core/src/features/keyboard/input.spec.ts
@@ -6,13 +6,13 @@ import {applySpanInput, enableInput, handleBeforeInput} from './input'
 function mountStructuralInline(value = 'hello') {
 	const store = new Store()
 	store.props.set({defaultValue: value})
-	store.lifecycle.mounted()
+	store.host.mounted()
 	const container = document.createElement('div')
 	const textSurface = document.createElement('span')
 	container.append(textSurface)
 	document.body.append(container)
-	store.dom.container(container)
-	store.lifecycle.rendered()
+	store.host.container(container)
+	store.host.rendered()
 	const textNode = textSurface.firstChild
 	if (!(textNode instanceof Text)) throw new Error('Structural text surface did not render a text node')
 	return {store, container, textSurface, textNode}
@@ -21,7 +21,7 @@ function mountStructuralInline(value = 'hello') {
 function mountStructuralMarkWithDescendant(value = '@[world]') {
 	const store = new Store()
 	store.props.set({defaultValue: value, Mark: () => null, options: [{markup: '@[__value__]'}]})
-	store.lifecycle.mounted()
+	store.host.mounted()
 	const container = document.createElement('div')
 	const before = document.createElement('span')
 	const mark = document.createElement('mark')
@@ -32,8 +32,8 @@ function mountStructuralMarkWithDescendant(value = '@[world]') {
 	mark.append(descendant)
 	container.append(before, mark, after)
 	document.body.append(container)
-	store.dom.container(container)
-	store.lifecycle.rendered()
+	store.host.container(container)
+	store.host.rendered()
 	const descendantText = descendant.firstChild
 	if (!(descendantText instanceof Text)) throw new Error('Structural mark descendant did not render a text node')
 	return {store, container, descendantText}

--- a/packages/core/src/features/keyboard/input.spec.ts
+++ b/packages/core/src/features/keyboard/input.spec.ts
@@ -6,7 +6,6 @@ import {applySpanInput, enableInput, handleBeforeInput} from './input'
 function mountStructuralInline(value = 'hello') {
 	const store = new Store()
 	store.props.set({defaultValue: value})
-	store.host.mounted()
 	const container = document.createElement('div')
 	const textSurface = document.createElement('span')
 	container.append(textSurface)
@@ -21,7 +20,6 @@ function mountStructuralInline(value = 'hello') {
 function mountStructuralMarkWithDescendant(value = '@[world]') {
 	const store = new Store()
 	store.props.set({defaultValue: value, Mark: () => null, options: [{markup: '@[__value__]'}]})
-	store.host.mounted()
 	const container = document.createElement('div')
 	const before = document.createElement('span')
 	const mark = document.createElement('mark')

--- a/packages/core/src/features/keyboard/input.spec.ts
+++ b/packages/core/src/features/keyboard/input.spec.ts
@@ -79,7 +79,7 @@ describe('handleBeforeInput()', () => {
 		range.setEnd(textNode, 1)
 		const event = inputEvent('insertText', range, {data: 'x'})
 
-		handleBeforeInput(store, event)
+		handleBeforeInput(store, container, event)
 
 		expect(event.defaultPrevented).toBe(true)
 		expect(replaceRange).toHaveBeenCalledWith({start: 1, end: 1}, 'x')
@@ -96,7 +96,7 @@ describe('handleBeforeInput()', () => {
 		const event = inputEvent('insertText', range, {data: 'x'})
 
 		store.dom.compositionStarted()
-		handleBeforeInput(store, event)
+		handleBeforeInput(store, container, event)
 
 		expect(replaceRange).not.toHaveBeenCalled()
 		expect(store.value.current()).toBe('hello')
@@ -111,7 +111,7 @@ describe('handleBeforeInput()', () => {
 		range.setEnd(descendantText, 0)
 		const event = inputEvent('insertText', range, {data: 'x'})
 
-		handleBeforeInput(store, event)
+		handleBeforeInput(store, container, event)
 
 		expect(event.defaultPrevented).toBe(false)
 		expect(replaceRange).not.toHaveBeenCalled()
@@ -122,7 +122,7 @@ describe('handleBeforeInput()', () => {
 describe('composition input', () => {
 	it('commits composition text at the original raw selection', () => {
 		const {store, container, textNode} = mountStructuralInline('ab')
-		enableInput(store)
+		enableInput(store, container)
 		const selection = window.getSelection()
 		const initialRange = document.createRange()
 		initialRange.setStart(textNode, 1)

--- a/packages/core/src/features/keyboard/input.ts
+++ b/packages/core/src/features/keyboard/input.ts
@@ -3,7 +3,7 @@ import type {Range} from '../../shared/editorContracts'
 import {listen} from '../../shared/signals/index.js'
 import type {Store} from '../../store/Store'
 
-type KbCtx = Pick<Store, 'dom' | 'value' | 'selection' | 'edit' | 'props' | 'tokens'>
+type KbCtx = Pick<Store, 'host' | 'dom' | 'value' | 'selection' | 'edit' | 'props' | 'tokens'>
 import {captureMarkupPaste, consumeMarkupPaste} from '../clipboard'
 import type {Token} from '../parsing'
 import {rawRangeFromInputEvent} from './inputRange'
@@ -14,12 +14,12 @@ type SpanInputTarget = {
 }
 
 export function enableInput(store: KbCtx): void {
-	const container = store.dom.container()
+	const container = store.host.container()
 	if (!container) return
 	let compositionRange: Range | undefined
 
 	listen(container, 'paste', e => {
-		const c = store.dom.container()
+		const c = store.host.container()
 		if (c) captureMarkupPaste(e, c)
 		handlePaste(store, e)
 	})
@@ -167,7 +167,7 @@ export function applySpanInput(focus: SpanInputTarget, event: InputEvent): boole
 function replacementForInput(store: KbCtx, event: InputEvent): string | undefined {
 	if (event.inputType.startsWith('delete')) return ''
 	if (event.inputType === 'insertFromPaste' || event.inputType === 'insertReplacementText') {
-		const container = store.dom.container()
+		const container = store.host.container()
 		const markup = container ? consumeMarkupPaste(container) : undefined
 		return markup ?? event.dataTransfer?.getData('text/plain') ?? event.data ?? ''
 	}
@@ -210,7 +210,7 @@ export function handlePaste(store: KbCtx, event: ClipboardEvent): void {
 	if (!store.selection.isAllSelected()) return
 
 	event.preventDefault()
-	const c = store.dom.container()
+	const c = store.host.container()
 	const markup = c ? consumeMarkupPaste(c) : undefined
 	const newContent = markup ?? event.clipboardData?.getData('text/plain') ?? ''
 	store.edit.replace({start: 0, end: -1}, newContent)

--- a/packages/core/src/features/keyboard/input.ts
+++ b/packages/core/src/features/keyboard/input.ts
@@ -3,7 +3,7 @@ import type {Range} from '../../shared/editorContracts'
 import {listen} from '../../shared/signals/index.js'
 import type {Store} from '../../store/Store'
 
-type KbCtx = Pick<Store, 'host' | 'dom' | 'value' | 'selection' | 'edit' | 'props' | 'tokens'>
+type KbCtx = Pick<Store, 'dom' | 'value' | 'selection' | 'edit' | 'props' | 'tokens'>
 import {captureMarkupPaste, consumeMarkupPaste} from '../clipboard'
 import type {Token} from '../parsing'
 import {rawRangeFromInputEvent} from './inputRange'
@@ -13,15 +13,12 @@ type SpanInputTarget = {
 	caret: number
 }
 
-export function enableInput(store: KbCtx): void {
-	const container = store.host.container()
-	if (!container) return
+export function enableInput(store: KbCtx, container: HTMLElement): void {
 	let compositionRange: Range | undefined
 
 	listen(container, 'paste', e => {
-		const c = store.host.container()
-		if (c) captureMarkupPaste(e, c)
-		handlePaste(store, e)
+		captureMarkupPaste(e, container)
+		handlePaste(store, container, e)
 	})
 
 	listen(container, 'compositionstart', () => {
@@ -44,7 +41,7 @@ export function enableInput(store: KbCtx): void {
 		container,
 		'beforeinput',
 		e => {
-			handleBeforeInput(store, e)
+			handleBeforeInput(store, container, e)
 		},
 		true
 	)
@@ -75,7 +72,7 @@ function handleDeleteKey(store: KbCtx, event: KeyboardEvent): void {
 	store.edit.replace(range, '')
 }
 
-export function handleBeforeInput(store: KbCtx, event: InputEvent): void {
+export function handleBeforeInput(store: KbCtx, container: HTMLElement, event: InputEvent): void {
 	if (store.selection.isAllSelected()) {
 		if (event.inputType === 'insertFromPaste') {
 			event.preventDefault()
@@ -92,7 +89,7 @@ export function handleBeforeInput(store: KbCtx, event: InputEvent): void {
 	const raw = rawRangeFromInputEvent(store, event)
 	if (!raw.ok) return
 
-	const replacement = replacementForInput(store, event)
+	const replacement = replacementForInput(container, event)
 	if (replacement === undefined) return
 
 	const range = rangeForInput(store, event, raw.value.range)
@@ -164,11 +161,10 @@ export function applySpanInput(focus: SpanInputTarget, event: InputEvent): boole
 	return true
 }
 
-function replacementForInput(store: KbCtx, event: InputEvent): string | undefined {
+function replacementForInput(container: HTMLElement, event: InputEvent): string | undefined {
 	if (event.inputType.startsWith('delete')) return ''
 	if (event.inputType === 'insertFromPaste' || event.inputType === 'insertReplacementText') {
-		const container = store.host.container()
-		const markup = container ? consumeMarkupPaste(container) : undefined
+		const markup = consumeMarkupPaste(container)
 		return markup ?? event.dataTransfer?.getData('text/plain') ?? event.data ?? ''
 	}
 	if (event.inputType === 'insertText') return event.data ?? ''
@@ -206,12 +202,11 @@ function adjacentMarkRange(tokens: readonly Token[], position: number, backward:
 	return undefined
 }
 
-export function handlePaste(store: KbCtx, event: ClipboardEvent): void {
+export function handlePaste(store: KbCtx, container: HTMLElement, event: ClipboardEvent): void {
 	if (!store.selection.isAllSelected()) return
 
 	event.preventDefault()
-	const c = store.host.container()
-	const markup = c ? consumeMarkupPaste(c) : undefined
+	const markup = consumeMarkupPaste(container)
 	const newContent = markup ?? event.clipboardData?.getData('text/plain') ?? ''
 	store.edit.replace({start: 0, end: -1}, newContent)
 }

--- a/packages/core/src/features/overlay/OverlayController.spec.ts
+++ b/packages/core/src/features/overlay/OverlayController.spec.ts
@@ -18,6 +18,7 @@ describe('OverlayController', () => {
 
 	beforeEach(() => {
 		store = new Store()
+		store.host.container(document.createElement('div'))
 		store.host.mounted()
 	})
 

--- a/packages/core/src/features/overlay/OverlayController.spec.ts
+++ b/packages/core/src/features/overlay/OverlayController.spec.ts
@@ -18,7 +18,7 @@ describe('OverlayController', () => {
 
 	beforeEach(() => {
 		store = new Store()
-		store.lifecycle.mounted()
+		store.host.mounted()
 	})
 
 	describe('ownership', () => {

--- a/packages/core/src/features/overlay/OverlayController.spec.ts
+++ b/packages/core/src/features/overlay/OverlayController.spec.ts
@@ -19,7 +19,6 @@ describe('OverlayController', () => {
 	beforeEach(() => {
 		store = new Store()
 		store.host.container(document.createElement('div'))
-		store.host.mounted()
 	})
 
 	describe('ownership', () => {

--- a/packages/core/src/features/overlay/OverlayController.ts
+++ b/packages/core/src/features/overlay/OverlayController.ts
@@ -12,7 +12,7 @@ import * as caretDom from '../selection/caretDom'
 import type {SelectionController} from '../selection/SelectionController'
 import {resolveOverlaySlot} from '../slots'
 import type {OverlaySlot} from '../slots'
-import type {Lifecycle} from '../state/Lifecycle'
+import type {Host} from '../state/Host'
 import type {PropsModel} from '../state/PropsModel'
 import type {ValueModel} from '../state/ValueModel'
 import {TriggerFinder} from './TriggerFinder'
@@ -37,7 +37,7 @@ export class OverlayController {
 	})
 
 	constructor(
-		private readonly lifecycle: Lifecycle,
+		private readonly host: Host,
 		private readonly props: PropsModel,
 		private readonly value: ValueModel,
 		private readonly dom: DomModel,
@@ -47,7 +47,7 @@ export class OverlayController {
 	) {
 		const hasOverlayTrigger = computed(() => this.props.options().some(opt => opt.overlay?.trigger != null))
 
-		this.lifecycle.onMounted(() => {
+		this.host.onMounted(() => {
 			watch(this.close, () => {
 				if (!hasOverlayTrigger()) return
 				this.match(undefined)
@@ -74,7 +74,7 @@ export class OverlayController {
 					e => {
 						const target = e.target instanceof HTMLElement ? e.target : null
 						if (this.element()?.contains(target)) return
-						if (this.dom.container()?.contains(target)) return
+						if (this.host.container()?.contains(target)) return
 						this.close()
 					},
 					true
@@ -84,7 +84,7 @@ export class OverlayController {
 			effect(() => {
 				if (!hasOverlayTrigger()) return
 				const handler = () => {
-					const container = this.dom.container()
+					const container = this.host.container()
 					if (!container?.contains(document.activeElement)) return
 					const showOverlayOn = this.props.showOverlayOn()
 					const type: OverlayTrigger = 'selectionChange'
@@ -153,7 +153,7 @@ export class OverlayController {
 				source,
 				range: {start, end: start + source.length},
 				span: value,
-				node: window.getSelection()?.anchorNode ?? this.dom.container() ?? document.body,
+				node: window.getSelection()?.anchorNode ?? this.host.container() ?? document.body,
 				option,
 			}
 		}

--- a/packages/core/src/features/parsing/MarkController.spec.ts
+++ b/packages/core/src/features/parsing/MarkController.spec.ts
@@ -7,7 +7,7 @@ import {MarkController} from './MarkController'
 function setup(value = 'hello @[world]', markup: Markup = '@[__value__]') {
 	const store = new Store()
 	store.props.set({defaultValue: value, Mark: () => null, options: [{markup}]})
-	store.lifecycle.mounted()
+	store.host.mounted()
 	const token = store.tokens.current().find(t => t.type === 'mark')
 	if (!token) throw new Error('expected parsed mark token')
 	const controller = MarkController.fromToken(store, token)

--- a/packages/core/src/features/parsing/MarkController.spec.ts
+++ b/packages/core/src/features/parsing/MarkController.spec.ts
@@ -7,7 +7,6 @@ import {MarkController} from './MarkController'
 function setup(value = 'hello @[world]', markup: Markup = '@[__value__]') {
 	const store = new Store()
 	store.props.set({defaultValue: value, Mark: () => null, options: [{markup}]})
-	store.host.mounted()
 	const token = store.tokens.current().find(t => t.type === 'mark')
 	if (!token) throw new Error('expected parsed mark token')
 	const controller = MarkController.fromToken(store, token)

--- a/packages/core/src/features/parsing/TokenModel.spec.ts
+++ b/packages/core/src/features/parsing/TokenModel.spec.ts
@@ -13,7 +13,7 @@ describe('TokenModel', () => {
 
 	function mountWith(value: string) {
 		store.props.set({Mark: () => null, defaultValue: value})
-		store.lifecycle.mounted()
+		store.host.mounted()
 	}
 
 	describe('auto-parse on value change', () => {
@@ -40,14 +40,14 @@ describe('TokenModel', () => {
 
 		it('does not parse markup when Mark is not set', () => {
 			store.props.set({options: [{markup: '@[__value__]'}]})
-			store.lifecycle.mounted()
+			store.host.mounted()
 			store.value.current('@[test]')
 			expect(store.tokens.current()).toEqual([{type: 'text', content: '@[test]', position: {start: 0, end: 7}}])
 		})
 
 		it('parses markup when Mark is set', () => {
 			store.props.set({Mark: () => null, options: [{markup: '@[__value__]'}]})
-			store.lifecycle.mounted()
+			store.host.mounted()
 			store.value.current('@[test]')
 			expect(store.tokens.current()).toEqual(expect.arrayContaining([expect.objectContaining({type: 'mark'})]))
 		})
@@ -79,7 +79,7 @@ describe('TokenModel', () => {
 			// added in onMounted, so by the time downstream listeners observe
 			// value.current, tokens.current reflects the new value.
 			store.props.set({Mark: () => null, defaultValue: ''})
-			store.lifecycle.mounted()
+			store.host.mounted()
 
 			let tokensAtChangeTime: Token[] | undefined
 			const stop = watch(store.value.current, () => {
@@ -102,7 +102,7 @@ describe('TokenModel', () => {
 				options: [{markup: '@[__value__]'}],
 				defaultValue: '@[hello]',
 			})
-			store.lifecycle.mounted()
+			store.host.mounted()
 			expect(store.tokens.current()).toHaveLength(1)
 			expect(store.tokens.current()[0].type).toBe('mark')
 		})
@@ -114,7 +114,7 @@ describe('TokenModel', () => {
 				options: [{markup: '@[__value__]'}],
 				defaultValue: '@[hello]',
 			})
-			store.lifecycle.mounted()
+			store.host.mounted()
 			expect(store.tokens.current()).toHaveLength(3)
 			expect(store.tokens.current()[0].type).toBe('text')
 			expect(store.tokens.current()[1].type).toBe('mark')

--- a/packages/core/src/features/parsing/TokenModel.spec.ts
+++ b/packages/core/src/features/parsing/TokenModel.spec.ts
@@ -13,7 +13,6 @@ describe('TokenModel', () => {
 
 	function mountWith(value: string) {
 		store.props.set({Mark: () => null, defaultValue: value})
-		store.host.mounted()
 	}
 
 	describe('auto-parse on value change', () => {
@@ -40,14 +39,12 @@ describe('TokenModel', () => {
 
 		it('does not parse markup when Mark is not set', () => {
 			store.props.set({options: [{markup: '@[__value__]'}]})
-			store.host.mounted()
 			store.value.current('@[test]')
 			expect(store.tokens.current()).toEqual([{type: 'text', content: '@[test]', position: {start: 0, end: 7}}])
 		})
 
 		it('parses markup when Mark is set', () => {
 			store.props.set({Mark: () => null, options: [{markup: '@[__value__]'}]})
-			store.host.mounted()
 			store.value.current('@[test]')
 			expect(store.tokens.current()).toEqual(expect.arrayContaining([expect.objectContaining({type: 'mark'})]))
 		})
@@ -79,8 +76,6 @@ describe('TokenModel', () => {
 			// added in onMounted, so by the time downstream listeners observe
 			// value.current, tokens.current reflects the new value.
 			store.props.set({Mark: () => null, defaultValue: ''})
-			store.host.mounted()
-
 			let tokensAtChangeTime: Token[] | undefined
 			const stop = watch(store.value.current, () => {
 				tokensAtChangeTime = store.tokens.current()
@@ -102,7 +97,6 @@ describe('TokenModel', () => {
 				options: [{markup: '@[__value__]'}],
 				defaultValue: '@[hello]',
 			})
-			store.host.mounted()
 			expect(store.tokens.current()).toHaveLength(1)
 			expect(store.tokens.current()[0].type).toBe('mark')
 		})
@@ -114,7 +108,6 @@ describe('TokenModel', () => {
 				options: [{markup: '@[__value__]'}],
 				defaultValue: '@[hello]',
 			})
-			store.host.mounted()
 			expect(store.tokens.current()).toHaveLength(3)
 			expect(store.tokens.current()[0].type).toBe('text')
 			expect(store.tokens.current()[1].type).toBe('mark')

--- a/packages/core/src/features/selection/SelectionController.spec.ts
+++ b/packages/core/src/features/selection/SelectionController.spec.ts
@@ -122,6 +122,7 @@ describe('SelectionController', () => {
 		it('attaches document listeners on mount', () => {
 			const addSpy = vi.spyOn(document, 'addEventListener')
 			const store = new Store()
+			store.host.container(document.createElement('div'))
 			store.host.mounted()
 			expect(addSpy).toHaveBeenCalledWith('mousedown', expect.any(Function), undefined)
 			addSpy.mockRestore()

--- a/packages/core/src/features/selection/SelectionController.spec.ts
+++ b/packages/core/src/features/selection/SelectionController.spec.ts
@@ -88,7 +88,6 @@ describe('SelectionController', () => {
 		it('sets range to full value range and applies it to DOM', () => {
 			const store = new Store()
 			store.props.set({defaultValue: 'hello'})
-			store.host.mounted()
 			const container = document.createElement('div')
 			const span = document.createElement('span')
 			span.appendChild(document.createTextNode('hello'))
@@ -109,8 +108,6 @@ describe('SelectionController', () => {
 		it('retains range intent when the DOM has no target yet', () => {
 			const store = new Store()
 			store.props.set({defaultValue: 'hello'})
-			store.host.mounted()
-
 			// No container set → dom.isIndexed() is false → placement is deferred
 			// until the next render. The range signal still reflects user intent.
 			store.selection.selectAll()
@@ -123,7 +120,6 @@ describe('SelectionController', () => {
 			const addSpy = vi.spyOn(document, 'addEventListener')
 			const store = new Store()
 			store.host.container(document.createElement('div'))
-			store.host.mounted()
 			expect(addSpy).toHaveBeenCalledWith('mousedown', expect.any(Function), undefined)
 			addSpy.mockRestore()
 		})
@@ -140,7 +136,6 @@ describe('SelectionController', () => {
 
 			store.props.set({defaultValue: 'hello'})
 			store.host.container(container)
-			store.host.mounted()
 			store.selection.position(5)
 
 			store.host.rendered()
@@ -159,7 +154,6 @@ describe('SelectionController', () => {
 			container.appendChild(span)
 			document.body.appendChild(container)
 			store.host.container(container)
-			store.host.mounted()
 			store.dom.isUserSelecting(true)
 			store.selection.position(3)
 
@@ -181,7 +175,6 @@ describe('SelectionController', () => {
 			document.body.appendChild(container)
 			store.props.set({defaultValue: 'hello'})
 			store.host.container(container)
-			store.host.mounted()
 			store.selection.position(3)
 			store.host.rendered()
 			expect(store.selection.range()).toEqual({start: 3, end: 3})
@@ -199,7 +192,6 @@ describe('SelectionController', () => {
 			container.appendChild(span)
 			document.body.appendChild(container)
 			store.host.container(container)
-			store.host.mounted()
 			store.host.rendered()
 
 			expect(span.contentEditable).toBe('true')

--- a/packages/core/src/features/selection/SelectionController.spec.ts
+++ b/packages/core/src/features/selection/SelectionController.spec.ts
@@ -88,14 +88,14 @@ describe('SelectionController', () => {
 		it('sets range to full value range and applies it to DOM', () => {
 			const store = new Store()
 			store.props.set({defaultValue: 'hello'})
-			store.lifecycle.mounted()
+			store.host.mounted()
 			const container = document.createElement('div')
 			const span = document.createElement('span')
 			span.appendChild(document.createTextNode('hello'))
 			container.appendChild(span)
 			document.body.appendChild(container)
-			store.dom.container(container)
-			store.lifecycle.rendered()
+			store.host.container(container)
+			store.host.rendered()
 
 			store.selection.selectAll()
 			expect(store.selection.range()).toEqual({start: 0, end: 5})
@@ -109,7 +109,7 @@ describe('SelectionController', () => {
 		it('retains range intent when the DOM has no target yet', () => {
 			const store = new Store()
 			store.props.set({defaultValue: 'hello'})
-			store.lifecycle.mounted()
+			store.host.mounted()
 
 			// No container set → dom.isIndexed() is false → placement is deferred
 			// until the next render. The range signal still reflects user intent.
@@ -122,7 +122,7 @@ describe('SelectionController', () => {
 		it('attaches document listeners on mount', () => {
 			const addSpy = vi.spyOn(document, 'addEventListener')
 			const store = new Store()
-			store.lifecycle.mounted()
+			store.host.mounted()
 			expect(addSpy).toHaveBeenCalledWith('mousedown', expect.any(Function), undefined)
 			addSpy.mockRestore()
 		})
@@ -138,11 +138,11 @@ describe('SelectionController', () => {
 			document.body.appendChild(container)
 
 			store.props.set({defaultValue: 'hello'})
-			store.dom.container(container)
-			store.lifecycle.mounted()
+			store.host.container(container)
+			store.host.mounted()
 			store.selection.position(5)
 
-			store.lifecycle.rendered()
+			store.host.rendered()
 			const sel = window.getSelection()
 			expect(sel?.focusNode).toBe(span.firstChild)
 			expect(sel?.focusOffset).toBe(5)
@@ -157,14 +157,14 @@ describe('SelectionController', () => {
 			span.appendChild(document.createTextNode('hello'))
 			container.appendChild(span)
 			document.body.appendChild(container)
-			store.dom.container(container)
-			store.lifecycle.mounted()
+			store.host.container(container)
+			store.host.mounted()
 			store.dom.isUserSelecting(true)
 			store.selection.position(3)
 
 			// Clear any pre-existing browser selection so we can detect non-changes.
 			window.getSelection()?.removeAllRanges()
-			store.lifecycle.rendered()
+			store.host.rendered()
 
 			const sel = window.getSelection()
 			expect(sel?.rangeCount ?? 0).toBe(0)
@@ -179,10 +179,10 @@ describe('SelectionController', () => {
 			const container = document.createElement('div')
 			document.body.appendChild(container)
 			store.props.set({defaultValue: 'hello'})
-			store.dom.container(container)
-			store.lifecycle.mounted()
+			store.host.container(container)
+			store.host.mounted()
 			store.selection.position(3)
-			store.lifecycle.rendered()
+			store.host.rendered()
 			expect(store.selection.range()).toEqual({start: 3, end: 3})
 			container.remove()
 		})
@@ -197,9 +197,9 @@ describe('SelectionController', () => {
 			span.appendChild(document.createTextNode('hello'))
 			container.appendChild(span)
 			document.body.appendChild(container)
-			store.dom.container(container)
-			store.lifecycle.mounted()
-			store.lifecycle.rendered()
+			store.host.container(container)
+			store.host.mounted()
+			store.host.rendered()
 
 			expect(span.contentEditable).toBe('true')
 

--- a/packages/core/src/features/selection/SelectionController.ts
+++ b/packages/core/src/features/selection/SelectionController.ts
@@ -32,13 +32,13 @@ export class SelectionController {
 		private readonly value: ValueModel,
 		private readonly props: PropsModel
 	) {
-		host.onMounted(() => {
-			this.#focusEmptyEditorOnClick()
+		host.onMounted(container => {
+			this.#focusEmptyEditorOnClick(container)
 
-			this.#trackSelection()
+			this.#trackSelection(container)
 			watch(this.range, () => this.#applyRangeToDOM())
 
-			this.#trackUserSelecting()
+			this.#trackUserSelecting(container)
 			watch(dom.indexed, () => this.#applyRangeToDOM())
 		})
 	}
@@ -83,18 +83,16 @@ export class SelectionController {
 	 * anywhere in the container should focus the first child — otherwise the
 	 * browser leaves the editor unfocused because there's no text to click on.
 	 */
-	#focusEmptyEditorOnClick(): void {
-		const container = this.host.container()
-		if (!container) return
+	#focusEmptyEditorOnClick(container: HTMLElement): void {
 		listen(container, 'click', () => {
 			const tokens = this.parsing.current()
 			if (tokens.length === 1 && tokens[0].type === 'text' && tokens[0].content === '') {
-				firstHtmlChild(this.host.container())?.focus()
+				firstHtmlChild(container)?.focus()
 			}
 		})
 	}
 
-	#trackUserSelecting(): void {
+	#trackUserSelecting(container: HTMLElement): void {
 		let pressedAt: Node | null = null
 
 		listen(document, 'mousedown', e => {
@@ -103,8 +101,6 @@ export class SelectionController {
 
 		listen(document, 'mousemove', e => {
 			if (pressedAt === null) return
-			const container = this.host.container()
-			if (!container) return
 
 			const startedOutsideEditor = !container.contains(pressedAt)
 			const sweepingAcrossNodes = pressedAt !== e.target
@@ -129,10 +125,7 @@ export class SelectionController {
 		listen(document, 'selectionchange', clearIfCollapsed)
 	}
 
-	#trackSelection(): void {
-		const container = this.host.container()
-		if (!container) return
-
+	#trackSelection(container: HTMLElement): void {
 		const sync = (): void => {
 			const rawSel = this.dom.readRawSelection()
 			if (rawSel.ok) this.range(rawSel.value.range)

--- a/packages/core/src/features/selection/SelectionController.ts
+++ b/packages/core/src/features/selection/SelectionController.ts
@@ -4,7 +4,7 @@ import {computed, listen, signal, watch} from '../../shared/signals'
 import {shallow} from '../../shared/utils/shallow'
 import type {DomModel} from '../dom/DomModel'
 import type {TokenModel} from '../parsing/TokenModel'
-import type {Lifecycle} from '../state/Lifecycle'
+import type {Host} from '../state/Host'
 import type {PropsModel} from '../state/PropsModel'
 import type {ValueModel} from '../state/ValueModel'
 import {focusIfNeeded, placeAtChildBoundary, placeAtTextOffset, placeRangeAcrossSurfaces} from './caretDom'
@@ -26,13 +26,13 @@ export class SelectionController {
 	#isPlacingCaret = false
 
 	constructor(
-		private readonly lifecycle: Lifecycle,
+		private readonly host: Host,
 		private readonly dom: DomModel,
 		private readonly parsing: TokenModel,
 		private readonly value: ValueModel,
 		private readonly props: PropsModel
 	) {
-		lifecycle.onMounted(() => {
+		host.onMounted(() => {
 			this.#focusEmptyEditorOnClick()
 
 			this.#trackSelection()
@@ -46,7 +46,7 @@ export class SelectionController {
 	focusFirst(): void {
 		const firstAddress = this.parsing.index().addressFor([0])
 		if (firstAddress && this.placeAtAddress(firstAddress, 'start')) return
-		this.dom.container()?.focus()
+		this.host.container()?.focus()
 	}
 
 	selectAll(): void {
@@ -84,12 +84,12 @@ export class SelectionController {
 	 * browser leaves the editor unfocused because there's no text to click on.
 	 */
 	#focusEmptyEditorOnClick(): void {
-		const container = this.dom.container()
+		const container = this.host.container()
 		if (!container) return
 		listen(container, 'click', () => {
 			const tokens = this.parsing.current()
 			if (tokens.length === 1 && tokens[0].type === 'text' && tokens[0].content === '') {
-				firstHtmlChild(this.dom.container())?.focus()
+				firstHtmlChild(this.host.container())?.focus()
 			}
 		})
 	}
@@ -103,7 +103,7 @@ export class SelectionController {
 
 		listen(document, 'mousemove', e => {
 			if (pressedAt === null) return
-			const container = this.dom.container()
+			const container = this.host.container()
 			if (!container) return
 
 			const startedOutsideEditor = !container.contains(pressedAt)
@@ -130,7 +130,7 @@ export class SelectionController {
 	}
 
 	#trackSelection(): void {
-		const container = this.dom.container()
+		const container = this.host.container()
 		if (!container) return
 
 		const sync = (): void => {

--- a/packages/core/src/features/state/Host.spec.ts
+++ b/packages/core/src/features/state/Host.spec.ts
@@ -22,47 +22,31 @@ describe('Host', () => {
 	})
 
 	describe('onMounted()', () => {
-		it('runs setup with the container once both mounted and container are set', () => {
+		it('runs setup when container is attached', () => {
 			const store = new Store()
 			const container = document.createElement('div')
 			const setup = vi.fn()
 			store.host.onMounted(setup)
 
-			expect(setup).not.toHaveBeenCalled()
-			store.host.mounted()
 			expect(setup).not.toHaveBeenCalled()
 			store.host.container(container)
 			expect(setup).toHaveBeenCalledTimes(1)
 			expect(setup).toHaveBeenCalledWith(container)
 		})
 
-		it('runs setup when mounted fires after container is already set', () => {
+		it('does not re-run setup if the same container is set again', () => {
 			const store = new Store()
 			const container = document.createElement('div')
 			const setup = vi.fn()
 			store.host.onMounted(setup)
 
 			store.host.container(container)
-			expect(setup).not.toHaveBeenCalled()
-			store.host.mounted()
-			expect(setup).toHaveBeenCalledTimes(1)
-			expect(setup).toHaveBeenCalledWith(container)
-		})
-
-		it('does not re-run setup if mounted fires again without an unmount', () => {
-			const store = new Store()
-			const container = document.createElement('div')
-			const setup = vi.fn()
-			store.host.onMounted(setup)
-
 			store.host.container(container)
-			store.host.mounted()
-			store.host.mounted()
 
 			expect(setup).toHaveBeenCalledTimes(1)
 		})
 
-		it('disposes inner watchers on unmount', () => {
+		it('disposes inner subscriptions when the container is detached', () => {
 			const store = new Store()
 			const container = document.createElement('div')
 			const source = signal<number>({initial: 0})
@@ -72,28 +56,26 @@ describe('Host', () => {
 			})
 
 			store.host.container(container)
-			store.host.mounted()
 			source(1)
 			expect(observed).toHaveBeenCalledTimes(1)
 			expect(observed).toHaveBeenLastCalledWith(1)
 
-			store.host.unmounted()
+			store.host.container(null)
 			source(2)
 			expect(observed).toHaveBeenCalledTimes(1)
 		})
 
-		it('does nothing if registered after mount', () => {
+		it('does nothing if registered after the container is already attached', () => {
 			const store = new Store()
 			const container = document.createElement('div')
 			const setup = vi.fn()
 
 			store.host.container(container)
-			store.host.mounted()
 			store.host.onMounted(setup)
 			expect(setup).not.toHaveBeenCalled()
 		})
 
-		it('re-runs setup with a fresh scope on remount', () => {
+		it('re-runs setup with a fresh scope on re-attach', () => {
 			const store = new Store()
 			const container = document.createElement('div')
 			const source = signal<number>({initial: 0})
@@ -104,35 +86,15 @@ describe('Host', () => {
 			store.host.onMounted(setup)
 
 			store.host.container(container)
-			store.host.mounted()
 			source(1)
-			store.host.unmounted()
-			store.host.mounted()
+			store.host.container(null)
+			store.host.container(container)
 			source(2)
 
 			expect(setup).toHaveBeenCalledTimes(2)
 			expect(observed).toHaveBeenCalledTimes(2)
 			expect(observed).toHaveBeenNthCalledWith(1, 1)
 			expect(observed).toHaveBeenNthCalledWith(2, 2)
-		})
-
-		it('disposes setup when container becomes null while mounted', () => {
-			const store = new Store()
-			const container = document.createElement('div')
-			const source = signal<number>({initial: 0})
-			const observed = vi.fn()
-			store.host.onMounted(() => {
-				watch(source, value => observed(value))
-			})
-
-			store.host.container(container)
-			store.host.mounted()
-			source(1)
-			expect(observed).toHaveBeenCalledTimes(1)
-
-			store.host.container(null)
-			source(2)
-			expect(observed).toHaveBeenCalledTimes(1)
 		})
 
 		it('re-runs setup with the new container on swap', () => {
@@ -143,7 +105,6 @@ describe('Host', () => {
 			store.host.onMounted(setup)
 
 			store.host.container(first)
-			store.host.mounted()
 			expect(setup).toHaveBeenCalledTimes(1)
 			expect(setup).toHaveBeenLastCalledWith(first)
 
@@ -163,13 +124,11 @@ describe('Host', () => {
 			})
 
 			store.host.container(first)
-			store.host.mounted()
 			source(1)
 			expect(observed).toHaveBeenCalledWith(first, 1)
 
 			store.host.container(second)
 			source(2)
-			// only the new scope's watcher fires
 			expect(observed).toHaveBeenCalledTimes(2)
 			expect(observed).toHaveBeenLastCalledWith(second, 2)
 		})

--- a/packages/core/src/features/state/Host.spec.ts
+++ b/packages/core/src/features/state/Host.spec.ts
@@ -22,21 +22,40 @@ describe('Host', () => {
 	})
 
 	describe('onMounted()', () => {
-		it('runs setup once on mounted', () => {
+		it('runs setup with the container once both mounted and container are set', () => {
 			const store = new Store()
+			const container = document.createElement('div')
 			const setup = vi.fn()
 			store.host.onMounted(setup)
 
 			expect(setup).not.toHaveBeenCalled()
 			store.host.mounted()
+			expect(setup).not.toHaveBeenCalled()
+			store.host.container(container)
 			expect(setup).toHaveBeenCalledTimes(1)
+			expect(setup).toHaveBeenCalledWith(container)
+		})
+
+		it('runs setup when mounted fires after container is already set', () => {
+			const store = new Store()
+			const container = document.createElement('div')
+			const setup = vi.fn()
+			store.host.onMounted(setup)
+
+			store.host.container(container)
+			expect(setup).not.toHaveBeenCalled()
+			store.host.mounted()
+			expect(setup).toHaveBeenCalledTimes(1)
+			expect(setup).toHaveBeenCalledWith(container)
 		})
 
 		it('does not re-run setup if mounted fires again without an unmount', () => {
 			const store = new Store()
+			const container = document.createElement('div')
 			const setup = vi.fn()
 			store.host.onMounted(setup)
 
+			store.host.container(container)
 			store.host.mounted()
 			store.host.mounted()
 
@@ -45,12 +64,14 @@ describe('Host', () => {
 
 		it('disposes inner watchers on unmount', () => {
 			const store = new Store()
+			const container = document.createElement('div')
 			const source = signal<number>({initial: 0})
 			const observed = vi.fn()
 			store.host.onMounted(() => {
 				watch(source, value => observed(value))
 			})
 
+			store.host.container(container)
 			store.host.mounted()
 			source(1)
 			expect(observed).toHaveBeenCalledTimes(1)
@@ -63,7 +84,10 @@ describe('Host', () => {
 
 		it('does nothing if registered after mount', () => {
 			const store = new Store()
+			const container = document.createElement('div')
 			const setup = vi.fn()
+
+			store.host.container(container)
 			store.host.mounted()
 			store.host.onMounted(setup)
 			expect(setup).not.toHaveBeenCalled()
@@ -71,6 +95,7 @@ describe('Host', () => {
 
 		it('re-runs setup with a fresh scope on remount', () => {
 			const store = new Store()
+			const container = document.createElement('div')
 			const source = signal<number>({initial: 0})
 			const observed = vi.fn()
 			const setup = vi.fn(() => {
@@ -78,6 +103,7 @@ describe('Host', () => {
 			})
 			store.host.onMounted(setup)
 
+			store.host.container(container)
 			store.host.mounted()
 			source(1)
 			store.host.unmounted()
@@ -88,6 +114,64 @@ describe('Host', () => {
 			expect(observed).toHaveBeenCalledTimes(2)
 			expect(observed).toHaveBeenNthCalledWith(1, 1)
 			expect(observed).toHaveBeenNthCalledWith(2, 2)
+		})
+
+		it('disposes setup when container becomes null while mounted', () => {
+			const store = new Store()
+			const container = document.createElement('div')
+			const source = signal<number>({initial: 0})
+			const observed = vi.fn()
+			store.host.onMounted(() => {
+				watch(source, value => observed(value))
+			})
+
+			store.host.container(container)
+			store.host.mounted()
+			source(1)
+			expect(observed).toHaveBeenCalledTimes(1)
+
+			store.host.container(null)
+			source(2)
+			expect(observed).toHaveBeenCalledTimes(1)
+		})
+
+		it('re-runs setup with the new container on swap', () => {
+			const store = new Store()
+			const first = document.createElement('div')
+			const second = document.createElement('div')
+			const setup = vi.fn()
+			store.host.onMounted(setup)
+
+			store.host.container(first)
+			store.host.mounted()
+			expect(setup).toHaveBeenCalledTimes(1)
+			expect(setup).toHaveBeenLastCalledWith(first)
+
+			store.host.container(second)
+			expect(setup).toHaveBeenCalledTimes(2)
+			expect(setup).toHaveBeenLastCalledWith(second)
+		})
+
+		it('disposes the previous scope before re-running on container swap', () => {
+			const store = new Store()
+			const first = document.createElement('div')
+			const second = document.createElement('div')
+			const source = signal<number>({initial: 0})
+			const observed = vi.fn()
+			store.host.onMounted(container => {
+				watch(source, value => observed(container, value))
+			})
+
+			store.host.container(first)
+			store.host.mounted()
+			source(1)
+			expect(observed).toHaveBeenCalledWith(first, 1)
+
+			store.host.container(second)
+			source(2)
+			// only the new scope's watcher fires
+			expect(observed).toHaveBeenCalledTimes(2)
+			expect(observed).toHaveBeenLastCalledWith(second, 2)
 		})
 	})
 })

--- a/packages/core/src/features/state/Host.spec.ts
+++ b/packages/core/src/features/state/Host.spec.ts
@@ -4,10 +4,8 @@ import {signal, watch} from '../../shared/signals'
 import {Store} from '../../store/Store'
 
 describe('Host', () => {
-	it('exposes mounted, unmounted, rendered events', () => {
+	it('exposes the rendered event', () => {
 		const store = new Store()
-		expect(typeof store.host.mounted).toBe('function')
-		expect(typeof store.host.unmounted).toBe('function')
 		expect(typeof store.host.rendered).toBe('function')
 	})
 

--- a/packages/core/src/features/state/Host.spec.ts
+++ b/packages/core/src/features/state/Host.spec.ts
@@ -3,32 +3,42 @@ import {describe, expect, it, vi} from 'vitest'
 import {signal, watch} from '../../shared/signals'
 import {Store} from '../../store/Store'
 
-describe('Lifecycle', () => {
+describe('Host', () => {
 	it('exposes mounted, unmounted, rendered events', () => {
 		const store = new Store()
-		expect(typeof store.lifecycle.mounted).toBe('function')
-		expect(typeof store.lifecycle.unmounted).toBe('function')
-		expect(typeof store.lifecycle.rendered).toBe('function')
+		expect(typeof store.host.mounted).toBe('function')
+		expect(typeof store.host.unmounted).toBe('function')
+		expect(typeof store.host.rendered).toBe('function')
+	})
+
+	it('exposes a container signal initialised to null', () => {
+		const store = new Store()
+		expect(store.host.container()).toBeNull()
+		const el = document.createElement('div')
+		store.host.container(el)
+		expect(store.host.container()).toBe(el)
+		store.host.container(null)
+		expect(store.host.container()).toBeNull()
 	})
 
 	describe('onMounted()', () => {
 		it('runs setup once on mounted', () => {
 			const store = new Store()
 			const setup = vi.fn()
-			store.lifecycle.onMounted(setup)
+			store.host.onMounted(setup)
 
 			expect(setup).not.toHaveBeenCalled()
-			store.lifecycle.mounted()
+			store.host.mounted()
 			expect(setup).toHaveBeenCalledTimes(1)
 		})
 
 		it('does not re-run setup if mounted fires again without an unmount', () => {
 			const store = new Store()
 			const setup = vi.fn()
-			store.lifecycle.onMounted(setup)
+			store.host.onMounted(setup)
 
-			store.lifecycle.mounted()
-			store.lifecycle.mounted()
+			store.host.mounted()
+			store.host.mounted()
 
 			expect(setup).toHaveBeenCalledTimes(1)
 		})
@@ -37,16 +47,16 @@ describe('Lifecycle', () => {
 			const store = new Store()
 			const source = signal<number>({initial: 0})
 			const observed = vi.fn()
-			store.lifecycle.onMounted(() => {
+			store.host.onMounted(() => {
 				watch(source, value => observed(value))
 			})
 
-			store.lifecycle.mounted()
+			store.host.mounted()
 			source(1)
 			expect(observed).toHaveBeenCalledTimes(1)
 			expect(observed).toHaveBeenLastCalledWith(1)
 
-			store.lifecycle.unmounted()
+			store.host.unmounted()
 			source(2)
 			expect(observed).toHaveBeenCalledTimes(1)
 		})
@@ -54,8 +64,8 @@ describe('Lifecycle', () => {
 		it('does nothing if registered after mount', () => {
 			const store = new Store()
 			const setup = vi.fn()
-			store.lifecycle.mounted()
-			store.lifecycle.onMounted(setup)
+			store.host.mounted()
+			store.host.onMounted(setup)
 			expect(setup).not.toHaveBeenCalled()
 		})
 
@@ -66,12 +76,12 @@ describe('Lifecycle', () => {
 			const setup = vi.fn(() => {
 				watch(source, value => observed(value))
 			})
-			store.lifecycle.onMounted(setup)
+			store.host.onMounted(setup)
 
-			store.lifecycle.mounted()
+			store.host.mounted()
 			source(1)
-			store.lifecycle.unmounted()
-			store.lifecycle.mounted()
+			store.host.unmounted()
+			store.host.mounted()
 			source(2)
 
 			expect(setup).toHaveBeenCalledTimes(2)

--- a/packages/core/src/features/state/Host.ts
+++ b/packages/core/src/features/state/Host.ts
@@ -1,12 +1,10 @@
 import {effectScope, event, signal, watch} from '../../shared/signals'
 
-// Owns adapter-fed runtime state: lifecycle events emitted by the embedding
-// component (mounted/unmounted/rendered) and the host element ref. Features
-// read these; only the React/Vue adapter writes them.
+// Owns adapter-fed runtime state: the rendered event emitted after each
+// component render and the host element ref. Features read these; only the
+// React/Vue adapter writes them.
 
 export class Host {
-	readonly mounted = event()
-	readonly unmounted = event()
 	readonly rendered = event()
 	readonly container = signal<HTMLElement | null>({initial: null})
 

--- a/packages/core/src/features/state/Host.ts
+++ b/packages/core/src/features/state/Host.ts
@@ -11,20 +11,35 @@ export class Host {
 	readonly container = signal<HTMLElement | null>({initial: null})
 
 	/**
-	 * Run `setup` when the editor is mounted. Any reactive subscription
-	 * created inside `setup` (`watch`, `listen`, `effect`, nested
-	 * `effectScope`) is automatically disposed on `unmounted` and re-created
-	 * on the next `mounted`.
+	 * Run `setup` while the editor is mounted with a host element. The callback
+	 * receives the live container; any subscriptions created inside it
+	 * (`watch`, `listen`, `effect`, nested `effectScope`) are auto-disposed
+	 * when the container swaps to a different element or `unmounted` fires,
+	 * and re-created with the new element on swap. The callback is not invoked
+	 * while either condition is unmet.
 	 */
-	onMounted(setup: () => void): void {
+	onMounted(setup: (container: HTMLElement) => void): void {
 		let scope: (() => void) | undefined
-		watch(this.mounted, () => {
-			if (scope) return
-			scope = effectScope(setup)
-		})
-		watch(this.unmounted, () => {
+		let mounted = false
+		let active: HTMLElement | null = null
+
+		const reattach = (): void => {
+			const next = mounted ? this.container() : null
+			if (next === active) return
 			scope?.()
 			scope = undefined
+			active = next
+			if (next) scope = effectScope(() => setup(next))
+		}
+
+		watch(this.mounted, () => {
+			mounted = true
+			reattach()
 		})
+		watch(this.unmounted, () => {
+			mounted = false
+			reattach()
+		})
+		watch(this.container, reattach)
 	}
 }

--- a/packages/core/src/features/state/Host.ts
+++ b/packages/core/src/features/state/Host.ts
@@ -1,9 +1,14 @@
-import {effectScope, event, watch} from '../../shared/signals'
+import {effectScope, event, signal, watch} from '../../shared/signals'
 
-export class Lifecycle {
+// Owns adapter-fed runtime state: lifecycle events emitted by the embedding
+// component (mounted/unmounted/rendered) and the host element ref. Features
+// read these; only the React/Vue adapter writes them.
+
+export class Host {
 	readonly mounted = event()
 	readonly unmounted = event()
 	readonly rendered = event()
+	readonly container = signal<HTMLElement | null>({initial: null})
 
 	/**
 	 * Run `setup` when the editor is mounted. Any reactive subscription

--- a/packages/core/src/features/state/Host.ts
+++ b/packages/core/src/features/state/Host.ts
@@ -11,35 +11,17 @@ export class Host {
 	readonly container = signal<HTMLElement | null>({initial: null})
 
 	/**
-	 * Run `setup` while the editor is mounted with a host element. The callback
-	 * receives the live container; any subscriptions created inside it
-	 * (`watch`, `listen`, `effect`, nested `effectScope`) are auto-disposed
-	 * when the container swaps to a different element or `unmounted` fires,
-	 * and re-created with the new element on swap. The callback is not invoked
-	 * while either condition is unmet.
+	 * Run `setup` whenever a host container is attached. The callback receives
+	 * the live container; any subscriptions created inside it (`watch`,
+	 * `listen`, `effect`, nested `effectScope`) are auto-disposed when the
+	 * container is detached or swapped, and re-created with the new element on
+	 * swap.
 	 */
 	onMounted(setup: (container: HTMLElement) => void): void {
 		let scope: (() => void) | undefined
-		let mounted = false
-		let active: HTMLElement | null = null
-
-		const reattach = (): void => {
-			const next = mounted ? this.container() : null
-			if (next === active) return
+		watch(this.container, container => {
 			scope?.()
-			scope = undefined
-			active = next
-			if (next) scope = effectScope(() => setup(next))
-		}
-
-		watch(this.mounted, () => {
-			mounted = true
-			reattach()
+			scope = container ? effectScope(() => setup(container)) : undefined
 		})
-		watch(this.unmounted, () => {
-			mounted = false
-			reattach()
-		})
-		watch(this.container, reattach)
 	}
 }

--- a/packages/core/src/features/state/ValueModel.spec.ts
+++ b/packages/core/src/features/state/ValueModel.spec.ts
@@ -15,8 +15,6 @@ describe('ValueModel', () => {
 	it('initializes from controlled value on enable', () => {
 		const store = new Store()
 		store.props.set({value: 'hello'})
-		store.host.mounted()
-
 		expect(store.value.current()).toBe('hello')
 		expect(store.tokens.current()).toEqual([{type: 'text', content: 'hello', position: {start: 0, end: 5}}])
 	})
@@ -24,8 +22,6 @@ describe('ValueModel', () => {
 	it('initializes from defaultValue when uncontrolled', () => {
 		const store = new Store()
 		store.props.set({defaultValue: 'hello'})
-		store.host.mounted()
-
 		expect(store.value.current()).toBe('hello')
 		expect(store.tokens.current()).toEqual([{type: 'text', content: 'hello', position: {start: 0, end: 5}}])
 	})
@@ -33,8 +29,6 @@ describe('ValueModel', () => {
 	it('controlled prop echo commits current and tokens', () => {
 		const store = new Store()
 		store.props.set({value: 'hello'})
-		store.host.mounted()
-
 		store.props.set({value: 'world'})
 
 		expect(store.value.current()).toBe('world')
@@ -44,8 +38,6 @@ describe('ValueModel', () => {
 	it('falls back to defaultValue when controlled value becomes undefined', () => {
 		const store = new Store()
 		store.props.set({value: 'hello', defaultValue: 'default'})
-		store.host.mounted()
-
 		store.props.set({value: undefined})
 
 		expect(store.props.value()).toBeUndefined()
@@ -57,8 +49,6 @@ describe('ValueModel', () => {
 		const store = new Store()
 		const onChange = vi.fn()
 		store.props.set({defaultValue: 'hello', readOnly: true, onChange})
-		store.host.mounted()
-
 		store.value.current('world')
 
 		expect(onChange).not.toHaveBeenCalled()
@@ -70,8 +60,6 @@ describe('ValueModel', () => {
 		const store = new Store()
 		const onChange = vi.fn()
 		store.props.set({value: 'hello', readOnly: true, onChange})
-		store.host.mounted()
-
 		store.props.set({value: 'world'})
 
 		expect(onChange).not.toHaveBeenCalled()
@@ -83,8 +71,6 @@ describe('ValueModel', () => {
 		it('commits uncontrolled range replacement', () => {
 			const store = new Store()
 			store.props.set({defaultValue: 'hello world'})
-			store.host.mounted()
-
 			store.value.replace({start: 6, end: 11}, 'markput')
 
 			expect(store.value.current()).toBe('hello markput')
@@ -94,8 +80,6 @@ describe('ValueModel', () => {
 			const store = new Store()
 			const onChange = vi.fn()
 			store.props.set({defaultValue: 'hello', onChange})
-			store.host.mounted()
-
 			store.value.replace({start: 4, end: 2}, 'x')
 
 			expect(onChange).not.toHaveBeenCalled()
@@ -106,8 +90,6 @@ describe('ValueModel', () => {
 			const store = new Store()
 			const onChange = vi.fn()
 			store.props.set({value: 'hello', onChange})
-			store.host.mounted()
-
 			store.value.replace({start: 0, end: 5}, 'world')
 
 			expect(onChange).toHaveBeenCalledWith('world')

--- a/packages/core/src/features/state/ValueModel.spec.ts
+++ b/packages/core/src/features/state/ValueModel.spec.ts
@@ -15,7 +15,7 @@ describe('ValueModel', () => {
 	it('initializes from controlled value on enable', () => {
 		const store = new Store()
 		store.props.set({value: 'hello'})
-		store.lifecycle.mounted()
+		store.host.mounted()
 
 		expect(store.value.current()).toBe('hello')
 		expect(store.tokens.current()).toEqual([{type: 'text', content: 'hello', position: {start: 0, end: 5}}])
@@ -24,7 +24,7 @@ describe('ValueModel', () => {
 	it('initializes from defaultValue when uncontrolled', () => {
 		const store = new Store()
 		store.props.set({defaultValue: 'hello'})
-		store.lifecycle.mounted()
+		store.host.mounted()
 
 		expect(store.value.current()).toBe('hello')
 		expect(store.tokens.current()).toEqual([{type: 'text', content: 'hello', position: {start: 0, end: 5}}])
@@ -33,7 +33,7 @@ describe('ValueModel', () => {
 	it('controlled prop echo commits current and tokens', () => {
 		const store = new Store()
 		store.props.set({value: 'hello'})
-		store.lifecycle.mounted()
+		store.host.mounted()
 
 		store.props.set({value: 'world'})
 
@@ -44,7 +44,7 @@ describe('ValueModel', () => {
 	it('falls back to defaultValue when controlled value becomes undefined', () => {
 		const store = new Store()
 		store.props.set({value: 'hello', defaultValue: 'default'})
-		store.lifecycle.mounted()
+		store.host.mounted()
 
 		store.props.set({value: undefined})
 
@@ -57,7 +57,7 @@ describe('ValueModel', () => {
 		const store = new Store()
 		const onChange = vi.fn()
 		store.props.set({defaultValue: 'hello', readOnly: true, onChange})
-		store.lifecycle.mounted()
+		store.host.mounted()
 
 		store.value.current('world')
 
@@ -70,7 +70,7 @@ describe('ValueModel', () => {
 		const store = new Store()
 		const onChange = vi.fn()
 		store.props.set({value: 'hello', readOnly: true, onChange})
-		store.lifecycle.mounted()
+		store.host.mounted()
 
 		store.props.set({value: 'world'})
 
@@ -83,7 +83,7 @@ describe('ValueModel', () => {
 		it('commits uncontrolled range replacement', () => {
 			const store = new Store()
 			store.props.set({defaultValue: 'hello world'})
-			store.lifecycle.mounted()
+			store.host.mounted()
 
 			store.value.replace({start: 6, end: 11}, 'markput')
 
@@ -94,7 +94,7 @@ describe('ValueModel', () => {
 			const store = new Store()
 			const onChange = vi.fn()
 			store.props.set({defaultValue: 'hello', onChange})
-			store.lifecycle.mounted()
+			store.host.mounted()
 
 			store.value.replace({start: 4, end: 2}, 'x')
 
@@ -106,7 +106,7 @@ describe('ValueModel', () => {
 			const store = new Store()
 			const onChange = vi.fn()
 			store.props.set({value: 'hello', onChange})
-			store.lifecycle.mounted()
+			store.host.mounted()
 
 			store.value.replace({start: 0, end: 5}, 'world')
 

--- a/packages/core/src/features/state/index.ts
+++ b/packages/core/src/features/state/index.ts
@@ -1,3 +1,3 @@
-export {Lifecycle} from './Lifecycle'
+export {Host} from './Host'
 export {PropsModel} from './PropsModel'
 export {ValueModel} from './ValueModel'

--- a/packages/core/src/store/MarkputHandler.ts
+++ b/packages/core/src/store/MarkputHandler.ts
@@ -1,16 +1,16 @@
-import type {DomModel} from '../features/dom/DomModel'
 import type {OverlayController} from '../features/overlay/OverlayController'
 import type {SelectionController} from '../features/selection/SelectionController'
+import type {Host} from '../features/state/Host'
 
 export class MarkputHandler {
 	constructor(
-		private readonly dom: DomModel,
+		private readonly host: Host,
 		private readonly overlayFeature: OverlayController,
 		private readonly selection: SelectionController
 	) {}
 
 	get container() {
-		return this.dom.container()
+		return this.host.container()
 	}
 
 	get overlay() {

--- a/packages/core/src/store/README.md
+++ b/packages/core/src/store/README.md
@@ -6,11 +6,12 @@ The central orchestrator of the markput system. Aggregates reactive state, compu
 
 - **Store**: Main state container that manages:
     - **Feature state** (`store.<feature>.*`) — signals owned by features: tokens, accepted serialized value, caret range, drag-selection flag, overlay match
+    - **Host** (`store.host`) — adapter-fed runtime state: `mounted`/`unmounted`/`rendered` events and the `container` HTMLElement signal. Written by React/Vue `MarkedInput`; features read.
     - **Props** (`store.props`) — readonly signals written only via `store.props.set()` (value, options, readOnly, drag, slots, etc.)
     - **Computed values** (`store.<feature>.*`) — derived values: `enabled`, `parser`, `caret.position`, `containerComponent`, `containerProps`, slot resolvers
-    - **Events** (`store.<feature>.<event>()`) — typed reactive events: `parsing.reparse`, `overlay.select`, `overlay.close`, `drag.action`, and lifecycle events
-    - **DOM refs** (`store.dom.container`, `store.overlay.element`) — reactive signals holding container and overlay HTMLElement references
-    - **DOM registration** (`store.dom`) — adapter-owned structural refs, token location, raw selection mapping, and caret placement
+    - **Events** (`store.<feature>.<event>()`) — typed reactive events: `parsing.reparse`, `overlay.select`, `overlay.close`, `drag.action`, and host lifecycle events
+    - **DOM refs** (`store.host.container`, `store.overlay.element`) — reactive signals holding container and overlay HTMLElement references
+    - **DOM registration** (`store.dom`) — adapter-owned structural refs (`controlFor`, `childrenFor`), token location, raw selection mapping, and caret placement
     - **Features** (`store.<feature>`) — all feature instances
     - **`store.props.set()`** — batch update for framework-provided prop signals (used by React/Vue `MarkedInput`)
 

--- a/packages/core/src/store/README.md
+++ b/packages/core/src/store/README.md
@@ -6,7 +6,7 @@ The central orchestrator of the markput system. Aggregates reactive state, compu
 
 - **Store**: Main state container that manages:
     - **Feature state** (`store.<feature>.*`) — signals owned by features: tokens, accepted serialized value, caret range, drag-selection flag, overlay match
-    - **Host** (`store.host`) — adapter-fed runtime state: `mounted`/`unmounted`/`rendered` events and the `container` HTMLElement signal. Written by React/Vue `MarkedInput`; features read. `host.onMounted(cb)` runs `cb(container)` only while both `mounted` and `container` are non-null, auto-disposing and re-running on container swaps.
+    - **Host** (`store.host`) — adapter-fed runtime state: `mounted`/`unmounted`/`rendered` events and the `container` HTMLElement signal. Written by React/Vue `MarkedInput`; features read. `host.onMounted(cb)` runs `cb(container)` whenever a container is attached, auto-disposing inner subscriptions on detach and re-running with the new element on swap.
     - **Props** (`store.props`) — readonly signals written only via `store.props.set()` (value, options, readOnly, drag, slots, etc.)
     - **Computed values** (`store.<feature>.*`) — derived values: `enabled`, `parser`, `caret.position`, `containerComponent`, `containerProps`, slot resolvers
     - **Events** (`store.<feature>.<event>()`) — typed reactive events: `parsing.reparse`, `overlay.select`, `overlay.close`, `drag.action`, and host lifecycle events

--- a/packages/core/src/store/README.md
+++ b/packages/core/src/store/README.md
@@ -6,7 +6,7 @@ The central orchestrator of the markput system. Aggregates reactive state, compu
 
 - **Store**: Main state container that manages:
     - **Feature state** (`store.<feature>.*`) — signals owned by features: tokens, accepted serialized value, caret range, drag-selection flag, overlay match
-    - **Host** (`store.host`) — adapter-fed runtime state: `mounted`/`unmounted`/`rendered` events and the `container` HTMLElement signal. Written by React/Vue `MarkedInput`; features read. `host.onMounted(cb)` runs `cb(container)` whenever a container is attached, auto-disposing inner subscriptions on detach and re-running with the new element on swap.
+    - **Host** (`store.host`) — adapter-fed runtime state: the `rendered` event and the `container` HTMLElement signal. Written by React/Vue `MarkedInput`; features read. `host.onMounted(cb)` runs `cb(container)` whenever a container is attached, auto-disposing inner subscriptions on detach and re-running with the new element on swap.
     - **Props** (`store.props`) — readonly signals written only via `store.props.set()` (value, options, readOnly, drag, slots, etc.)
     - **Computed values** (`store.<feature>.*`) — derived values: `enabled`, `parser`, `caret.position`, `containerComponent`, `containerProps`, slot resolvers
     - **Events** (`store.<feature>.<event>()`) — typed reactive events: `parsing.reparse`, `overlay.select`, `overlay.close`, `drag.action`, and host lifecycle events

--- a/packages/core/src/store/README.md
+++ b/packages/core/src/store/README.md
@@ -6,7 +6,7 @@ The central orchestrator of the markput system. Aggregates reactive state, compu
 
 - **Store**: Main state container that manages:
     - **Feature state** (`store.<feature>.*`) — signals owned by features: tokens, accepted serialized value, caret range, drag-selection flag, overlay match
-    - **Host** (`store.host`) — adapter-fed runtime state: `mounted`/`unmounted`/`rendered` events and the `container` HTMLElement signal. Written by React/Vue `MarkedInput`; features read.
+    - **Host** (`store.host`) — adapter-fed runtime state: `mounted`/`unmounted`/`rendered` events and the `container` HTMLElement signal. Written by React/Vue `MarkedInput`; features read. `host.onMounted(cb)` runs `cb(container)` only while both `mounted` and `container` are non-null, auto-disposing and re-running on container swaps.
     - **Props** (`store.props`) — readonly signals written only via `store.props.set()` (value, options, readOnly, drag, slots, etc.)
     - **Computed values** (`store.<feature>.*`) — derived values: `enabled`, `parser`, `caret.position`, `containerComponent`, `containerProps`, slot resolvers
     - **Events** (`store.<feature>.<event>()`) — typed reactive events: `parsing.reparse`, `overlay.select`, `overlay.close`, `drag.action`, and host lifecycle events

--- a/packages/core/src/store/Store.spec.ts
+++ b/packages/core/src/store/Store.spec.ts
@@ -36,7 +36,7 @@ describe('Store', () => {
 			expect(handler.container).toBe(null)
 			// oxlint-disable-next-line no-unsafe-type-assertion -- minimal stub for reference identity check only, no DOM methods used
 			const stub = {} as HTMLDivElement
-			store.dom.container(stub)
+			store.host.container(stub)
 			expect(handler.container).toBe(stub)
 		})
 
@@ -131,7 +131,7 @@ describe('Store', () => {
 	describe('value edits', () => {
 		it('updates tokens and current when uncontrolled replacement is accepted', () => {
 			const store = new Store()
-			store.lifecycle.mounted()
+			store.host.mounted()
 			store.value.current('hello')
 			expect(store.tokens.current()).toEqual([{type: 'text', content: 'hello', position: {start: 0, end: 5}}])
 			expect(store.value.current()).toBe('hello')
@@ -141,7 +141,7 @@ describe('Store', () => {
 			const store = new Store()
 			const onChange = vi.fn()
 			store.props.set({onChange})
-			store.lifecycle.mounted()
+			store.host.mounted()
 			store.value.current('world')
 			expect(onChange).toHaveBeenCalledOnce()
 			expect(onChange).toHaveBeenCalledWith('world')
@@ -151,7 +151,7 @@ describe('Store', () => {
 			const store = new Store()
 			const onChange = vi.fn()
 			store.props.set({value: 'hello', onChange})
-			store.lifecycle.mounted()
+			store.host.mounted()
 			store.value.current('world')
 			expect(onChange).toHaveBeenCalledWith('world')
 			expect(store.value.current()).toBe('hello')
@@ -160,7 +160,7 @@ describe('Store', () => {
 
 		it('not throw when onChange is not set', () => {
 			const store = new Store()
-			store.lifecycle.mounted()
+			store.host.mounted()
 			expect(() => store.value.current('test')).not.toThrow()
 		})
 	})
@@ -397,7 +397,7 @@ describe('Store', () => {
 		it('reacts to props.value changes when ValueModel is enabled', () => {
 			const store = new Store()
 			store.props.set({value: 'initial'})
-			store.lifecycle.mounted()
+			store.host.mounted()
 			expect(store.value.current()).toBe('initial')
 			store.props.set({value: 'changed'})
 			expect(store.value.current()).toBe('changed')

--- a/packages/core/src/store/Store.spec.ts
+++ b/packages/core/src/store/Store.spec.ts
@@ -34,10 +34,9 @@ describe('Store', () => {
 			const store = new Store()
 			const handler = store.handler
 			expect(handler.container).toBe(null)
-			// oxlint-disable-next-line no-unsafe-type-assertion -- minimal stub for reference identity check only, no DOM methods used
-			const stub = {} as HTMLDivElement
-			store.host.container(stub)
-			expect(handler.container).toBe(stub)
+			const el = document.createElement('div')
+			store.host.container(el)
+			expect(handler.container).toBe(el)
 		})
 
 		it('reflect state.overlay via handler.overlay', () => {

--- a/packages/core/src/store/Store.spec.ts
+++ b/packages/core/src/store/Store.spec.ts
@@ -130,7 +130,6 @@ describe('Store', () => {
 	describe('value edits', () => {
 		it('updates tokens and current when uncontrolled replacement is accepted', () => {
 			const store = new Store()
-			store.host.mounted()
 			store.value.current('hello')
 			expect(store.tokens.current()).toEqual([{type: 'text', content: 'hello', position: {start: 0, end: 5}}])
 			expect(store.value.current()).toBe('hello')
@@ -140,7 +139,6 @@ describe('Store', () => {
 			const store = new Store()
 			const onChange = vi.fn()
 			store.props.set({onChange})
-			store.host.mounted()
 			store.value.current('world')
 			expect(onChange).toHaveBeenCalledOnce()
 			expect(onChange).toHaveBeenCalledWith('world')
@@ -150,7 +148,6 @@ describe('Store', () => {
 			const store = new Store()
 			const onChange = vi.fn()
 			store.props.set({value: 'hello', onChange})
-			store.host.mounted()
 			store.value.current('world')
 			expect(onChange).toHaveBeenCalledWith('world')
 			expect(store.value.current()).toBe('hello')
@@ -159,7 +156,6 @@ describe('Store', () => {
 
 		it('not throw when onChange is not set', () => {
 			const store = new Store()
-			store.host.mounted()
 			expect(() => store.value.current('test')).not.toThrow()
 		})
 	})
@@ -396,7 +392,6 @@ describe('Store', () => {
 		it('reacts to props.value changes when ValueModel is enabled', () => {
 			const store = new Store()
 			store.props.set({value: 'initial'})
-			store.host.mounted()
 			expect(store.value.current()).toBe('initial')
 			store.props.set({value: 'changed'})
 			expect(store.value.current()).toBe('changed')

--- a/packages/core/src/store/Store.ts
+++ b/packages/core/src/store/Store.ts
@@ -15,8 +15,6 @@ export type {DragAction} from '../shared/types'
 
 export class Store {
 	readonly key = new KeyGenerator()
-	// 0 from 10
-	readonly blocks = new BlockRegistry()
 
 	readonly host = new Host()
 	readonly props = new PropsModel()
@@ -49,6 +47,8 @@ export class Store {
 		this.props
 	)
 	readonly block = new BlockController(this.props, this.value, this.tokens, this.selection, this.edit)
+	readonly blocks = new BlockRegistry()
+
 	readonly clipboard = new ClipboardController(this.host, this.edit, this.dom, this.tokens)
 
 	readonly handler = new MarkputHandler(this.host, this.overlay, this.selection)

--- a/packages/core/src/store/Store.ts
+++ b/packages/core/src/store/Store.ts
@@ -7,7 +7,7 @@ import {OverlayController} from '../features/overlay'
 import {TokenModel} from '../features/parsing'
 import {SelectionController} from '../features/selection'
 import {SlotsFeature} from '../features/slots'
-import {Lifecycle, PropsModel, ValueModel} from '../features/state'
+import {Host, PropsModel, ValueModel} from '../features/state'
 import {KeyGenerator} from '../shared/classes'
 import {MarkputHandler} from './MarkputHandler'
 
@@ -18,20 +18,20 @@ export class Store {
 	// 0 from 10
 	readonly blocks = new BlockRegistry()
 
-	readonly lifecycle = new Lifecycle()
+	readonly host = new Host()
 	readonly props = new PropsModel()
 	readonly value = new ValueModel(this.props)
 	readonly tokens = new TokenModel(this.value, this.props)
 
 	readonly slots = new SlotsFeature(this.props)
 
-	readonly dom = new DomModel(this.lifecycle, this.props, this.tokens)
+	readonly dom = new DomModel(this.host, this.props, this.tokens)
 
-	readonly selection = new SelectionController(this.lifecycle, this.dom, this.tokens, this.value, this.props)
+	readonly selection = new SelectionController(this.host, this.dom, this.tokens, this.value, this.props)
 	readonly edit = new EditController(this.value, this.selection)
 
 	readonly overlay = new OverlayController(
-		this.lifecycle,
+		this.host,
 		this.props,
 		this.value,
 		this.dom,
@@ -40,7 +40,7 @@ export class Store {
 		this.tokens
 	)
 	readonly keyboard = new KeyboardController(
-		this.lifecycle,
+		this.host,
 		this.dom,
 		this.value,
 		this.selection,
@@ -49,7 +49,7 @@ export class Store {
 		this.props
 	)
 	readonly block = new BlockController(this.props, this.value, this.tokens, this.selection, this.edit)
-	readonly clipboard = new ClipboardController(this.lifecycle, this.edit, this.dom, this.tokens)
+	readonly clipboard = new ClipboardController(this.host, this.edit, this.dom, this.tokens)
 
-	readonly handler = new MarkputHandler(this.dom, this.overlay, this.selection)
+	readonly handler = new MarkputHandler(this.host, this.overlay, this.selection)
 }

--- a/packages/react/markput/src/components/Container.tsx
+++ b/packages/react/markput/src/components/Container.tsx
@@ -5,9 +5,8 @@ import {Block} from './Block'
 import {Token} from './Token'
 
 export const Container = memo(() => {
-	const {dom, lifecycle, isBlock, tokens, key, Component, props} = useMarkput(s => ({
-		dom: s.dom,
-		lifecycle: s.lifecycle,
+	const {host, isBlock, tokens, key, Component, props} = useMarkput(s => ({
+		host: s.host,
 		isBlock: s.props.layout.isBlock,
 		tokens: s.tokens.current,
 		key: s.key,
@@ -16,11 +15,11 @@ export const Container = memo(() => {
 	}))
 
 	useLayoutEffect(() => {
-		lifecycle.rendered()
+		host.rendered()
 	})
 
 	return (
-		<Component ref={dom.container} {...props}>
+		<Component ref={host.container} {...props}>
 			{isBlock
 				? tokens.map(t => <Block key={key.get(t)} token={t} />)
 				: tokens.map(t => <Token key={key.get(t)} token={t} />)}

--- a/packages/react/markput/src/components/MarkedInput.tsx
+++ b/packages/react/markput/src/components/MarkedInput.tsx
@@ -90,11 +90,6 @@ export function MarkedInput<TMarkProps = MarkProps, TOverlayProps extends CoreOp
 		store.props.set(props)
 	})
 
-	useLayoutEffect(() => {
-		store.host.mounted()
-		return () => store.host.unmounted()
-	}, [])
-
 	useImperativeHandle(props.ref, () => store.handler, [store])
 
 	return (

--- a/packages/react/markput/src/components/MarkedInput.tsx
+++ b/packages/react/markput/src/components/MarkedInput.tsx
@@ -91,8 +91,8 @@ export function MarkedInput<TMarkProps = MarkProps, TOverlayProps extends CoreOp
 	})
 
 	useLayoutEffect(() => {
-		store.lifecycle.mounted()
-		return () => store.lifecycle.unmounted()
+		store.host.mounted()
+		return () => store.host.unmounted()
 	}, [])
 
 	useImperativeHandle(props.ref, () => store.handler, [store])

--- a/packages/react/markput/src/components/Suggestions/Suggestions.tsx
+++ b/packages/react/markput/src/components/Suggestions/Suggestions.tsx
@@ -8,7 +8,7 @@ import {ListItem} from '../Popup/ListItem'
 import {Popup} from '../Popup/Popup'
 
 export const Suggestions = () => {
-	const container = useMarkput(s => s.dom.container)
+	const container = useMarkput(s => s.host.container)
 	const {match, select, style, ref} = useOverlay()
 	const [active, setActive] = useState(NaN)
 	const data = match?.option.overlay?.data ?? []

--- a/packages/vue/markput/src/components/Container.vue
+++ b/packages/vue/markput/src/components/Container.vue
@@ -16,14 +16,14 @@ const result = useMarkput(s => ({
 const setContainerRef = (el: unknown) => {
 	const resolved = el as {$el?: HTMLElement} | HTMLElement | null
 	const element = (resolved && '$el' in resolved ? resolved.$el : resolved) as HTMLDivElement | null
-	store.dom.container(element)
+	store.host.container(element)
 }
 
 const containerComponent = useMarkput(s => s.slots.containerComponent)
 const containerProps = useMarkput(s => s.slots.containerProps)
 
-onMounted(() => store.lifecycle.rendered())
-onUpdated(() => store.lifecycle.rendered())
+onMounted(() => store.host.rendered())
+onUpdated(() => store.host.rendered())
 </script>
 
 <template>

--- a/packages/vue/markput/src/components/MarkedInput.vue
+++ b/packages/vue/markput/src/components/MarkedInput.vue
@@ -78,9 +78,9 @@ watch(
 )
 
 onMounted(() => {
-	store.value.lifecycle.mounted()
+	store.value.host.mounted()
 })
-onUnmounted(() => store.value.lifecycle.unmounted())
+onUnmounted(() => store.value.host.unmounted())
 
 defineExpose(store.value.handler)
 </script>

--- a/packages/vue/markput/src/components/MarkedInput.vue
+++ b/packages/vue/markput/src/components/MarkedInput.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import {type CoreSlots, Store} from '@markput/core'
-import {markRaw, onMounted, onUnmounted, provide, shallowRef, toRaw, watch} from 'vue'
+import {markRaw, provide, shallowRef, toRaw, watch} from 'vue'
 
 import {STORE_KEY} from '../lib/providers/storeKey'
 import type {MarkedInputProps} from '../types'
@@ -76,11 +76,6 @@ watch(
 	],
 	syncProps
 )
-
-onMounted(() => {
-	store.value.host.mounted()
-})
-onUnmounted(() => store.value.host.unmounted())
 
 defineExpose(store.value.handler)
 </script>

--- a/packages/vue/markput/src/components/Suggestions/Suggestions.vue
+++ b/packages/vue/markput/src/components/Suggestions/Suggestions.vue
@@ -37,12 +37,12 @@ function handleKeyDown(event: KeyboardEvent) {
 }
 
 onMounted(() => {
-	const container = store.dom.container()
+	const container = store.host.container()
 	if (container) container.addEventListener('keydown', handleKeyDown)
 })
 
 onUnmounted(() => {
-	const container = store.dom.container()
+	const container = store.host.container()
 	if (container) container.removeEventListener('keydown', handleKeyDown)
 })
 

--- a/packages/website/src/content/docs/api/classes/MarkController.md
+++ b/packages/website/src/content/docs/api/classes/MarkController.md
@@ -13,8 +13,8 @@ Defined in: [core/src/features/parsing/MarkController.ts:6](https://github.com/N
 
 ```ts
 new MarkController(
-   store,
-   address,
+   store, 
+   address, 
    snapshot): MarkController;
 ```
 

--- a/packages/website/src/content/docs/api/classes/MarkController.md
+++ b/packages/website/src/content/docs/api/classes/MarkController.md
@@ -13,8 +13,8 @@ Defined in: [core/src/features/parsing/MarkController.ts:6](https://github.com/N
 
 ```ts
 new MarkController(
-   store, 
-   address, 
+   store,
+   address,
    snapshot): MarkController;
 ```
 

--- a/packages/website/src/content/docs/api/classes/MarkputHandler.md
+++ b/packages/website/src/content/docs/api/classes/MarkputHandler.md
@@ -13,8 +13,8 @@ Defined in: [core/src/store/MarkputHandler.ts:5](https://github.com/Nowely/marke
 
 ```ts
 new MarkputHandler(
-   host, 
-   overlayFeature, 
+   host,
+   overlayFeature,
    selection): MarkputHandler;
 ```
 

--- a/packages/website/src/content/docs/api/classes/MarkputHandler.md
+++ b/packages/website/src/content/docs/api/classes/MarkputHandler.md
@@ -13,8 +13,8 @@ Defined in: [core/src/store/MarkputHandler.ts:5](https://github.com/Nowely/marke
 
 ```ts
 new MarkputHandler(
-   host,
-   overlayFeature,
+   host, 
+   overlayFeature, 
    selection): MarkputHandler;
 ```
 

--- a/packages/website/src/content/docs/api/classes/MarkputHandler.md
+++ b/packages/website/src/content/docs/api/classes/MarkputHandler.md
@@ -13,7 +13,7 @@ Defined in: [core/src/store/MarkputHandler.ts:5](https://github.com/Nowely/marke
 
 ```ts
 new MarkputHandler(
-   dom,
+   host,
    overlayFeature,
    selection): MarkputHandler;
 ```
@@ -24,7 +24,7 @@ Defined in: [core/src/store/MarkputHandler.ts:6](https://github.com/Nowely/marke
 
 | Parameter | Type |
 | ------ | ------ |
-| `dom` | `DomModel` |
+| `host` | `Host` |
 | `overlayFeature` | `OverlayController` |
 | `selection` | `SelectionController` |
 

--- a/packages/website/src/content/docs/api/functions/denote.md
+++ b/packages/website/src/content/docs/api/functions/denote.md
@@ -7,8 +7,8 @@ title: "denote"
 
 ```ts
 function denote(
-   value, 
-   callback, 
+   value,
+   callback,
    markups): string;
 ```
 

--- a/packages/website/src/content/docs/api/functions/denote.md
+++ b/packages/website/src/content/docs/api/functions/denote.md
@@ -7,8 +7,8 @@ title: "denote"
 
 ```ts
 function denote(
-   value,
-   callback,
+   value, 
+   callback, 
    markups): string;
 ```
 

--- a/packages/website/src/content/docs/api/interfaces/OverlayHandler.md
+++ b/packages/website/src/content/docs/api/interfaces/OverlayHandler.md
@@ -26,7 +26,7 @@ Defined in: [react/markput/src/lib/hooks/useOverlay.tsx:14](https://github.com/N
 ### match
 
 ```ts
-match: 
+match:
   | OverlayMatch<Option<MarkProps, OverlayProps>>
   | undefined;
 ```

--- a/packages/website/src/content/docs/api/interfaces/OverlayHandler.md
+++ b/packages/website/src/content/docs/api/interfaces/OverlayHandler.md
@@ -26,7 +26,7 @@ Defined in: [react/markput/src/lib/hooks/useOverlay.tsx:14](https://github.com/N
 ### match
 
 ```ts
-match:
+match: 
   | OverlayMatch<Option<MarkProps, OverlayProps>>
   | undefined;
 ```

--- a/packages/website/src/content/docs/api/type-aliases/Markup.md
+++ b/packages/website/src/content/docs/api/type-aliases/Markup.md
@@ -6,7 +6,7 @@ title: "Markup"
 ---
 
 ```ts
-type Markup = 
+type Markup =
   | ValueMarkup
   | `${ValueMarkup}${MetaMarkup}`
   | `${ValueMarkup}${MetaMarkup}${SlotMarkup}`

--- a/packages/website/src/content/docs/api/type-aliases/Markup.md
+++ b/packages/website/src/content/docs/api/type-aliases/Markup.md
@@ -6,7 +6,7 @@ title: "Markup"
 ---
 
 ```ts
-type Markup =
+type Markup = 
   | ValueMarkup
   | `${ValueMarkup}${MetaMarkup}`
   | `${ValueMarkup}${MetaMarkup}${SlotMarkup}`

--- a/packages/website/src/content/docs/api/type-aliases/Token.md
+++ b/packages/website/src/content/docs/api/type-aliases/Token.md
@@ -6,7 +6,7 @@ title: "Token"
 ---
 
 ```ts
-type Token = 
+type Token =
   | TextToken
   | MarkToken;
 ```

--- a/packages/website/src/content/docs/api/type-aliases/Token.md
+++ b/packages/website/src/content/docs/api/type-aliases/Token.md
@@ -6,7 +6,7 @@ title: "Token"
 ---
 
 ```ts
-type Token =
+type Token = 
   | TextToken
   | MarkToken;
 ```

--- a/packages/website/src/content/docs/development/architecture.md
+++ b/packages/website/src/content/docs/development/architecture.md
@@ -385,8 +385,11 @@ Signal subscription order is significant: `ParseController` subscribes to `value
 React/Vue render asynchronously, so initialization order matters:
 
 ```typescript
-// 1. Framework emits store.host.mounted() on initial mount
-//    → Store enables all features (DOM listeners, reactive subscriptions)
+// 1. Framework writes the container element via store.host.container(el)
+//    and emits store.host.mounted() on initial mount.
+//    → Each feature's onMounted callback fires only when both conditions hold,
+//      receiving the live container element. It also re-fires (with auto-disposal
+//      of the previous scope) if the framework swaps to a different container.
 
 // 2. After mount, ValueModel accepts props.value/defaultValue. ParseController
 //    subscribed to value.current first inside its onMounted hook, so tokens are

--- a/packages/website/src/content/docs/development/architecture.md
+++ b/packages/website/src/content/docs/development/architecture.md
@@ -222,9 +222,9 @@ Events use `event<T>()` to create typed emitters backed by reactive signals:
 | `reparse`       | parsing        | Re-parse triggered          | `void`                           |
 | `close`         | overlay        | Close overlay               | `void`                           |
 | `select`        | overlay        | Overlay item selected       | `{ mark: Token, match: OverlayMatch }` |
-| `rendered`      | lifecycle      | After tokens render         | `void`                           |
-| `mounted`       | lifecycle      | Framework initial mount      | `void`                           |
-| `unmounted`     | lifecycle      | Framework unmount           | `void`                           |
+| `rendered`      | host           | After tokens render         | `void`                           |
+| `mounted`       | host           | Framework initial mount      | `void`                           |
+| `unmounted`     | host           | Framework unmount           | `void`                           |
 | `action`        | drag           | Drag-and-drop action        | `DragAction`                     |
 
 `DomController.reconcile()` is a method called by reactive effects and by the post-render focus workflow; it is not a store event.
@@ -314,7 +314,7 @@ class Store {
     }
 
     // Features live directly on store, not nested under .feature
-    readonly lifecycle: Lifecycle          // mounted, unmounted, rendered events
+    readonly host:      Host               // mounted/unmounted/rendered events + container HTMLElement
     readonly props:     PropsModel         // framework-provided configuration
     readonly caret:     CaretModel         // selection, position (computed), isUserSelecting, isAllSelected
     readonly slots:     SlotsFeature       // isBlock, isDragEnabled, slot component/props, mark resolver
@@ -366,7 +366,7 @@ Signal subscription order is significant: `ParseController` subscribes to `value
 
 | Feature                       | Responsibility                                           |
 | ----------------------------- | -------------------------------------------------------- |
-| **Lifecycle**                 | Mount/unmount/render lifecycle events                     |
+| **Host**                      | Adapter-fed runtime state: mount/unmount/render events and the container HTMLElement |
 | **ValueModel**                | Accepted serialized value state, raw range replacement   |
 | **EditController**            | Unified user edit path: `replace(range, replacement, caretAt?)`, `{end: -1}` resolves to current value length |
 | **ParseController**           | Token parsing, parser selection, reparse event            |
@@ -385,7 +385,7 @@ Signal subscription order is significant: `ParseController` subscribes to `value
 React/Vue render asynchronously, so initialization order matters:
 
 ```typescript
-// 1. Framework emits store.lifecycle.mounted() on initial mount
+// 1. Framework emits store.host.mounted() on initial mount
 //    → Store enables all features (DOM listeners, reactive subscriptions)
 
 // 2. After mount, ValueModel accepts props.value/defaultValue. ParseController
@@ -395,9 +395,9 @@ React/Vue render asynchronously, so initialization order matters:
 // 3. Sync contenteditable attributes (layout effect)
 //    → DomController reconciles DOM state
 
-// 4. Framework emits store.lifecycle.rendered() after tokens render
+// 4. Framework emits store.host.rendered() after tokens render
 
-// 5. Framework emits store.lifecycle.unmounted() on unmount
+// 5. Framework emits store.host.unmounted() on unmount
 //    → Store disables all features (cleanup DOM listeners, dispose scopes)
 ```
 

--- a/packages/website/src/content/docs/development/architecture.md
+++ b/packages/website/src/content/docs/development/architecture.md
@@ -385,11 +385,10 @@ Signal subscription order is significant: `ParseController` subscribes to `value
 React/Vue render asynchronously, so initialization order matters:
 
 ```typescript
-// 1. Framework writes the container element via store.host.container(el)
-//    and emits store.host.mounted() on initial mount.
-//    → Each feature's onMounted callback fires only when both conditions hold,
-//      receiving the live container element. It also re-fires (with auto-disposal
-//      of the previous scope) if the framework swaps to a different container.
+// 1. Framework writes the container element via store.host.container(el).
+//    → Each feature's onMounted callback fires with the live container element.
+//      It also re-fires (with auto-disposal of the previous scope) if the
+//      framework swaps to a different container.
 
 // 2. After mount, ValueModel accepts props.value/defaultValue. ParseController
 //    subscribed to value.current first inside its onMounted hook, so tokens are
@@ -400,8 +399,8 @@ React/Vue render asynchronously, so initialization order matters:
 
 // 4. Framework emits store.host.rendered() after tokens render
 
-// 5. Framework emits store.host.unmounted() on unmount
-//    → Store disables all features (cleanup DOM listeners, dispose scopes)
+// 5. Framework writes store.host.container(null) on unmount
+//    → Each onMounted scope is disposed (DOM listeners removed, watchers torn down)
 ```
 
 ## Block System (Drag Mode)

--- a/packages/website/src/content/docs/development/architecture.md
+++ b/packages/website/src/content/docs/development/architecture.md
@@ -366,7 +366,7 @@ Signal subscription order is significant: `ParseController` subscribes to `value
 
 | Feature                       | Responsibility                                           |
 | ----------------------------- | -------------------------------------------------------- |
-| **Host**                      | Adapter-fed runtime state: mount/unmount/render events and the container HTMLElement |
+| **Host**                      | Adapter-fed runtime state: the rendered event and the container HTMLElement |
 | **ValueModel**                | Accepted serialized value state, raw range replacement   |
 | **EditController**            | Unified user edit path: `replace(range, replacement, caretAt?)`, `{end: -1}` resolves to current value length |
 | **ParseController**           | Token parsing, parser selection, reparse event            |

--- a/packages/website/src/content/docs/guides/keyboard-handling.md
+++ b/packages/website/src/content/docs/guides/keyboard-handling.md
@@ -9,7 +9,7 @@ Markput handles text input, deletion, paste, overlay insertion, block editing, a
 ## Edit Flow
 
 1. React/Vue render adapter-owned token shells and text surfaces.
-2. The adapter registers the root with `store.dom.container` and child structure through `store.dom.controlFor(path?)` (for non-editable controls inside a token) and `store.dom.childrenFor(ownerPath)` (for nested `__slot__` child sequence hosts).
+2. The adapter registers the root with `store.host.container` and child structure through `store.dom.controlFor(path?)` (for non-editable controls inside a token) and `store.dom.childrenFor(ownerPath)` (for nested `__slot__` child sequence hosts).
 3. Keyboard handlers convert the browser selection to a raw serialized range through `store.dom.readRawSelection()` or `store.dom.rawPositionFromBoundary()`.
 4. Edits call `store.value.replace()` and optionally write `store.caret.selection()` to set the post-edit caret.
 5. `DomController` applies `caret.selection` to the DOM after the next render.


### PR DESCRIPTION
## Summary
- Renamed `Lifecycle` to `Host` across core, providing a cleaner container-attachment API for lifecycle callbacks
- Updated `BlockController`, `ClipboardController`, `KeyboardController`, `OverlayController`, `SelectionController`, and related features to use `container` from `Host` instead of direct lifecycle references
- Removed unnecessary `mounted` calls from tests and components, reducing boilerplate throughout React and Vue packages

## Test Plan
- [x] Core test suite passes (577 tests, 1 todo)
- [ ] Verify React storybook renders and drag interactions work
- [ ] Verify Vue storybook renders and drag interactions work