### PR TITLE
refactor(selection): extract pure helpers as free functions

### DIFF
--- a/packages/core/src/features/selection/SelectionController.ts
+++ b/packages/core/src/features/selection/SelectionController.ts
@@ -1,11 +1,12 @@
 // packages/core/src/features/selection/SelectionController.ts
 import {firstHtmlChild, nodeTarget} from '../../shared/checkers'
-import type {Range, RawSelection, TokenAddress, TokenPath} from '../../shared/editorContracts'
+import type {Range, RawSelection, TokenAddress} from '../../shared/editorContracts'
 import {computed, listen, signal, watch} from '../../shared/signals'
 import type {Computed, Signal} from '../../shared/signals'
 import {shallow} from '../../shared/utils/shallow'
 import {reconcileTextSurfaces, type DomIndex, type TokenNode} from '../dom'
 import type {Token} from '../parsing'
+import type {TokenIndex} from '../parsing/tokenIndex'
 import type {TokenModel} from '../parsing/TokenModel'
 import type {Host} from '../state/Host'
 import type {PropsModel} from '../state/PropsModel'
@@ -43,12 +44,14 @@ export class SelectionController {
 			this.#trackSelection(container)
 			this.#trackUserSelecting(container)
 
-			watch(this.dom.indexed, () => this.#reconcileSurfaces())
+			watch(this.dom.indexed, () => {
+				this.#reconcileSurfaces()
+				this.#applyRange()
+			})
 			watch(this.props.readOnly, () => this.#reconcileSurfaces())
 			watch(this.isUserSelecting, () => this.#reconcileSurfaces())
 
 			watch(this.range, () => this.#applyRange())
-			watch(this.dom.indexed, () => this.#applyRange())
 		})
 	}
 
@@ -92,20 +95,21 @@ export class SelectionController {
 	rawPositionFromBoundary(node: Node, offset: number, affinity: 'before' | 'after' = 'after'): number | undefined {
 		const container = this.host.container()
 		if (container && node === container) {
-			return this.#fromContainerBoundary(offset, affinity)
+			return fromContainerBoundary(this.tokens.current(), offset, affinity)
 		}
 
 		const lookup = this.dom.locate(node)
 		if (lookup?.kind !== 'token') return undefined
 
-		const token = this.tokens.index().resolveAddress(lookup.node.address)
+		const tokenIndex = this.tokens.index()
+		const token = tokenIndex.resolveAddress(lookup.node.address)
 		if (!token) return undefined
 
 		if (node instanceof HTMLElement && node === lookup.node.childSequenceHost) {
 			const childCount = node.childNodes.length
 			if (offset <= 0) return token.position.start
 			if (offset >= childCount) return token.position.end
-			return this.#fromTokenChildBoundary(node, offset, token, affinity)
+			return fromTokenChildBoundary(this.dom, tokenIndex, node, offset, token, affinity)
 		}
 
 		const textElement = lookup.node.textElement
@@ -119,7 +123,7 @@ export class SelectionController {
 			const childCount = lookup.node.tokenElement.childNodes.length
 			if (offset <= 0) return token.position.start
 			if (offset >= childCount) return token.position.end
-			return this.#fromTokenChildBoundary(lookup.node.tokenElement, offset, token, affinity)
+			return fromTokenChildBoundary(this.dom, tokenIndex, lookup.node.tokenElement, offset, token, affinity)
 		}
 
 		if (token.type === 'mark' && lookup.node.tokenElement.contains(node)) {
@@ -134,49 +138,6 @@ export class SelectionController {
 		}
 
 		return undefined
-	}
-
-	#fromContainerBoundary(offset: number, affinity: 'before' | 'after'): number | undefined {
-		const tokens = this.tokens.current()
-		if (tokens.length === 0) return 0
-		if (offset <= 0) return tokens[0].position.start
-		if (offset >= tokens.length) return tokens[tokens.length - 1].position.end
-
-		const before = tokens[offset - 1]
-		const after = tokens[offset]
-		return affinity === 'before' ? before.position.end : after.position.start
-	}
-
-	#fromTokenChildBoundary(
-		tokenElement: HTMLElement,
-		offset: number,
-		token: Token,
-		affinity: 'before' | 'after'
-	): number | undefined {
-		if (token.type === 'text') {
-			const path: TokenPath = this.tokens.index().pathFor(token) ?? []
-			const address = this.tokens.index().addressFor(path)
-			const textElement = address ? this.dom.nodeFor(address)?.textElement : undefined
-			if (!textElement || textLength(textElement) === 0) return token.position.start
-		}
-
-		const before = this.#lookupDescendant(tokenElement.childNodes.item(offset - 1))
-		const after = this.#lookupDescendant(tokenElement.childNodes.item(offset))
-		if (before && after) {
-			const beforeToken = this.tokens.index().resolveAddress(before.address)
-			const afterToken = this.tokens.index().resolveAddress(after.address)
-			if (beforeToken && afterToken) {
-				return affinity === 'before' ? beforeToken.position.end : afterToken.position.start
-			}
-		}
-
-		return affinity === 'before' ? token.position.start : token.position.end
-	}
-
-	#lookupDescendant(node: Node | null): TokenNode | undefined {
-		if (!node) return undefined
-		const lookup = this.dom.locate(node)
-		return lookup?.kind === 'token' ? lookup.node : undefined
 	}
 
 	readSelectedContent(): {html: string; text: string} | undefined {
@@ -386,4 +347,52 @@ export class SelectionController {
 			syncIfInEditor(sel.focusNode)
 		})
 	}
+}
+
+function fromContainerBoundary(
+	tokens: readonly Token[],
+	offset: number,
+	affinity: 'before' | 'after'
+): number | undefined {
+	if (tokens.length === 0) return 0
+	if (offset <= 0) return tokens[0].position.start
+	if (offset >= tokens.length) return tokens[tokens.length - 1].position.end
+
+	const before = tokens[offset - 1]
+	const after = tokens[offset]
+	return affinity === 'before' ? before.position.end : after.position.start
+}
+
+function fromTokenChildBoundary(
+	dom: DomIndex,
+	tokenIndex: TokenIndex,
+	tokenElement: HTMLElement,
+	offset: number,
+	token: Token,
+	affinity: 'before' | 'after'
+): number | undefined {
+	if (token.type === 'text') {
+		const path = tokenIndex.pathFor(token) ?? []
+		const address = tokenIndex.addressFor(path)
+		const textElement = address ? dom.nodeFor(address)?.textElement : undefined
+		if (!textElement || textLength(textElement) === 0) return token.position.start
+	}
+
+	const before = lookupTokenDescendant(dom, tokenElement.childNodes.item(offset - 1))
+	const after = lookupTokenDescendant(dom, tokenElement.childNodes.item(offset))
+	if (before && after) {
+		const beforeToken = tokenIndex.resolveAddress(before.address)
+		const afterToken = tokenIndex.resolveAddress(after.address)
+		if (beforeToken && afterToken) {
+			return affinity === 'before' ? beforeToken.position.end : afterToken.position.start
+		}
+	}
+
+	return affinity === 'before' ? token.position.start : token.position.end
+}
+
+function lookupTokenDescendant(dom: DomIndex, node: Node | null): TokenNode | undefined {
+	if (!node) return undefined
+	const lookup = dom.locate(node)
+	return lookup?.kind === 'token' ? lookup.node : undefined
 }

