### PR TITLE
refactor(overlay): collapse hasOverlayTrigger gates into one effect

### DIFF
--- a/packages/core/src/features/overlay/OverlayController.ts
+++ b/packages/core/src/features/overlay/OverlayController.ts
@@ -1,5 +1,4 @@
 import {KEYBOARD} from '../../shared/constants'
-import {escape} from '../../shared/escape'
 import {signal, computed, event, effect, watch, listen} from '../../shared/signals/index.js'
 import type {Computed} from '../../shared/signals/index.js'
 import type {CoreOption, OverlayMatch, OverlayTrigger, Slot} from '../../shared/types'
@@ -46,18 +45,51 @@ export class OverlayController {
 		const hasOverlayTrigger = computed(() => this.props.options().some(opt => opt.overlay?.trigger != null))
 
 		this.host.onMounted(() => {
-			watch(this.close, () => {
+			effect(() => {
 				if (!hasOverlayTrigger()) return
-				this.match(undefined)
-			})
 
-			watch(this.value.current, () => {
-				if (!hasOverlayTrigger()) return
-				const showOverlayOn = this.props.showOverlayOn()
-				const type: OverlayTrigger = 'change'
-				if (showOverlayOn === type || (Array.isArray(showOverlayOn) && showOverlayOn.includes(type))) {
-					this.#probeTrigger()
-				}
+				watch(this.close, () => this.match(undefined))
+
+				watch(this.value.current, () => {
+					const showOverlayOn = this.props.showOverlayOn()
+					const type: OverlayTrigger = 'change'
+					if (showOverlayOn === type || (Array.isArray(showOverlayOn) && showOverlayOn.includes(type))) {
+						this.#probeTrigger()
+					}
+				})
+
+				listen(document, 'selectionchange', () => {
+					const container = this.host.container()
+					if (!container?.contains(document.activeElement)) return
+					const showOverlayOn = this.props.showOverlayOn()
+					const type: OverlayTrigger = 'selectionChange'
+					if (showOverlayOn === type || (Array.isArray(showOverlayOn) && showOverlayOn.includes(type))) {
+						this.#probeTrigger()
+					}
+				})
+
+				watch(this.select, overlayEvent => {
+					const {
+						mark,
+						match: {option, range},
+					} = overlayEvent
+
+					const markup = option.markup
+					if (!markup) return
+
+					const annotation =
+						mark.type === 'mark'
+							? annotate(markup, {
+									value: mark.value,
+									meta: mark.meta,
+								})
+							: annotate(markup, {
+									value: mark.content,
+								})
+
+					this.edit.replace(range, annotation)
+					this.match(undefined)
+				})
 			})
 
 			effect(() => {
@@ -78,82 +110,10 @@ export class OverlayController {
 					true
 				)
 			})
-
-			effect(() => {
-				if (!hasOverlayTrigger()) return
-				const handler = () => {
-					const container = this.host.container()
-					if (!container?.contains(document.activeElement)) return
-					const showOverlayOn = this.props.showOverlayOn()
-					const type: OverlayTrigger = 'selectionChange'
-					if (showOverlayOn === type || (Array.isArray(showOverlayOn) && showOverlayOn.includes(type))) {
-						this.#probeTrigger()
-					}
-				}
-				listen(document, 'selectionchange', handler)
-			})
-
-			watch(this.select, overlayEvent => {
-				if (!hasOverlayTrigger()) return
-				const {
-					mark,
-					match: {option, range},
-				} = overlayEvent
-
-				const markup = option.markup
-				if (!markup) return
-
-				const annotation =
-					mark.type === 'mark'
-						? annotate(markup, {
-								value: mark.value,
-								meta: mark.meta,
-							})
-						: annotate(markup, {
-								value: mark.content,
-							})
-
-				this.edit.replace(range, annotation)
-				this.match(undefined)
-			})
 		})
 	}
 
 	#probeTrigger() {
-		const match =
-			TriggerFinder.find(this.props.options(), option => option.overlay?.trigger, this.selection) ??
-			this.#probeTriggerFromCaretRange()
-		this.match(match)
-	}
-
-	#probeTriggerFromCaretRange(): OverlayMatch | undefined {
-		const sel = this.selection.range()
-		if (!sel || sel.start !== sel.end) return
-
-		const cursor = sel.start
-		const value = this.value.current()
-		const left = value.slice(0, cursor)
-		const right = value.slice(cursor)
-		const rightWord = right.match(/^\w*/)?.[0] ?? ''
-
-		for (const option of this.props.options()) {
-			const trigger = option.overlay?.trigger
-			if (!trigger) continue
-
-			const match = left.match(new RegExp(`${escape(trigger)}(\\w*)$`))
-			if (!match) continue
-
-			const [sourceLeft, wordLeft] = match
-			const source = sourceLeft + rightWord
-			const start = cursor - sourceLeft.length
-			return {
-				value: wordLeft + rightWord,
-				source,
-				range: {start, end: start + source.length},
-				span: value,
-				node: window.getSelection()?.anchorNode ?? this.host.container() ?? document.body,
-				option,
-			}
-		}
+		this.match(TriggerFinder.find(this.props.options(), option => option.overlay?.trigger, this.selection))
 	}
 }

--- a/packages/core/src/features/overlay/OverlayController.ts
+++ b/packages/core/src/features/overlay/OverlayController.ts
@@ -1,4 +1,5 @@
 import {KEYBOARD} from '../../shared/constants'
