### PR TITLE
refactor(keyboard): simplify blockEdit + input cleanup

### DIFF
--- a/packages/core/src/features/block/README.md
+++ b/packages/core/src/features/block/README.md
@@ -10,7 +10,7 @@ Manages the block editing mode where each row/token is rendered as a separate dr
 
 ## Operations (internal)
 
-The feature uses pure functions from `operations.ts` for manipulating the raw value: `reorderDragRows`, `addDragRow`, `deleteDragRow`, `duplicateDragRow`, `mergeDragRows`, `canMergeRows`, `getMergeDragRowJoinPos`.
+The feature uses pure functions from `operations.ts` for manipulating the raw value: `reorderDragRows`, `addDragRow`, `deleteDragRow`, `duplicateDragRow`, `mergeDragRows` (returns `{value, caret}`), `canMergeRows`.
 
 ## Usage
 

--- a/packages/core/src/features/block/operations.ts
+++ b/packages/core/src/features/block/operations.ts
@@ -51,30 +51,21 @@ export function duplicateDragRow(value: string, rows: Token[], index: number): s
 }
 
 /**
- * Returns the raw-value position of the join point between row[index-1] and row[index]
- * for use as the caret position after a merge.
- */
-export function getMergeDragRowJoinPos(rows: Token[], index: number): number {
-	if (index <= 0 || index >= rows.length) return 0
-	const prev = rows[index - 1]
-	if (isSlotLeadingMark(prev) && prev.slot) return prev.slot.end
-	return prev.position.end
-}
-
-/**
  * Merges row[index] into row[index - 1] by removing the boundary between them.
  * For text rows: removes the gap between them.
  * For slot-leading marks: removes the first mark's literal suffix, merging slot content.
+ * Returns the new value and the raw-value caret position at the join point.
  */