--- a/packages/core/src/features/selection/SelectionController.ts
+++ b/packages/core/src/features/selection/SelectionController.ts
@@ -200,7 +200,7 @@ export class SelectionController {
 		const resolved = this.tokens.index().resolveAddress(address)
 		if (!resolved) return false
 		if (resolved.type === 'mark') {
-			this.#placeAtMarkBoundary(node.tokenElement, rawPosition, resolved.position)
+			placeAtMarkBoundary(node.tokenElement, rawPosition, resolved.position)
 			return true
 		}
 		const target = node.textElement ?? node.tokenElement
@@ -211,56 +211,30 @@ export class SelectionController {
 		return true
 	}
 
-	#findTextTargetForRawPosition(rawPosition: number): {element: HTMLElement; start: number; end: number} | undefined {
-		const candidates: Array<{element: HTMLElement; start: number; end: number}> = []
-		const tokenIndex = this.tokens.index()
-		for (const node of this.dom.nodes()) {
-			if (!node.textElement) continue
-			const resolved = tokenIndex.resolveAddress(node.address)
-			if (resolved?.type !== 'text') continue
-			candidates.push({
-				element: node.textElement,
-				start: resolved.position.start,
-				end: resolved.position.end,
-			})
-		}
-		candidates.sort((a, b) => a.start - b.start)
-		const containing = candidates.find(c => rawPosition >= c.start && rawPosition <= c.end)
-		if (containing) return containing
-		return candidates.find(c => c.start >= rawPosition)
-	}
+	#placeCollapsed(rawPosition: number): boolean {
+		if (this.#applyPreferredAddress(rawPosition)) return true
 
-	#focusMarkBoundaryForRawPosition(rawPosition: number): boolean {
 		const tokenIndex = this.tokens.index()
-		for (const node of this.dom.nodes()) {
-			const resolved = tokenIndex.resolveAddress(node.address)
-			if (resolved?.type !== 'mark') continue
-			if (rawPosition !== resolved.position.start && rawPosition !== resolved.position.end) continue
-			this.#placeAtMarkBoundary(node.tokenElement, rawPosition, resolved.position)
+		const textTarget = findTextTargetAt(this.dom, tokenIndex, rawPosition)
+		if (textTarget) {
+			focusIfNeeded(textTarget.element)
+			placeAtTextOffset(textTarget.element, rawPosition - textTarget.start)
 			return true
 		}
+
+		const markTarget = findMarkBoundaryAt(this.dom, tokenIndex, rawPosition)
+		if (markTarget) {
+			placeAtMarkBoundary(markTarget.element, rawPosition, markTarget.position)
+			return true
+		}
+
 		return false
 	}
 
-	#placeAtMarkBoundary(element: HTMLElement, rawPosition: number, position: {start: number; end: number}): void {
-		focusIfNeeded(element)
-		placeAtChildBoundary(element, rawPosition === position.end ? 'end' : 'start')
-	}
-
-	#placeCollapsed(rawPosition: number): boolean {
-		if (this.#applyPreferredAddress(rawPosition)) return true
-		const target = this.#findTextTargetForRawPosition(rawPosition)
-		if (target) {
-			focusIfNeeded(target.element)
-			placeAtTextOffset(target.element, rawPosition - target.start)
-			return true
-		}
-		return this.#focusMarkBoundaryForRawPosition(rawPosition)
-	}
-
 	#placeExtended(range: Range): boolean {