+import {escape} from '../../shared/escape'
 import {signal, computed, event, effect, watch, listen} from '../../shared/signals/index.js'
 import type {Computed} from '../../shared/signals/index.js'
 import type {CoreOption, OverlayMatch, OverlayTrigger, Slot} from '../../shared/types'
@@ -114,6 +115,40 @@ export class OverlayController {
 	}
 
 	#probeTrigger() {
-		this.match(TriggerFinder.find(this.props.options(), option => option.overlay?.trigger, this.selection))
+		const match =
+			TriggerFinder.find(this.props.options(), option => option.overlay?.trigger, this.selection) ??
+			this.#probeTriggerFromCaretRange()
+		this.match(match)
+	}
+
+	#probeTriggerFromCaretRange(): OverlayMatch | undefined {
+		const sel = this.selection.range()
+		if (!sel || sel.start !== sel.end) return
+
+		const cursor = sel.start
+		const value = this.value.current()
+		const left = value.slice(0, cursor)
+		const right = value.slice(cursor)
+		const rightWord = right.match(/^\w*/)?.[0] ?? ''
+
+		for (const option of this.props.options()) {
+			const trigger = option.overlay?.trigger
+			if (!trigger) continue
+
+			const match = left.match(new RegExp(`${escape(trigger)}(\\w*)$`))
+			if (!match) continue
+
+			const [sourceLeft, wordLeft] = match
+			const source = sourceLeft + rightWord
+			const start = cursor - sourceLeft.length
+			return {
+				value: wordLeft + rightWord,
+				source,
+				range: {start, end: start + source.length},
+				span: value,
+				node: window.getSelection()?.anchorNode ?? this.host.container() ?? document.body,
+				option,
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Collapse four `hasOverlayTrigger` early-returns in [`OverlayController.ts`](packages/core/src/features/overlay/OverlayController.ts) into one `effect`-scoped gate wrapping all trigger-dependent subscriptions. When no option declares an overlay trigger, the controller registers zero subscriptions instead of registering them and bailing inside each handler.

## Result

- `OverlayController.ts`: **158 → 153 lines** (~5 line reduction).
- `hasOverlayTrigger` guard sites: **4 → 1**.
- All trigger-dependent subscribers tear down together when `hasOverlayTrigger` flips, via the signal library's effect-scope cleanup.

## Detail

### Gate collapse

Before — four separate subscribers each early-return on `!hasOverlayTrigger()`:

```ts
watch(this.close, () => {
    if (!hasOverlayTrigger()) return
    this.match(undefined)
})

watch(this.value.current, () => {
    if (!hasOverlayTrigger()) return
    // ...
})

effect(() => {
    if (!hasOverlayTrigger()) return
    listen(document, 'selectionchange', /* ... */)
})

watch(this.select, overlayEvent => {
    if (!hasOverlayTrigger()) return
    // ...
})
```

After — one outer effect wraps the four trigger-dependent subscribers:

```ts
effect(() => {
    if (!hasOverlayTrigger()) return

    watch(this.close, () => this.match(undefined))
    watch(this.value.current, () => /* ... */)
    listen(document, 'selectionchange', /* ... */)
    watch(this.select, overlayEvent => /* ... */)
})
```

When `hasOverlayTrigger` flips, the outer effect re-runs and the four inner subscriptions are torn down via the signal library's effect-scope cleanup ([signal.ts:789-799](packages/core/src/shared/signals/signal.ts#L789-L799) — `listen` returns an effect that auto-disposes).

The match-dismissal effect (keydown + click listeners that depend on `match()`) stays separate — its dependency is `match()`, not `hasOverlayTrigger`.

## What this PR DOES NOT do (corrected from earlier attempt)

The first commit on this branch also deleted `#probeTriggerFromCaretRange` claiming it was defensive recovery code. **That was wrong** — browser tests (`Overlay.react.spec.tsx`, `Overlay.vue.spec.ts`) surfaced the regression and commit `11b9393a` restored the fallback.

The fallback is load-bearing: when the `'change'` trigger fires synchronously inside the value-change watcher, the DOM has not re-rendered yet. `TriggerFinder.find()` reads stale `window.getSelection()` / `node.textContent` and returns `undefined`. The fallback then uses the fresh `value.current()` + `selection.range()` signal state to find the trigger. Without it, overlays never appear after typing.

**Lesson captured in the fix commit:** the unit test suite passed because no test asserted a positive match from a real probe — every `expect(match()).toBe(stubMatch)` was preceded by a programmatic `store.overlay.match(stubMatch)` assignment. Browser-driven end-to-end coverage was needed to catch the regression.

## Plan

[docs/superpowers/plans/2026-05-25-overlay-controller-simplification.md](docs/superpowers/plans/2026-05-25-overlay-controller-simplification.md) — plan as originally written. Step 3 (deleting the fallback) turned out to be wrong and was reverted.

## Commits

```
11b9393a fix(overlay): restore #probeTriggerFromCaretRange — fallback is load-bearing
7ed9a174 refactor(overlay): collapse hasOverlayTrigger gates and drop recovery probe
```

If you prefer a single clean commit, squash-merge will collapse these.

## Test plan

- [x] \`pnpm --filter @markput/core test --run\` — 600 pass, 1 todo
- [x] \`pnpm --filter @markput/storybook test:react\` — 216 pass (all 4 Overlay scenarios green)
- [x] \`pnpm --filter @markput/react build\` — clean
- [x] \`pnpm --filter @markput/vue build\` — clean
- [ ] Manual smoke: type \`@\` in the React storybook overlay demo, dismiss with Esc, dismiss with outside-click
- [ ] Toggle `options` between trigger-having and triggerless states to confirm subscriptions tear down and re-build cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)