-export function mergeDragRows(value: string, rows: Token[], index: number): string {
-	if (index <= 0 || index >= rows.length) return value
+export function mergeDragRows(value: string, rows: Token[], index: number): {value: string; caret: number} {
+	if (index <= 0 || index >= rows.length) return {value, caret: 0}
 	const prev = rows[index - 1]
 	const curr = rows[index]
 	if (isSlotLeadingMark(prev) && isSlotLeadingMark(curr)) {
 		const slotEnd = prev.slot ? prev.slot.end : prev.position.end
-		return value.slice(0, slotEnd) + value.slice(curr.position.start)
+		return {value: value.slice(0, slotEnd) + value.slice(curr.position.start), caret: slotEnd}
 	}
-	return value.slice(0, prev.position.end) + value.slice(curr.position.start)
+	const caret = prev.position.end
+	return {value: value.slice(0, caret) + value.slice(curr.position.start), caret}
 }
 
 /**

--- a/packages/core/src/features/keyboard/blockEdit.ts
+++ b/packages/core/src/features/keyboard/blockEdit.ts
@@ -190,35 +190,34 @@ function handleBlockArrowLeftRight(
 	container: HTMLElement,
 	event: KeyboardEvent,
 	direction: 'left' | 'right'
-): boolean {
+): void {
 	const activeElement = document.activeElement
-	if (!isHtmlElement(activeElement) || !container.contains(activeElement)) return false
+	if (!isHtmlElement(activeElement) || !container.contains(activeElement)) return
 
 	const blockDivs = htmlChildren(container)
 	const blockIndex = blockDivs.findIndex(div => div === activeElement || div.contains(activeElement))
-	if (blockIndex === -1) return false
+	if (blockIndex === -1) return
 
 	const blockDiv = blockDivs[blockIndex]
 
 	if (direction === 'left') {
-		if (caretDom.getCaretIndex(blockDiv) !== 0) return false
-		if (blockIndex === 0) return true
+		if (caretDom.getCaretIndex(blockDiv) !== 0) return
+		if (blockIndex === 0) return
 		event.preventDefault()
 		const prevBlock = blockDivs[blockIndex - 1]
 		prevBlock.focus()
 		caretDom.setAtElement(prevBlock, Infinity)
-		return true
+		return
 	}
 
 	const caretIndex = caretDom.getCaretIndex(blockDiv)
 	const textLen = blockDiv.textContent.length
-	if (caretIndex !== textLen) return false
-	if (blockIndex >= blockDivs.length - 1) return true
+	if (caretIndex !== textLen) return
+	if (blockIndex >= blockDivs.length - 1) return
 	event.preventDefault()
 	const nextBlock = blockDivs[blockIndex + 1]
 	nextBlock.focus()
 	caretDom.setAtElement(nextBlock, 0)
-	return true
 }
 
 function handleArrowUpDown(store: KbCtx, container: HTMLElement, event: KeyboardEvent) {

--- a/packages/core/src/features/keyboard/blockEdit.ts
+++ b/packages/core/src/features/keyboard/blockEdit.ts
@@ -6,7 +6,7 @@ import type {Store} from '../../store/Store'
 
 type KbCtx = Pick<Store, 'dom' | 'value' | 'selection' | 'edit' | 'tokens' | 'props'>
 import {createRowContent} from '../block/createRowContent'
-import {addDragRow, getMergeDragRowJoinPos, mergeDragRows, canMergeRows} from '../block/operations'
+import {addDragRow, mergeDragRows, canMergeRows} from '../block/operations'
 import {consumeMarkupPaste} from '../clipboard'
 import type {Token} from '../parsing'
 import * as caretDom from '../selection/caretDom'
@@ -285,9 +285,8 @@ function mergeOrFocusNeighbor(
 	const b = rows[joinIndex]
 	event.preventDefault()
 	if (canMergeRows(a, b)) {
-		const joinPos = getMergeDragRowJoinPos(rows, joinIndex)
-		const newValue = mergeDragRows(value, rows, joinIndex)
-		store.edit.replace({start: 0, end: -1}, newValue, joinPos)
+		const merged = mergeDragRows(value, rows, joinIndex)
+		store.edit.replace({start: 0, end: -1}, merged.value, merged.caret)
 		return
 	}
 	focusRow(store, rows[toIndex], blockDivs[toIndex], caretOnFocus)

--- a/packages/core/src/features/keyboard/blockEdit.ts
+++ b/packages/core/src/features/keyboard/blockEdit.ts
@@ -17,6 +17,21 @@ function isTextLikeRow(token: Token): boolean {
 	return token.descriptor.hasSlot && token.descriptor.segments.length === 1
 }
 
+type ActiveBlock = {
+	blockDivs: HTMLElement[]
+	index: number
+	div: HTMLElement
+}
+
+function findActiveBlock(container: HTMLElement): ActiveBlock | undefined {
+	const active = document.activeElement
+	if (!isHtmlElement(active) || !container.contains(active)) return undefined
+	const blockDivs = htmlChildren(container)
+	const index = blockDivs.findIndex(div => div === active || div.contains(active))
+	if (index === -1) return undefined
+	return {blockDivs, index, div: blockDivs[index]}
+}
+
 export function enableBlockEdit(store: KbCtx, container: HTMLElement): void {
 	listen(container, 'keydown', e => {
 		if (!store.props.layout.isBlock()) return
@@ -44,11 +59,9 @@ export function enableBlockEdit(store: KbCtx, container: HTMLElement): void {
 }
 
 function handleDelete(store: KbCtx, container: HTMLElement, event: KeyboardEvent) {
-	const blockDivs = htmlChildren(container)
-	const blockIndex = blockDivs.findIndex(
-		div => div === document.activeElement || div.contains(document.activeElement)
-	)
-	if (blockIndex === -1) return
+	const active = findActiveBlock(container)
+	if (!active) return
+	const {blockDivs, index: blockIndex} = active
 
 	const rows = store.tokens.current()
 	if (blockIndex >= rows.length) return
@@ -137,20 +150,11 @@ function handleEnter(store: KbCtx, container: HTMLElement, event: KeyboardEvent)
 	if (event.key !== KEYBOARD.ENTER) return
 	if (event.shiftKey) return
 
-	const activeElement = document.activeElement
-	if (!isHtmlElement(activeElement) || !container.contains(activeElement)) return
+	const active = findActiveBlock(container)
+	if (!active) return
 
 	event.preventDefault()
-
-	const blockDivs = htmlChildren(container)
-	let blockIndex = -1
-	for (let i = 0; i < blockDivs.length; i++) {
-		if (blockDivs[i] === activeElement || blockDivs[i].contains(activeElement)) {
-			blockIndex = i
-			break
-		}
-	}
-	if (blockIndex === -1) return
+	const {index: blockIndex} = active
 
 	const rows = store.tokens.current()
 	const token = rows[blockIndex]
@@ -191,14 +195,9 @@ function handleBlockArrowLeftRight(
 	event: KeyboardEvent,
 	direction: 'left' | 'right'
 ): void {
-	const activeElement = document.activeElement
-	if (!isHtmlElement(activeElement) || !container.contains(activeElement)) return
-
-	const blockDivs = htmlChildren(container)
-	const blockIndex = blockDivs.findIndex(div => div === activeElement || div.contains(activeElement))
-	if (blockIndex === -1) return
-
-	const blockDiv = blockDivs[blockIndex]
+	const active = findActiveBlock(container)
+	if (!active) return
+	const {blockDivs, index: blockIndex, div: blockDiv} = active
 
 	if (direction === 'left') {
 		if (caretDom.getCaretIndex(blockDiv) !== 0) return
@@ -221,14 +220,9 @@ function handleBlockArrowLeftRight(
 }
 
 function handleArrowUpDown(store: KbCtx, container: HTMLElement, event: KeyboardEvent) {
-	const activeElement = document.activeElement
-	if (!isHtmlElement(activeElement) || !container.contains(activeElement)) return
-
-	const blockDivs = htmlChildren(container)
-	const blockIndex = blockDivs.findIndex(div => div === activeElement || div.contains(activeElement))
-	if (blockIndex === -1) return
-
-	const blockDiv = blockDivs[blockIndex]
+	const active = findActiveBlock(container)
+	if (!active) return
+	const {blockDivs, index: blockIndex, div: blockDiv} = active
 
 	if (event.key === KEYBOARD.UP) {
 		if (!caretDom.isOnFirstLine(blockDiv)) return
@@ -256,12 +250,7 @@ function handleArrowUpDown(store: KbCtx, container: HTMLElement, event: Keyboard
 }
 
 function handleBlockBeforeInput(store: KbCtx, container: HTMLElement, event: InputEvent) {
-	const activeElement = document.activeElement
-	if (!isHtmlElement(activeElement) || !container.contains(activeElement)) return
-
-	const blockDivs = htmlChildren(container)
-	const blockIndex = blockDivs.findIndex(div => div === activeElement || div.contains(activeElement))
-	if (blockIndex === -1) return
+	if (!findActiveBlock(container)) return
 
 	switch (event.inputType) {
 		case 'insertText': {

--- a/packages/core/src/features/keyboard/blockEdit.ts
+++ b/packages/core/src/features/keyboard/blockEdit.ts
@@ -93,17 +93,7 @@ function handleDelete(store: KbCtx, container: HTMLElement, event: KeyboardEvent
 		}
 
 		if (caretAtStart && blockIndex > 0) {
-			const prevToken = rows[blockIndex - 1]
-			const currToken = rows[blockIndex]
-			if (canMergeRows(prevToken, currToken)) {
-				event.preventDefault()
-				const joinPos = getMergeDragRowJoinPos(rows, blockIndex)
-				const newValue = mergeDragRows(value, rows, blockIndex)
-				store.edit.replace({start: 0, end: -1}, newValue, joinPos)
-				return
-			}
-			event.preventDefault()
-			focusRow(store, prevToken, blockDivs[blockIndex - 1], 'end')
+			mergeOrFocusNeighbor(store, event, rows, value, blockIndex, blockIndex - 1, blockDivs, 'end')
 			return
 		}
 	}
@@ -115,32 +105,12 @@ function handleDelete(store: KbCtx, container: HTMLElement, event: KeyboardEvent
 		const caretAtStart = caretIndex === 0
 
 		if (caretAtStart && blockIndex > 0) {
-			const prevToken = rows[blockIndex - 1]
-			const currToken = rows[blockIndex]
-			if (canMergeRows(prevToken, currToken)) {
-				event.preventDefault()
-				const joinPos = getMergeDragRowJoinPos(rows, blockIndex)
-				const newValue = mergeDragRows(value, rows, blockIndex)
-				store.edit.replace({start: 0, end: -1}, newValue, joinPos)
-				return
-			}
-			event.preventDefault()
-			focusRow(store, prevToken, blockDivs[blockIndex - 1], 'end')
+			mergeOrFocusNeighbor(store, event, rows, value, blockIndex, blockIndex - 1, blockDivs, 'end')
 			return
 		}
 
 		if (caretAtEnd && blockIndex < rows.length - 1) {
-			const currToken = rows[blockIndex]
-			const nextToken = rows[blockIndex + 1]
-			if (canMergeRows(currToken, nextToken)) {
-				event.preventDefault()
-				const joinPos = getMergeDragRowJoinPos(rows, blockIndex + 1)
-				const newValue = mergeDragRows(value, rows, blockIndex + 1)
-				store.edit.replace({start: 0, end: -1}, newValue, joinPos)
-				return
-			}
-			event.preventDefault()
-			focusRow(store, nextToken, blockDivs[blockIndex + 1], 'start')
+			mergeOrFocusNeighbor(store, event, rows, value, blockIndex, blockIndex + 1, blockDivs, 'start')
 			return
 		}
 	}
@@ -298,4 +268,27 @@ function rangeForBlockInput(store: KbCtx, event: InputEvent, range: Range): Rang
 		return {start: range.start, end: range.end + 1}
 	}
 	return undefined
+}
+
+function mergeOrFocusNeighbor(
+	store: KbCtx,
+	event: KeyboardEvent,
+	rows: Token[],
+	value: string,
+	fromIndex: number,
+	toIndex: number,
+	blockDivs: HTMLElement[],
+	caretOnFocus: 'start' | 'end'
+): void {
+	const joinIndex = Math.max(fromIndex, toIndex)
+	const a = rows[Math.min(fromIndex, toIndex)]
+	const b = rows[joinIndex]
+	event.preventDefault()
+	if (canMergeRows(a, b)) {
+		const joinPos = getMergeDragRowJoinPos(rows, joinIndex)
+		const newValue = mergeDragRows(value, rows, joinIndex)
+		store.edit.replace({start: 0, end: -1}, newValue, joinPos)
+		return
+	}
+	focusRow(store, rows[toIndex], blockDivs[toIndex], caretOnFocus)
 }

--- a/packages/core/src/features/keyboard/input.spec.ts
+++ b/packages/core/src/features/keyboard/input.spec.ts
@@ -1,7 +1,7 @@
 import {describe, it, expect, vi} from 'vitest'
 
 import {Store} from '../../store/Store'
-import {applySpanInput, handleBeforeInput} from './input'
+import {handleBeforeInput} from './input'
 
 function mountStructuralInline(value = 'hello') {
 	const store = new Store()
@@ -47,26 +47,6 @@ function inputEvent(inputType: string, range: Range, init?: InputEventInit): Inp
 	Object.defineProperty(event, 'getTargetRanges', {value: () => [range]})
 	return event
 }
-
-describe('applySpanInput()', () => {
-	it('delete the next character when deleteContentForward has no target ranges', () => {
-		const focus = {
-			content: '!',
-			caret: 0,
-		}
-		const event = {
-			inputType: 'deleteContentForward',
-			getTargetRanges: () => [],
-			preventDefault: vi.fn(),
-		}
-
-		// oxlint-disable-next-line no-unsafe-type-assertion -- applySpanInput only touches content/caret in this focused regression test
-		expect(applySpanInput(focus as never, event as never)).toBe(true)
-		expect(event.preventDefault).toHaveBeenCalledOnce()
-		expect(focus.content).toBe('')
-		expect(focus.caret).toBe(0)
-	})
-})
 
 describe('handleBeforeInput()', () => {
 	it('inserts text through replaceRange using target ranges', () => {

--- a/packages/core/src/features/keyboard/input.ts
+++ b/packages/core/src/features/keyboard/input.ts
@@ -8,11 +8,6 @@ import {captureMarkupPaste, consumeMarkupPaste} from '../clipboard'
 import type {Token} from '../parsing'
 import {rawRangeFromInputEvent} from './inputRange'
 
-type SpanInputTarget = {
-	content: string
-	caret: number
-}
-
 export function enableInput(store: KbCtx, container: HTMLElement): void {
 	listen(container, 'paste', e => {
 		captureMarkupPaste(e, container)
@@ -81,68 +76,6 @@ export function handleBeforeInput(store: KbCtx, container: HTMLElement, event: I
 	store.edit.replace(range, replacement)
 }
 
-export function applySpanInput(focus: SpanInputTarget, event: InputEvent): boolean {
-	const offset = focus.caret
-	const content = focus.content
-	let newContent: string
-	let newCaret: number
-
-	switch (event.inputType) {
-		case 'insertText': {
-			event.preventDefault()
-			const data = event.data ?? ''
-			newContent = content.slice(0, offset) + data + content.slice(offset)
-			newCaret = offset + data.length
-			break
-		}
-		case 'deleteContentBackward':
-		case 'deleteContentForward':
-		case 'deleteWordBackward':
-		case 'deleteWordForward':
-		case 'deleteSoftLineBackward':
-		case 'deleteSoftLineForward': {
-			const ranges = event.getTargetRanges()
-			let startOffset: number
-			let endOffset: number
-			if (ranges.length > 0 && ranges[0].startOffset !== ranges[0].endOffset) {
-				startOffset = ranges[0].startOffset
-				endOffset = ranges[0].endOffset
-			} else {
-				if (event.inputType === 'deleteContentBackward' && offset > 0) {
-					startOffset = offset - 1
-					endOffset = offset
-				} else if (event.inputType === 'deleteContentForward' && offset < content.length) {
-					startOffset = offset
-					endOffset = offset + 1
-				} else {
-					return false
-				}
-			}
-			event.preventDefault()
-			newContent = content.slice(0, startOffset) + content.slice(endOffset)
-			newCaret = startOffset
-			break
-		}
-		case 'insertFromPaste':
-		case 'insertReplacementText': {
-			const text = event.dataTransfer?.getData('text/plain') ?? ''
-			const ranges = event.getTargetRanges()
-			const start = ranges[0]?.startOffset ?? offset
-			const end = ranges[0]?.endOffset ?? offset
-			event.preventDefault()
-			newContent = content.slice(0, start) + text + content.slice(end)
-			newCaret = start + text.length
-			break
-		}
-		default:
-			return false
-	}
-
-	focus.content = newContent
-	focus.caret = newCaret
-	return true
-}
-
 function replacementForInput(container: HTMLElement, event: InputEvent): string | undefined {
 	if (event.inputType.startsWith('delete')) return ''
 	if (event.inputType === 'insertFromPaste' || event.inputType === 'insertReplacementText') {
@@ -184,7 +117,7 @@ function adjacentMarkRange(tokens: readonly Token[], position: number, backward:
 	return undefined
 }
 
-export function handlePaste(store: KbCtx, container: HTMLElement, event: ClipboardEvent): void {
+function handlePaste(store: KbCtx, container: HTMLElement, event: ClipboardEvent): void {
 	if (!store.selection.isAllSelected()) return
 
 	event.preventDefault()


### PR DESCRIPTION
## Summary

- Cut [`blockEdit.ts`](packages/core/src/features/keyboard/blockEdit.ts) from 312 → 292 lines and remove structural duplication (5× block-index lookup, 3× merge-or-focus branches, 2 always-paired functions).
- Drop dead `applySpanInput` and tighten `input.ts` exports (separate commit by repo owner).

## What's removed

| Before | After |
|---|---|
| 5 handlers each open with the same 4-line "find active block" lookup (`handleDelete`, `handleEnter`, `handleBlockArrowLeftRight`, `handleArrowUpDown`, `handleBlockBeforeInput`) | One `findActiveBlock(container): {blockDivs, index, div}` helper. |
| `handleEnter` uses a `for` loop for the same lookup; other handlers use `findIndex` | All five use the helper consistently. |
| `handleDelete` has 3 near-identical branches (backspace-at-start, delete-at-start, delete-at-end) doing "try merge or focus the neighbor" | One `mergeOrFocusNeighbor(...)` helper, 3 one-line call sites. |
| `mergeDragRows(value, rows, i)` and `getMergeDragRowJoinPos(rows, i)` always called together with same args | Folded into `mergeDragRows`'s `{value, caret}` return. |
| `handleBlockArrowLeftRight` returns `boolean` that no caller reads | Returns `void`. |

## Per-commit breakdown

```
d10cffc9 refactor(block): fold getMergeDragRowJoinPos into mergeDragRows return
ad05747b refactor(keyboard): consolidate three merge-or-focus branches in handleDelete
34866362 refactor(keyboard): extract findActiveBlock helper
c50f9380 refactor(keyboard): drop unused boolean return on handleBlockArrowLeftRight
47798bc8 refactor(keyboard): drop dead applySpanInput + tighten input.ts exports
```

Each commit ships independently.

## Caret invariant (highest risk)

Task 4 merged two functions that produced `(value, caretPos)` separately. The new combined `mergeDragRows` preserves the exact caret semantics:
- Invalid index → `caret: 0`
- Slot-leading mark + slot-leading mark → `caret: prev.slot.end` (with fallback to `prev.position.end` if slot missing)
- Text + text (or any other valid merge) → `caret: prev.position.end`

The "asymmetric" path in the old `getMergeDragRowJoinPos` (where `prev` was slot-leading but `curr` wasn't) was dead code — gated by `canMergeRows` which requires both sides to be slot-leading marks.

## Architectural note

`blockEdit.ts` has **no unit-test file** — behavior is verified end-to-end via storybook. Each task in the plan included a manual smoke-test step. The vitest suite (594 tests + 1 todo) confirms the refactor doesn't break anything else, but the block-keyboard interactions specifically should be exercised in the storybook before merge.

## Plan

[docs/superpowers/plans/2026-05-25-blockedit-simplification.md](docs/superpowers/plans/2026-05-25-blockedit-simplification.md) — 4-task plan with explicit step-by-step instructions.

## Test plan

- [x] `pnpm --filter @markput/core test --run` — 594 pass, 1 todo
- [x] `pnpm --filter @markput/react build` — clean
- [x] `pnpm --filter @markput/vue build` — clean
- [ ] Manual smoke: open block-layout storybook page; type, arrow-keys (l/r/u/d), Enter mid-row, Backspace at row start (mergeable + non-mergeable), Delete at row end (mergeable + non-mergeable), drag-and-drop rows
- [ ] Verify caret lands at the correct join position after Backspace-at-start and Delete-at-end merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)