-		const startTarget = this.#findTextTargetForRawPosition(range.start)
-		const endTarget = this.#findTextTargetForRawPosition(range.end)
+		const tokenIndex = this.tokens.index()
+		const startTarget = findTextTargetAt(this.dom, tokenIndex, range.start)
+		const endTarget = findTextTargetAt(this.dom, tokenIndex, range.end)
 		if (!startTarget || !endTarget) return false
 		placeRangeAcrossSurfaces(
 			{element: startTarget.element, offset: range.start - startTarget.start},
@@ -395,4 +369,45 @@ function lookupTokenDescendant(dom: DomIndex, node: Node | null): TokenNode | un
 	if (!node) return undefined
 	const lookup = dom.locate(node)
 	return lookup?.kind === 'token' ? lookup.node : undefined
+}
+
+function findTextTargetAt(
+	dom: DomIndex,
+	tokenIndex: TokenIndex,
+	rawPosition: number
+): {element: HTMLElement; start: number; end: number} | undefined {
+	const candidates: Array<{element: HTMLElement; start: number; end: number}> = []
+	for (const node of dom.nodes()) {
+		if (!node.textElement) continue
+		const resolved = tokenIndex.resolveAddress(node.address)
+		if (resolved?.type !== 'text') continue
+		candidates.push({
+			element: node.textElement,
+			start: resolved.position.start,
+			end: resolved.position.end,
+		})
+	}
+	candidates.sort((a, b) => a.start - b.start)
+	const containing = candidates.find(c => rawPosition >= c.start && rawPosition <= c.end)
+	if (containing) return containing
+	return candidates.find(c => c.start >= rawPosition)
+}
+
+function findMarkBoundaryAt(
+	dom: DomIndex,
+	tokenIndex: TokenIndex,
+	rawPosition: number
+): {element: HTMLElement; position: {start: number; end: number}} | undefined {
+	for (const node of dom.nodes()) {
+		const resolved = tokenIndex.resolveAddress(node.address)
+		if (resolved?.type !== 'mark') continue
+		if (rawPosition !== resolved.position.start && rawPosition !== resolved.position.end) continue
+		return {element: node.tokenElement, position: resolved.position}
+	}
+	return undefined
+}
+
+function placeAtMarkBoundary(element: HTMLElement, rawPosition: number, position: {start: number; end: number}): void {
+	focusIfNeeded(element)
+	placeAtChildBoundary(element, rawPosition === position.end ? 'end' : 'start')
 }


### PR DESCRIPTION
## Summary

Internal cleanup of [`SelectionController.ts`](packages/core/src/features/selection/SelectionController.ts). Moves six pure helpers from class methods to module-private free functions in the same file. No public API change. No behavior change.

| Metric | Before | After |
|---|---|---|
| Class body | 388 lines | ~308 lines |
| File total | 388 lines | 412 lines |
| Private methods | 15 | 9 |
| Pure helpers (module-private functions) | 0 | 6 |

The class body now focuses on state, lifecycle, event tracking, and methods that genuinely touch `this`-state. The math (boundary↔raw position, find-target) sits below it as functions you can read in isolation.

## Why this shape

The class absorbed `DomBoundary` and `TextSurfaces` in earlier refactors (#256, #257, #259). That left ~80 lines of pure boundary arithmetic interleaved with the state-management thread. Reading the class top-to-bottom required scrolling past the math to follow the state code. The math methods didn't depend on `this` beyond `this.dom` and `this.tokens.index()` — they were functions wearing method clothes.

Re-splitting into a separate module was explicitly rejected in PR #257 because of cross-class `#isPlacingCaret` coupling. Free functions in the same file get the same separation without re-introducing that coupling.

## What moved

| Was | Now |
|---|---|
| `#fromContainerBoundary(offset, affinity)` | `fromContainerBoundary(tokens, offset, affinity)` |
| `#fromTokenChildBoundary(elem, offset, token, affinity)` | `fromTokenChildBoundary(dom, tokenIndex, elem, offset, token, affinity)` |
| `#lookupDescendant(node)` | `lookupTokenDescendant(dom, node)` |
| `#findTextTargetForRawPosition(rawPosition)` | `findTextTargetAt(dom, tokenIndex, rawPosition)` |
| `#focusMarkBoundaryForRawPosition(rawPosition)` | `findMarkBoundaryAt(dom, tokenIndex, rawPosition)` *(see semantic shift)* |
| `#placeAtMarkBoundary(element, rawPosition, position)` | `placeAtMarkBoundary(element, rawPosition, position)` |

## Semantic shift

The old `#focusMarkBoundaryForRawPosition` *found AND placed* in one method, returning `boolean`. The new `findMarkBoundaryAt` only *finds* and returns the candidate. The caller (`#placeCollapsed`) now does the find + place as two explicit steps. End behavior is identical; the split separates the pure find from the side-effect.

## What didn't change

- Public API surface: `range`, `position`, `isAllSelected`, `isUserSelecting`, `selectAll`, `focusFirst`, `readRaw`, `rawPositionFromBoundary`, `readSelectedContent`, `placeAtAddress` — all byte-identical.
- `#isPlacingCaret` reentrancy guard (load-bearing: breaks the `range → applyRange → DOM mutation → selectionchange → range` cycle).
- `#preferredAddress` sticky state (load-bearing: resolves caret ambiguity at offsets where two tokens meet).
- `#reconcileSurfaces` and its watch wiring (uses `isUserSelecting`, internal to selection).

## Bundled small deletion

Constructor had two `watch(this.dom.indexed, …)` subscriptions. Collapsed into one combined callback that runs `#reconcileSurfaces` before `#applyRange`, preserving the original implicit ordering.
